### PR TITLE
Pin the version of multiaddr we require.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "click",
         "base58",
         "pymultihash",
-        "multiaddr",
+        "multiaddr==0.0.4",
         "rpcudp",
         "grpcio",
         "grpcio-tools",


### PR DESCRIPTION
Temporary workaround for https://github.com/multiformats/py-multiaddr/issues/47

