### PR TITLE
Stream rearchitecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# py-libp2p [![Build Status](https://travis-ci.com/zixuanzh/py-libp2p.svg?branch=master)](https://travis-ci.com/zixuanzh/py-libp2p) [![codecov](https://codecov.io/gh/zixuanzh/py-libp2p/branch/master/graph/badge.svg)](https://codecov.io/gh/zixuanzh/py-libp2p) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/py-libp2p/Lobby)[![Freenode](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+# py-libp2p [![Build Status](https://travis-ci.com/libp2p/py-libp2p.svg?branch=master)](https://travis-ci.com/libp2p/py-libp2p) [![codecov](https://codecov.io/gh/libp2p/py-libp2p/branch/master/graph/badge.svg)](https://codecov.io/gh/libp2p/py-libp2p) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/py-libp2p/Lobby)[![Freenode](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 
 
 
 <h1 align="center">
-  <img width="250" align="center" src="https://github.com/zixuanzh/py-libp2p/blob/master/assets/py-libp2p-logo.png?raw=true" alt="py-libp2p hex logo" />
+  <img width="250" align="center" src="https://github.com/libp2p/py-libp2p/blob/master/assets/py-libp2p-logo.png?raw=true" alt="py-libp2p hex logo" />
 </h1>
 
 ## WARNING

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -1,8 +1,7 @@
-from Crypto.PublicKey import RSA
-
-import multiaddr
 import asyncio
+import multiaddr
 
+from Crypto.PublicKey import RSA
 from .peer.peerstore import PeerStore
 from .peer.id import id_from_public_key
 from .network.swarm import Swarm

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -1,6 +1,7 @@
 from Crypto.PublicKey import RSA
 
 import multiaddr
+import asyncio
 
 from .peer.peerstore import PeerStore
 from .peer.id import id_from_public_key
@@ -9,6 +10,16 @@ from .host.basic_host import BasicHost
 from .transport.upgrader import TransportUpgrader
 from .transport.tcp.tcp import TCP
 
+
+async def cleanup_done_tasks():
+    while True:
+        for task in asyncio.all_tasks():
+            if task.done():
+                await task
+
+        # Need not run often
+        # Some sleep necessary to context switch
+        await asyncio.sleep(3)
 
 async def new_node(
         id_opt=None, transport_opt=None,
@@ -34,5 +45,8 @@ async def new_node(
     # TODO enable support for other host type
     # TODO routing unimplemented
     host = BasicHost(swarm)
+
+    # Kick off cleanup job
+    asyncio.ensure_future(cleanup_done_tasks())
 
     return host

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -91,7 +91,7 @@ class Swarm(INetwork):
         # Use muxed conn to open stream, which returns
         # a muxed stream
         # TODO: Remove protocol id from being passed into muxed_conn
-        muxed_stream = await muxed_conn.open_stream(protocol_ids[0], peer_id, multiaddr)
+        muxed_stream = await muxed_conn.open_stream(protocol_ids[0], multiaddr)
 
         # Perform protocol muxing to determine protocol to use
         selected_protocol = await self.multiselect_client.select_one_of(protocol_ids, muxed_stream)

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -155,6 +155,13 @@ class Swarm(INetwork):
         # TODO: Support more than one transport
         self.transport = transport
 
+    def generic_protocol_handler(self, muxed_stream):
+        # Perform protocol muxing to determine protocol to use
+        selected_protocol, handler = await self.multiselect.negotiate(muxed_stream)
+
+        # Give to stream handler
+        await handler(muxed_stream)
+
 
 class SwarmException(Exception):
     pass

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from libp2p.protocol_muxer.multiselect_client import MultiselectClient
 from libp2p.protocol_muxer.multiselect import Multiselect
 
@@ -157,13 +159,11 @@ def create_generic_protocol_handler(swarm):
     multiselect = swarm.multiselect
 
     async def generic_protocol_handler(muxed_stream):
-        print("generic_protocol_handler")
         # Perform protocol muxing to determine protocol to use
         _, handler = await multiselect.negotiate(muxed_stream)
 
         # Give to stream handler
-        print("call stream handler")
-        await handler(muxed_stream)
+        asyncio.ensure_future(handler(muxed_stream))
 
     return generic_protocol_handler
 

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -25,9 +25,6 @@ class Swarm(INetwork):
         # Create generic protocol handler
         self.generic_protocol_handler = create_generic_protocol_handler(self)
 
-    def close(self):
-        asyncio.get_event_loop.close()
-
     def get_peer_id(self):
         return self.self_id
 

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -123,16 +123,8 @@ class Swarm(INetwork):
                                          multiaddr.value_for_protocol('tcp'), reader, writer, False)
                 muxed_conn = self.upgrader.upgrade_connection(raw_conn, self.generic_protocol_handler)
 
-                # TODO: Remove protocol id from muxed_conn accept stream or
-                # move protocol muxing into accept_stream
-                muxed_stream, _, _ = await muxed_conn.accept_stream()
-
-                # Perform protocol muxing to determine protocol to use
-                selected_protocol, handler = await self.multiselect.negotiate(muxed_stream)
-
-                # Give to stream handler
-                # TODO: handle case of multiple protocols over same raw connection
-                await handler(muxed_stream)
+                # Store muxed_conn with peer id
+                self.connections[multiaddr.value_for_protocol('p2p')] = muxed_conn
 
             try:
                 # Success

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -25,6 +25,9 @@ class Swarm(INetwork):
         # Create generic protocol handler
         self.generic_protocol_handler = create_generic_protocol_handler(self)
 
+    def close(self):
+        asyncio.get_event_loop.close()
+
     def get_peer_id(self):
         return self.self_id
 
@@ -127,7 +130,8 @@ class Swarm(INetwork):
                     self.generic_protocol_handler)
 
                 # Store muxed_conn with peer id
