### PR TITLE
Full-length Peer ID

### DIFF
--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -27,7 +27,7 @@ class ID:
 
     def __str__(self):
         pid = self.pretty()
-        return "<peer.ID %s>" % pid
+        return pid
 
     __repr__ = __str__
 

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -27,9 +27,7 @@ class ID:
 
     def __str__(self):
         pid = self.pretty()
-        if len(pid) <= 10:
-            return "<peer.ID %s>" % pid
-        return "<peer.ID %s*%s>" % (pid[:2], pid[len(pid)-6:])
+        return "<peer.ID %s>" % pid
 
     __repr__ = __str__
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "click",
         "base58",
         "pymultihash",
-        "multiaddr",
+        "multiaddr==0.0.4",
         "rpcudp",
         "grpcio",
         "grpcio-tools",

--- a/tests/peer/test_peerid.py
+++ b/tests/peer/test_peerid.py
@@ -36,7 +36,7 @@ def test_str_less_than_10():
     for _ in range(5):
         random_id_string += random.SystemRandom().choice(ALPHABETS)
     pid = base58.b58encode(random_id_string).decode()
-    expected = "<peer.ID " + pid  + ">"
+    expected = pid
     actual = ID(random_id_string).__str__()
 
     assert actual == expected
@@ -46,7 +46,7 @@ def test_str_more_than_10():
     for _ in range(10):
         random_id_string += random.SystemRandom().choice(ALPHABETS)
     pid = base58.b58encode(random_id_string).decode()
-    expected = "<peer.ID " + pid + ">"
+    expected = pid
     actual = ID(random_id_string).__str__()
 
     assert actual == expected

--- a/tests/peer/test_peerid.py
+++ b/tests/peer/test_peerid.py
@@ -46,9 +46,7 @@ def test_str_more_than_10():
     for _ in range(10):
         random_id_string += random.SystemRandom().choice(ALPHABETS)
     pid = base58.b58encode(random_id_string).decode()
-    part_1, part_2 = pid[:2], pid[len(pid)-6:]
-
-    expected = "<peer.ID " + part_1 + "*" + part_2 + ">"
+    expected = "<peer.ID " + pid + ">"
     actual = ID(random_id_string).__str__()
 
     assert actual == expected


### PR DESCRIPTION
In many components of the codebase the peer ID is object is converted to a string and is (1) transmitted over the wire to a node as a string (2) used as a string in some data structure. The previous peer ID implementation truncated peer IDs when they were converted to strings to make them more readable. However, since that `str` function is used in many critical sections of our code, truncated peer IDs are no longer acceptable.

Note: at some point, the codebase should be refactored to minimize the number of places where peer IDs are converted to strings as I know for sure there are spots where doing so presented itself as a convenience to avoid type-related issues although it is not necessary.

- [x] `str` returns full length peer IDs
- [x] update tests for full-length string peer IDs