### PR TITLE
remove unused umsgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
         "pymultihash",
         "multiaddr",
         "rpcudp",
-        "umsgpack",
         "grpcio",
         "grpcio-tools",
         "lru-dict>=1.1.6"


### PR DESCRIPTION
Kad test seems to run without it and removes warnings from our test output. Makes our Travis builds much easier to read - let's add this back if we need it later.