### PR TITLE
[WIP] Connection and stream interop between Python and Go

### DIFF
--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -76,14 +76,14 @@ def initialize_default_swarm(
     # TODO TransportUpgrader is not doing anything really
     # TODO parse muxer and sec to pass into TransportUpgrader
     muxer = muxer_opt or ["mplex/6.7.0"]
-    sec = sec_opt or {"insecure/1.0.0": InsecureTransport("insecure")}
+    sec = sec_opt or {"/plaintext/1.0.0": InsecureTransport("insecure")}
     upgrader = TransportUpgrader(sec, muxer)
 
     peerstore = peerstore_opt or PeerStore()
-    swarm_opt = Swarm(id_opt, peerstore,\
+    swarm = Swarm(id_opt, peerstore,\
                       upgrader, transport, disc_opt)
 
-    return swarm_opt
+    return swarm
 
 
 async def new_node(

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -92,7 +92,7 @@ class GossipSub(IPubsubRouter):
         """
         control_message = rpc.control
 
-        # Relay each rpc control  to the appropriate handler
+        # Relay each rpc control to the appropriate handler
         if control_message.ihave:
             for ihave in control_message.ihave:
                 await self.handle_ihave(ihave, sender_peer_id)

--- a/libp2p/security/security_multistream.py
+++ b/libp2p/security/security_multistream.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from libp2p.protocol_muxer.multiselect_client import MultiselectClient
 from libp2p.protocol_muxer.multiselect import Multiselect
 
@@ -10,7 +9,7 @@ involved in the secured connection
 
 Relevant go repo: https://github.com/libp2p/go-conn-security/blob/master/interface.go
 """
-class SecurityMultistream(ABC):
+class SecurityMultistream:
 
     def __init__(self):
         # Map protocol to secure transport
@@ -31,7 +30,6 @@ class SecurityMultistream(ABC):
         # we only care about selecting the protocol, not any handler function
         self.multiselect.add_handler(protocol, None)
 
-
     async def secure_inbound(self, conn):
         """
         Secure the connection, either locally or by communicating with opposing node via conn,
@@ -47,7 +45,6 @@ class SecurityMultistream(ABC):
 
         return secure_conn
 
-
     async def secure_outbound(self, conn, peer_id):
         """
         Secure the connection, either locally or by communicating with opposing node via conn,
@@ -62,7 +59,6 @@ class SecurityMultistream(ABC):
         secure_conn = await transport.secure_outbound(conn, peer_id)
 
         return secure_conn
-
 
     async def select_transport(self, conn, initiator):
         """

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -70,23 +70,28 @@ class TCP(ITransport):
         :param multiaddr: multiaddr of peer
         :param self_id: peer_id of the dialer (to send to receiver)
         :param options: optional object
-        :return: True if successful
+        :return: `RawConnection` if successful
         """
         host = multiaddr.value_for_protocol('ip4')
         port = int(multiaddr.value_for_protocol('tcp'))
 
         reader, writer = await asyncio.open_connection(host, port)
 
-        # First: send our peer ID so receiver knows it
-        writer.write(id_b58_encode(self_id).encode())
-        await writer.drain()
+        # # where we store the peers' `peer_id`?
+        # # First: send our peer ID so receiver knows it
+        # writer.write(id_b58_encode(self_id).encode())
+        # print(f"!@# writer.write: {id_b58_encode(self_id)}")
+        # await writer.drain()
 
-        # Await ack for peer id
-        expected_ack_str = "received peer id"
-        ack = (await reader.read(len(expected_ack_str))).decode()
+        # # Await ack for peer id
+        # expected_ack_str = "received peer id"
+        # expected_ack_str = "\x13"  # /multistream/1.0.0"
+        # ack = (await reader.read(len(expected_ack_str))).decode()
 
-        if ack != expected_ack_str:
-            raise Exception("Receiver did not receive peer id")
+        # print("!@# reader.read: {!r}".format(ack))
+        # if ack != expected_ack_str:
+        #     print(f"!@# ack={ack}, expected_ack_str={expected_ack_str}")
+        #     raise Exception("Receiver did not receive peer id")
 
         return RawConnection(host, port, reader, writer, True)
 

--- a/libp2p/transport/upgrader.py
+++ b/libp2p/transport/upgrader.py
@@ -8,9 +8,8 @@ class TransportUpgrader:
     def __init__(self, secOpt, muxerOpt):
         # Store security option
         self.security_multistream = SecurityMultistream()
-        for key in secOpt:
-            self.security_multistream.add_transport(key, secOpt[key])
-
+        for key, value in secOpt.items():
+            self.security_multistream.add_transport(key, value)
         # Store muxer option
         self.muxer = muxerOpt
 


### PR DESCRIPTION
**[Sill work in progress]**

Fixes https://github.com/libp2p/py-libp2p/issues/169
Try to make py-libp2p talk with go-libp2p. Currently, in this PR I removed "sending peer id" from python, and added delimited read/write, to make python and go pass agree on the same multiselect protocol and security. Still need to confirm whether it really works.

TODOs
- [ ] Confirm if the connection is done both sides.
- [ ] Find out when we should send `peer_id`.
- [ ] Make `new_stream` work.