-                self.connections[multiaddr.value_for_protocol('p2p')] = muxed_conn
+                # TODO: FIX
+                self.connections['foo'] = muxed_conn
 
             try:
                 # Success

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -156,10 +156,12 @@ def create_generic_protocol_handler(swarm):
     multiselect = swarm.multiselect
 
     async def generic_protocol_handler(muxed_stream):
+        print("generic_protocol_handler")
         # Perform protocol muxing to determine protocol to use
         _, handler = await multiselect.negotiate(muxed_stream)
 
         # Give to stream handler
+        print("call stream handler")
         await handler(muxed_stream)
 
     return generic_protocol_handler

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -31,21 +31,16 @@ class Multiselect(IMultiselectMuxer):
         :return: selected protocol name, handler function
         :raise Exception: negotiation failed exception
         """
-        print("negotiate")
         # Create a communicator to handle all communication across the stream
         communicator = MultiselectCommunicator(stream)
 
         # Perform handshake to ensure multiselect protocol IDs match
         await self.handshake(communicator)
 
-        print("negotiate handshake succeeded")
-
         # Read and respond to commands until a valid protocol ID is sent
         while True:
             # Read message
-            print("receiver reading during protocol negotation")
             command = await communicator.read_stream_until_eof()
-            print("receiver read success protocol negotation")
 
             # Command is ls or a protocol
             if command == "ls":
@@ -75,9 +70,7 @@ class Multiselect(IMultiselectMuxer):
         await communicator.write(MULTISELECT_PROTOCOL_ID)
 
         # Read in the protocol ID from other party
-        print("receiever waiting on handshake")
         handshake_contents = await communicator.read_stream_until_eof()
-        print("reciever done with handshake")
 
         # Confirm that the protocols are the same
         if not validate_handshake(handshake_contents):

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -31,12 +31,14 @@ class Multiselect(IMultiselectMuxer):
         :return: selected protocol name, handler function
         :raise Exception: negotiation failed exception
         """
-
+        print("negotiate")
         # Create a communicator to handle all communication across the stream
         communicator = MultiselectCommunicator(stream)
 
         # Perform handshake to ensure multiselect protocol IDs match
         await self.handshake(communicator)
+
+        print("negotiate handshake succeeded")
 
         # Read and respond to commands until a valid protocol ID is sent
         while True:

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -43,7 +43,9 @@ class Multiselect(IMultiselectMuxer):
         # Read and respond to commands until a valid protocol ID is sent
         while True:
             # Read message
