### PR TITLE
DISCUSSION: Code refactor change all crypto lib to python-cryptography

### DIFF
--- a/tests/benchCrypto.py
+++ b/tests/benchCrypto.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3.6
+# pylint: skip-file
+
 from Crypto.PublicKey import RSA
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -6,6 +9,11 @@ from cryptography.hazmat.primitives.hashes import SHA256, Hash
 from time import time
 import multihash
 
+SAMPLES = 10
+
+def formatDuration(t):
+    return str(round(t, 2)) + "s"
+
 def makeItTime(func, count):
     i = 0
     time1 = time()
@@ -13,6 +21,9 @@ def makeItTime(func, count):
         func()
         i += 1
     return (time() - time1) / count
+
+def makeItTimeFormated(func, count):
+    return formatDuration(makeItTime(func, count))
 
 def genPyCrypto__hashMultihash():
     k = RSA.generate(2048, e=65537)
@@ -35,11 +46,21 @@ def genPython_Cryptography__hashPython_Cryptography():
     h.update(priv.public_key().public_bytes(Encoding.DER, PublicFormat.PKCS1))
     h.finalize()
 
-print("Py-Crypto - MultiHash :")
-print(str(round(makeItTime(genPyCrypto__hashMultihash, 10), 2)) + "s")
-print("Python Cryptography - MultiHash :")
-print(str(round(makeItTime(genPython_Cryptography__hashMultihash, 10), 2)) + "s")
-print("Py-Crypto - Python Cryptography :")
-print(str(round(makeItTime(genPyCrypto__hashPython_Cryptography, 10), 2)) + "s")
-print("Python Cryptography - Python Cryptography :")
-print(str(round(makeItTime(genPython_Cryptography__hashPython_Cryptography, 10), 2)) + "s")
+print("Running some test with " + str(SAMPLES) + " samples per algo.")
+print("I will print result in a markdown compatible table.")
+
+print("test 0/4")
+CM = makeItTimeFormated(genPyCrypto__hashMultihash, SAMPLES)
+print("test 1/4")
+CgM = makeItTimeFormated(genPython_Cryptography__hashMultihash, SAMPLES)
+print("test 2/4")
+CCg = makeItTimeFormated(genPyCrypto__hashPython_Cryptography, SAMPLES)
+print("test 3/4")
+CgCg = makeItTimeFormated(genPython_Cryptography__hashPython_Cryptography, SAMPLES)
+print("test 4/4\n")
+print(
+    "|                     | Crypto | Python Cryptography |\n" +
+    "| :-----------------: | ------ | ------------------- |\n" +
+    "| MultiHash           | " + CM + " " * (7 - len(CM)) + "| " + CgM + " " * (20 - len(CgM)) + "|\n" +
+    "| Python Cryptography | " + CCg + " " * (7 - len(CCg)) + "| " + CgCg + " " * (20 - len(CgCg)) +"|"
+)

--- a/tests/benchCrypto.py
+++ b/tests/benchCrypto.py
@@ -1,0 +1,45 @@
+from Crypto.PublicKey import RSA
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.hazmat.primitives.hashes import SHA256, Hash
+from time import time
+import multihash
+
+def makeItTime(func, count):
+    i = 0
+    time1 = time()
+    while i < count:
+        func()
+        i += 1
+    return (time() - time1) / count
+
+def genPyCrypto__hashMultihash():
+    k = RSA.generate(2048, e=65537)
+    algo = multihash.Func.sha2_256
+    mh_digest = multihash.digest(k.publickey().exportKey("DER"), algo)
+
+def genPython_Cryptography__hashMultihash():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    algo = multihash.Func.sha2_256
+    mh_digest = multihash.digest(priv.public_key().public_bytes(Encoding.DER, PublicFormat.PKCS1), algo)
+
+def genPyCrypto__hashPython_Cryptography():
+    k = RSA.generate(2048, e=65537)
+    algo = multihash.Func.sha2_256
+    mh_digest = multihash.digest(k.publickey().exportKey("DER"), algo)
+
+def genPython_Cryptography__hashPython_Cryptography():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+    h = Hash(SHA256(), default_backend())
+    h.update(priv.public_key().public_bytes(Encoding.DER, PublicFormat.PKCS1))
+    h.finalize()
+
+print("Py-Crypto - MultiHash :")
+print(str(round(makeItTime(genPyCrypto__hashMultihash, 10), 2)) + "s")
+print("Python Cryptography - MultiHash :")
+print(str(round(makeItTime(genPython_Cryptography__hashMultihash, 10), 2)) + "s")
+print("Py-Crypto - Python Cryptography :")
+print(str(round(makeItTime(genPyCrypto__hashPython_Cryptography, 10), 2)) + "s")
+print("Python Cryptography - Python Cryptography :")
+print(str(round(makeItTime(genPython_Cryptography__hashPython_Cryptography, 10), 2)) + "s")


### PR DESCRIPTION
[Python-Cryptography](https://github.com/pyca/cryptography) is an C binding of openssl library and this is LOT more faster than Crypto and MultiHash, see your self (generating a new node key) :

|                     | Crypto | Python Cryptography |
| :-----------------: | ------ | ------------------- |
| MultiHash           | 0.94s  | 0.2s                |
| Python Cryptography | 0.93s  | 0.15s               |

Horizontaly : RSA key gen
Verticaly : sha2_256 hashing

[Python-Cryptography](https://github.com/pyca/cryptography) also have a full python implementation for be compatible on platform where the C lib isn't available.
It also give lot more of control than MultiHash or Crypto.
Python-Cryptography have just one bad point, it is huge ! This lib include so many hashing and encryption algo that importing all the lib can make performance drop, but it can easly solved by using `from xxxxx import yyyyy` and go deeper than possible (never import any module).

I would have your feelings about that (the ranking of choice is my view):
 - Should I implement cryptography directly ? (2nd choice)
 - Should I just create some (deprecated ?) functions to convert Crypto key object to cryptography and implement cryptography. So users of py-libp2p can choose what to use ? (best choice)
 - Should I create a proxy library simplifying use of cryptography (with minor performance loss (still lot better than now)). (Worst choice)
 - Other ? (It depends)

**TO DO :**
- [X] Do an example file of cryptography. (tests/benchCrypto.py)
- [ ] **Discuss with other maintainer, contributors of py-libp2p.** (in progress)
- [ ] Replace all hashing function to cryptography.
- [ ] Replace all RSA use to cryptography.