### PR TITLE
add dependencies to correctly build

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,11 @@
-pytest>=3.7
 codecov
-pytest-cov
-pytest-asyncio
-pylint
 grpcio
 grpcio-tools
+lru-dict
+multiaddr==0.0.4
+pylint
+pymultihash
+pytest-asyncio
+pytest-cov
+pytest>=3.7
+rpcudp


### PR DESCRIPTION

Some python dependencies needed to be added to do the build correctly.

Also temporarily adds work around for py-multiaddr,