+            print("receiver reading during protocol negotation")
             command = await communicator.read_stream_until_eof()
+            print("receiver read success protocol negotation")
 
             # Command is ls or a protocol
             if command == "ls":
@@ -73,7 +75,9 @@ class Multiselect(IMultiselectMuxer):
         await communicator.write(MULTISELECT_PROTOCOL_ID)
 
         # Read in the protocol ID from other party
+        print("receiever waiting on handshake")
         handshake_contents = await communicator.read_stream_until_eof()
+        print("reciever done with handshake")
 
         # Confirm that the protocols are the same
         if not validate_handshake(handshake_contents):

--- a/libp2p/protocol_muxer/multiselect_client.py
+++ b/libp2p/protocol_muxer/multiselect_client.py
@@ -51,7 +51,6 @@ class MultiselectClient(IMultiselectClient):
 
         # Perform handshake to ensure multiselect protocol IDs match
         await self.handshake(communicator)
-        print("client handshake done")
 
         # Try to select the given protocol
         selected_protocol = await self.try_select(communicator, protocol)
@@ -96,7 +95,6 @@ class MultiselectClient(IMultiselectClient):
         """
 
         # Tell counterparty we want to use protocol
-        print("client choosing protocol")
         await communicator.write(protocol)
 
         # Get what counterparty says in response

--- a/libp2p/protocol_muxer/multiselect_client.py
+++ b/libp2p/protocol_muxer/multiselect_client.py
@@ -51,6 +51,7 @@ class MultiselectClient(IMultiselectClient):
 
         # Perform handshake to ensure multiselect protocol IDs match
         await self.handshake(communicator)
+        print("client handshake done")
 
         # Try to select the given protocol
         selected_protocol = await self.try_select(communicator, protocol)
@@ -95,6 +96,7 @@ class MultiselectClient(IMultiselectClient):
         """
 
         # Tell counterparty we want to use protocol
+        print("client choosing protocol")
         await communicator.write(protocol)
 
         # Get what counterparty says in response

--- a/libp2p/protocol_muxer/multiselect_communicator.py
+++ b/libp2p/protocol_muxer/multiselect_communicator.py
@@ -16,7 +16,8 @@ class MultiselectCommunicator(IMultiselectCommunicator):
         Write message to stream
         :param msg_str: message to write
         """
-        await self.stream.write(msg_str.encode())
+        result = await self.stream.write(msg_str.encode())
+        print("multiselect comm got this write response: " + str(result))
 
     async def read_stream_until_eof(self):
         """

--- a/libp2p/protocol_muxer/multiselect_communicator.py
+++ b/libp2p/protocol_muxer/multiselect_communicator.py
@@ -16,8 +16,7 @@ class MultiselectCommunicator(IMultiselectCommunicator):
         Write message to stream
         :param msg_str: message to write
         """
-        result = await self.stream.write(msg_str.encode())
-        print("multiselect comm got this write response: " + str(result))
+        await self.stream.write(msg_str.encode())
 
     async def read_stream_until_eof(self):
         """

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -94,9 +94,10 @@ class Mplex(IMuxedConn):
         accepts a muxed stream opened by the other end
         :return: the accepted stream
         """
+        print("accept_stream")
         stream_id = await self.stream_queue.get()
         stream = MplexStream(stream_id, False, self)
-        self.generic_protocol_handler(stream)
+        await self.generic_protocol_handler(stream)
 
     async def send_message(self, flag, data, stream_id):
         """
@@ -150,7 +151,8 @@ class Mplex(IMuxedConn):
 
             if flag is get_flag(True, "NEW_STREAM"):
                 # new stream detected on connection
-                self.accept_stream()
+                print("handle_incoming new_stream")
+                await self.accept_stream()
 
             if not message:
                 await self.buffers[stream_id].put(message)

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -64,12 +64,10 @@ class Mplex(IMuxedConn):
         # Stream not created yet
         return None
 
-    async def open_stream(self, protocol_id, peer_id, multi_addr):
+    async def open_stream(self, protocol_id, multi_addr):
         """
         creates a new muxed_stream
         :param protocol_id: protocol_id of stream
-        :param stream_id: stream_id of stream
-        :param peer_id: peer_id that stream connects to
         :param multi_addr: multi_addr that stream connects to
         :return: a new stream
         """

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -18,7 +18,7 @@ class Mplex(IMuxedConn):
         :param generic_protocol_handler: generic protocol handler
         for new muxed streams
         """
-        super(Mplex, self).__init__()
+        super(Mplex, self).__init__(conn, generic_protocol_handler)
 
         self.raw_conn = conn
         self.initiator = conn.initiator

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -11,14 +11,18 @@ class Mplex(IMuxedConn):
     reference: https://github.com/libp2p/go-mplex/blob/master/multiplex.go
     """
 
-    def __init__(self, conn):
+    def __init__(self, conn, generic_protocol_handler):
         """
         create a new muxed connection
         :param conn: an instance of raw connection
-        :param initiator: boolean to prevent multiplex with self
+        :param generic_protocol_handler: generic protocol handler
+        for new muxed streams
         """
         self.raw_conn = conn
         self.initiator = conn.initiator
+
+        # Store generic protocol handler
+        self.generic_protocol_handler = generic_protocol_handler
 
         # Mapping from stream ID -> buffer of messages for that stream
         self.buffers = {}

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -154,7 +154,7 @@ class Mplex(IMuxedConn):
                 print("handle_incoming new_stream")
                 await self.accept_stream()
 
-            if not message:
+            if message:
                 await self.buffers[stream_id].put(message)
 
     async def read_chunk(self):

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -18,7 +18,7 @@ class Mplex(IMuxedConn):
         :param generic_protocol_handler: generic protocol handler
         for new muxed streams
         """
-        super()
+        super(Mplex, self).__init__()
 
         self.raw_conn = conn
         self.initiator = conn.initiator

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -57,7 +57,6 @@ class Mplex(IMuxedConn):
         if stream_id in self.buffers:
             try:
                 data = await asyncio.wait_for(self.buffers[stream_id].get(), timeout=3)
-                self.buffers[stream_id].task_done()
                 return data
             except asyncio.TimeoutError:
                 return None

--- a/libp2p/stream_muxer/muxed_connection_interface.py
+++ b/libp2p/stream_muxer/muxed_connection_interface.py
@@ -30,12 +30,10 @@ class IMuxedConn(ABC):
         """
 
     @abstractmethod
-    def open_stream(self, protocol_id, peer_id, multi_addr):
+    def open_stream(self, protocol_id, multi_addr):
         """
         creates a new muxed_stream
         :param protocol_id: protocol_id of stream
-        :param stream_id: stream_id of stream
-        :param peer_id: peer_id that stream connects to
         :param multi_addr: multi_addr that stream connects to
         :return: a new stream
         """

--- a/libp2p/stream_muxer/muxed_connection_interface.py
+++ b/libp2p/stream_muxer/muxed_connection_interface.py
@@ -7,6 +7,15 @@ class IMuxedConn(ABC):
     """
 
     @abstractmethod
+    def __init__(self, conn, generic_protocol_handler):
+        """
+        create a new muxed connection
+        :param conn: an instance of raw connection
+        :param generic_protocol_handler: generic protocol handler
+        for new muxed streams
+        """
+
+    @abstractmethod
     def close(self):
         """
         close connection

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -78,7 +78,6 @@ class TCP(ITransport):
         reader, writer = await asyncio.open_connection(host, port)
 
         # First: send our peer ID so receiver knows it
-        #writer.write(str(self_id).encode())
         writer.write(id_b58_encode(self_id).encode())
         await writer.drain()
 

--- a/libp2p/transport/transport_interface.py
+++ b/libp2p/transport/transport_interface.py
@@ -4,10 +4,11 @@ from abc import ABC, abstractmethod
 class ITransport(ABC):
 
     @abstractmethod
-    def dial(self, multiaddr, options=None):
+    def dial(self, multiaddr, self_id, options=None):
         """
         dial a transport to peer listening on multiaddr
         :param multiaddr: multiaddr of peer
+        :param self_id: peer_id of the dialer (to send to receier)
         :param options: optional object
         :return: list of multiaddrs
         """

--- a/libp2p/transport/upgrader.py
+++ b/libp2p/transport/upgrader.py
@@ -17,11 +17,11 @@ class TransportUpgrader:
     def upgrade_security(self):
         pass
 
-    def upgrade_connection(self, conn):
+    def upgrade_connection(self, conn, generic_protocol_handler):
         """
         upgrade raw connection to muxed connection
         """
 
         # For PoC, no security, default to mplex
         # TODO do exchange to determine multiplexer
-        return Mplex(conn)
+        return Mplex(conn, generic_protocol_handler)

--- a/tests/examples/test_chat.py
+++ b/tests/examples/test_chat.py
@@ -1,5 +1,7 @@
 import pytest
+import asyncio
 
+from tests.utils import cleanup
 from libp2p import new_node
 from libp2p.peer.peerinfo import info_from_p2p_addr
 from libp2p.protocol_muxer.multiselect_client import MultiselectClientError
@@ -27,25 +29,28 @@ async def hello_world(host_a, host_b):
 
 
 async def connect_write(host_a, host_b):
-    messages = [b'data %d' % i for i in range(5)]
+    messages = ['data %d' % i for i in range(5)]
+    received = []
 
     async def stream_handler(stream):
-        received = []
         while True:
             try:
                 received.append((await stream.read()).decode())
             except Exception:  # exception is raised when other side close the stream ?
                 break
-        await stream.close()
-        assert received == messages
     host_a.set_stream_handler(PROTOCOL_ID, stream_handler)
 
     # Start a stream with the destination.
     # Multiaddress of the destination peer is fetched from the peerstore using 'peerId'.
     stream = await host_b.new_stream(host_a.get_id(), [PROTOCOL_ID])
     for message in messages:
-        await stream.write(message)
+        await stream.write(message.encode())
+
+    # Reader needs time due to async reads
+    await asyncio.sleep(2)
+
     await stream.close()
+    assert received == messages
 
 
 async def connect_read(host_a, host_b):
@@ -103,3 +108,5 @@ async def test_chat(test):
     await host_b.connect(info)
 
     await test(host_a, host_b)
+
+    await cleanup()

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -1,6 +1,7 @@
 import multiaddr
 import pytest
 
+from tests.utils import cleanup
 from libp2p import new_node
 from libp2p.peer.peerinfo import info_from_p2p_addr
 
@@ -13,10 +14,8 @@ async def test_simple_messages():
     async def stream_handler(stream):
         while True:
             read_string = (await stream.read()).decode()
-            print("host B received:" + read_string)
 
             response = "ack:" + read_string
-            print("sending response:" + response)
             await stream.write(response.encode())
 
     node_b.set_stream_handler("/echo/1.0.0", stream_handler)
@@ -32,11 +31,10 @@ async def test_simple_messages():
 
         response = (await stream.read()).decode()
 
-        print("res: " + response)
         assert response == ("ack:" + message)
 
     # Success, terminate pending tasks.
-    return
+    await cleanup()
 
 
 @pytest.mark.asyncio
@@ -47,38 +45,31 @@ async def test_double_response():
     async def stream_handler(stream):
         while True:
             read_string = (await stream.read()).decode()
-            print("host B received:" + read_string)
 
             response = "ack1:" + read_string
-            print("sending response:" + response)
             await stream.write(response.encode())
 
             response = "ack2:" + read_string
-            print("sending response:" + response)
             await stream.write(response.encode())
 
     node_b.set_stream_handler("/echo/1.0.0", stream_handler)
 
     # Associate the peer with local ip address (see default parameters of Libp2p())
     node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
-    print("node_a about to open stream")
     stream = await node_a.new_stream(node_b.get_id(), ["/echo/1.0.0"])
+
     messages = ["hello" + str(x) for x in range(10)]
     for message in messages:
         await stream.write(message.encode())
 
         response1 = (await stream.read()).decode()
-
-        print("res1: " + response1)
         assert response1 == ("ack1:" + message)
 
         response2 = (await stream.read()).decode()
-
-        print("res2: " + response2)
         assert response2 == ("ack2:" + message)
 
     # Success, terminate pending tasks.
-    return
+    await cleanup()
 
 
 @pytest.mark.asyncio
@@ -127,35 +118,103 @@ async def test_multiple_streams():
         assert response_a == ("ack_b:" + a_message) and response_b == ("ack_a:" + b_message)
 
     # Success, terminate pending tasks.
-    return
+    await cleanup()
 
 @pytest.mark.asyncio
 async def test_multiple_streams_same_initiator_different_protocols():
-    # Node A should be able to open a stream with node B and then vice versa.
-    # Stream IDs should be generated uniquely so that the stream state is not overwritten
     node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
     node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
 
     async def stream_handler_a1(stream):
-        print("stream_handler_a1 hit")
         while True:
-            print("stream_handler_a1 entered while")
             read_string = (await stream.read()).decode()
-            print("stream_handler_a1 read " + read_string)
 
             response = "ack_a1:" + read_string
             await stream.write(response.encode())
-            print("stream_handler_a1 sent response")
 
     async def stream_handler_a2(stream):
-        print("stream_handler_a2 hit")
         while True:
             read_string = (await stream.read()).decode()
-            print("stream_handler_a2 read " + read_string)
 
             response = "ack_a2:" + read_string
             await stream.write(response.encode())
-            print("stream_handler_a2 sent response")
+
+    async def stream_handler_a3(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack_a3:" + read_string
+            await stream.write(response.encode())
+
+    node_b.set_stream_handler("/echo_a1/1.0.0", stream_handler_a1)
+    node_b.set_stream_handler("/echo_a2/1.0.0", stream_handler_a2)
+    node_b.set_stream_handler("/echo_a3/1.0.0", stream_handler_a3)
+
+    # Associate the peer with local ip address (see default parameters of Libp2p())
+    node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
+    node_b.get_peerstore().add_addrs(node_a.get_id(), node_a.get_addrs(), 10)
+
+    # Open streams to node_b over echo_a1 echo_a2 echo_a3 protocols
+    stream_a1 = await node_a.new_stream(node_b.get_id(), ["/echo_a1/1.0.0"])
+    stream_a2 = await node_a.new_stream(node_b.get_id(), ["/echo_a2/1.0.0"])
+    stream_a3 = await node_a.new_stream(node_b.get_id(), ["/echo_a3/1.0.0"])
+
+    messages = ["hello" + str(x) for x in range(10)]
+    for message in messages:
+        a1_message = message + "_a1"
+        a2_message = message + "_a2"
+        a3_message = message + "_a3"
+
+        await stream_a1.write(a1_message.encode())
+        await stream_a2.write(a2_message.encode())
+        await stream_a3.write(a3_message.encode())
+
+        response_a1 = (await stream_a1.read()).decode()
+        response_a2 = (await stream_a2.read()).decode()
+        response_a3 = (await stream_a3.read()).decode()
+
+        assert (response_a1 == ("ack_a1:" + a1_message)
+                and response_a2 == ("ack_a2:" + a2_message)
+                and response_a3 == ("ack_a3:" + a3_message))
+
+    # Success, terminate pending tasks.
+    await cleanup()
+
+@pytest.mark.asyncio
+async def test_multiple_streams_two_initiators():
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+
+    async def stream_handler_a1(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack_a1:" + read_string
+            await stream.write(response.encode())
+
+    async def stream_handler_a2(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack_a2:" + read_string
+            await stream.write(response.encode())
+
+    async def stream_handler_b1(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack_b1:" + read_string
+            await stream.write(response.encode())
+
+    async def stream_handler_b2(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack_b2:" + read_string
+            await stream.write(response.encode())
+
+    node_a.set_stream_handler("/echo_b1/1.0.0", stream_handler_b1)
+    node_a.set_stream_handler("/echo_b2/1.0.0", stream_handler_b2)
 
     node_b.set_stream_handler("/echo_a1/1.0.0", stream_handler_a1)
     node_b.set_stream_handler("/echo_a2/1.0.0", stream_handler_a2)
@@ -164,9 +223,11 @@ async def test_multiple_streams_same_initiator_different_protocols():
     node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
     node_b.get_peerstore().add_addrs(node_a.get_id(), node_a.get_addrs(), 10)
 
-    # Open streams to node_b over echo_a1 protocol and echo_a2 protocol
     stream_a1 = await node_a.new_stream(node_b.get_id(), ["/echo_a1/1.0.0"])
     stream_a2 = await node_a.new_stream(node_b.get_id(), ["/echo_a2/1.0.0"])
+
+    stream_b1 = await node_b.new_stream(node_a.get_id(), ["/echo_b1/1.0.0"])
+    stream_b2 = await node_b.new_stream(node_a.get_id(), ["/echo_b2/1.0.0"])
 
     # A writes to /echo_b via stream_a, and B writes to /echo_a via stream_b
     messages = ["hello" + str(x) for x in range(10)]
@@ -174,16 +235,81 @@ async def test_multiple_streams_same_initiator_different_protocols():
         a1_message = message + "_a1"
         a2_message = message + "_a2"
 
+        b1_message = message + "_b1"
+        b2_message = message + "_b2"
+
         await stream_a1.write(a1_message.encode())
         await stream_a2.write(a2_message.encode())
+
+        await stream_b1.write(b1_message.encode())
+        await stream_b2.write(b2_message.encode())
 
         response_a1 = (await stream_a1.read()).decode()
         response_a2 = (await stream_a2.read()).decode()
 
-        assert response_a1 == ("ack_a1:" + a1_message) and response_a2 == ("ack_a2:" + a2_message)
+        response_b1 = (await stream_b1.read()).decode()
+        response_b2 = (await stream_b2.read()).decode()
+
+        assert (response_a1 == ("ack_a1:" + a1_message)
+                and response_a2 == ("ack_a2:" + a2_message)
+                and response_b1 == ("ack_b1:" + b1_message)
+                and response_b2 == ("ack_b2:" + b2_message))
 
     # Success, terminate pending tasks.
-    return
+    await cleanup()
+
+@pytest.mark.asyncio
+async def test_triangle_nodes_connection():
+    node_a = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_b = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+    node_c = await new_node(transport_opt=["/ip4/127.0.0.1/tcp/0"])
+
+    async def stream_handler(stream):
+        while True:
+            read_string = (await stream.read()).decode()
+
+            response = "ack:" + read_string
+            await stream.write(response.encode())
+
+    node_a.set_stream_handler("/echo/1.0.0", stream_handler)
+    node_b.set_stream_handler("/echo/1.0.0", stream_handler)
+    node_c.set_stream_handler("/echo/1.0.0", stream_handler)
+
+    # Associate the peer with local ip address (see default parameters of Libp2p())
+    # Associate all permutations
+    node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
+    node_a.get_peerstore().add_addrs(node_c.get_id(), node_c.get_addrs(), 10)
+
+    node_b.get_peerstore().add_addrs(node_a.get_id(), node_a.get_addrs(), 10)
+    node_b.get_peerstore().add_addrs(node_c.get_id(), node_c.get_addrs(), 10)
+
+    node_c.get_peerstore().add_addrs(node_a.get_id(), node_a.get_addrs(), 10)
+    node_c.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
+
+    stream_a_to_b = await node_a.new_stream(node_b.get_id(), ["/echo/1.0.0"])
+    stream_a_to_c = await node_a.new_stream(node_c.get_id(), ["/echo/1.0.0"])
+
+    stream_b_to_a = await node_b.new_stream(node_a.get_id(), ["/echo/1.0.0"])
+    stream_b_to_c = await node_b.new_stream(node_c.get_id(), ["/echo/1.0.0"])
+
+    stream_c_to_a = await node_c.new_stream(node_a.get_id(), ["/echo/1.0.0"])
+    stream_c_to_b = await node_c.new_stream(node_b.get_id(), ["/echo/1.0.0"])
+
+    messages = ["hello" + str(x) for x in range(5)]
+    streams = [stream_a_to_b, stream_a_to_c, stream_b_to_a, stream_b_to_c,
+               stream_c_to_a, stream_c_to_b]
+
+    for message in messages:
+        for stream in streams:
+            await stream.write(message.encode())
+
+            response = (await stream.read()).decode()
+
+            assert response == ("ack:" + message)
+
+    # Success, terminate pending tasks.
+    await cleanup()
+
 
 @pytest.mark.asyncio
 async def test_host_connect():
@@ -207,3 +333,6 @@ async def test_host_connect():
     ma_node_b = multiaddr.Multiaddr('/p2p/%s' % node_b.get_id().pretty())
     for addr in node_a.get_peerstore().addrs(node_b.get_id()):
         assert addr.encapsulate(ma_node_b) in node_b.get_addrs()
+
+    # Success, terminate pending tasks.
+    await cleanup()

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -5,6 +5,8 @@ from tests.utils import cleanup
 from libp2p import new_node
 from libp2p.peer.peerinfo import info_from_p2p_addr
 
+# pylint: disable=too-many-locals
+
 
 @pytest.mark.asyncio
 async def test_simple_messages():

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -180,7 +180,7 @@ async def test_multiple_streams_same_initiator_different_protocols():
         response_a1 = (await stream_a1.read()).decode()
         response_a2 = (await stream_a2.read()).decode()
 
-        assert response_a1 == ("ack_a1:" + a1_message) # and response_a2 == ("ack_a2:" + a2_message)
+        assert response_a1 == ("ack_a1:" + a1_message) and response_a2 == ("ack_a2:" + a2_message)
 
     # Success, terminate pending tasks.
     return

--- a/tests/protocol_muxer/test_protocol_muxer.py
+++ b/tests/protocol_muxer/test_protocol_muxer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.utils import cleanup
 from libp2p import new_node
 from libp2p.protocol_muxer.multiselect_client import MultiselectClientError
 
@@ -49,7 +50,7 @@ async def perform_simple_test(expected_selected_protocol,
     assert expected_selected_protocol == stream.get_protocol()
 
     # Success, terminate pending tasks.
-    return
+    await cleanup()
 
 
 @pytest.mark.asyncio
@@ -64,6 +65,9 @@ async def test_single_protocol_fails():
     with pytest.raises(MultiselectClientError):
         await perform_simple_test("", ["/echo/1.0.0"],
                                   ["/potato/1.0.0"])
+
+    # Cleanup not reached on error
+    await cleanup()
 
 
 @pytest.mark.asyncio
@@ -91,3 +95,6 @@ async def test_multiple_protocol_fails():
     with pytest.raises(MultiselectClientError):
         await perform_simple_test("", protocols_for_client,
                                   protocols_for_listener)
+
+    # Cleanup not reached on error
+    await cleanup()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from contextlib import suppress
+
+
+async def cleanup():
+    pending = asyncio.all_tasks()
+    for task in pending:
+        task.cancel()
+
+        # Now we should await task to execute it's cancellation.
+        # Cancelled task raises asyncio.CancelledError that we can suppress:
+        with suppress(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
This is a rearchitecture of the current multistream reading logic. This PR:

- [ ] turns `handle_incoming` into an infinite loop which is perpetually rescheduled
- [ ] turns `read_buffer` into a simple read on internal buffer with a timeout (enough time for `handle_incoming` calls to occur (eventually, timeout will be user-specified))
- [ ] enables multiple streams over same raw connection through "generic protocol handler" and "NEW_STREAM" messages
- [ ] adds tests for multiple streams from initiator and on receiver (i.e., stream muxing _really_ works)
- [ ] adds a test for multiple raw connections (three nodes, all connected to each other)
- [ ] adds cleanup logic for both tests and tasks in general. When tests complete, they should call `cleanup` so that all tasks are cancelled and the tests exit with no warnings. Additionally, there should be a task that cleans up "done" tasks periodically (e.g. those that were previously scheduled by a call to `ensure_future`). This cleanup task is kicked off in `new_node`.
- [ ] adds sending of peer id upon a first raw connection. This lets peers properly reuse raw connections (previously there was no connection reuse, but it was not detected because we only test with two nodes)

Credit is due for offline work done by all of @alexh @stuckinaboot @zixuanzh.