### PR TITLE
Fix and refactor: `gossipsub.join`

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -265,26 +265,28 @@ class GossipSub(IPubsubRouter):
     async def mesh_heartbeat(self):
         # Note: the comments here are the exact pseudocode from the spec
         for topic in self.mesh:
+            # Skip if no peers have subscribed to the topic
+            if topic not in self.pubsub.peer_topics:
+                continue
 
             num_mesh_peers_in_topic = len(self.mesh[topic])
             if num_mesh_peers_in_topic < self.degree_low:
-                if topic in self.pubsub.peer_topics:
-                    gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
-                                                if peer in self.peers_gossipsub]
+                gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
+                                            if peer in self.peers_gossipsub]
 
-                    # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
-                    selected_peers = GossipSub.select_from_minus(
-                        self.degree - num_mesh_peers_in_topic,
-                        gossipsub_peers_in_topic,
-                        self.mesh[topic]
-                    )
+                # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
+                selected_peers = GossipSub.select_from_minus(
+                    self.degree - num_mesh_peers_in_topic,
+                    gossipsub_peers_in_topic,
+                    self.mesh[topic]
+                )
 
-                    for peer in selected_peers:
-                        # Add peer to mesh[topic]
-                        self.mesh[topic].append(peer)
+                for peer in selected_peers:
+                    # Add peer to mesh[topic]
+                    self.mesh[topic].append(peer)
 
-                        # Emit GRAFT(topic) control message to peer
-                        await self.emit_graft(topic, peer)
+                    # Emit GRAFT(topic) control message to peer
+                    await self.emit_graft(topic, peer)
 
             if num_mesh_peers_in_topic > self.degree_high:
                 # Select |mesh[topic]| - D peers from mesh[topic]

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -267,10 +267,12 @@ class GossipSub(IPubsubRouter):
 
             num_mesh_peers_in_topic = len(self.mesh[topic])
             if num_mesh_peers_in_topic < self.degree_low:
+                gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
+                                                    if peer in self.peers_gossipsub]
 
                 # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
                 selected_peers = GossipSub.select_from_minus(self.degree - num_mesh_peers_in_topic,
-                                                             self.peers_gossipsub, self.mesh[topic])
+                                                             gossipsub_peers_in_topic, self.mesh[topic])
 
                 for peer in selected_peers:
                     # Add peer to mesh[topic]

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -207,7 +207,8 @@ class GossipSub(IPubsubRouter):
             self.mesh[topic].append(peer)
             await self.emit_graft(topic, peer)
 
-        # TODO: Do we remove all peers from fanout[topic]?
+        if topic_in_fanout:
+            del self.fanout[topic]
 
     async def leave(self, topic):
         # Note: the comments here are the near-exact algorithm description from the spec
@@ -303,7 +304,7 @@ class GossipSub(IPubsubRouter):
             # TODO: there's no way time_since_last_publish gets set anywhere yet
             if self.time_since_last_publish[topic] > self.time_to_live:
                 # Remove topic from fanout
-                self.fanout.remove(topic)
+                del self.fanout[topic]
                 self.time_since_last_publish.remove(topic)
             else:
                 num_fanout_peers_in_topic = len(self.fanout[topic])

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -267,19 +267,20 @@ class GossipSub(IPubsubRouter):
 
             num_mesh_peers_in_topic = len(self.mesh[topic])
             if num_mesh_peers_in_topic < self.degree_low:
-                gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
-                                                    if peer in self.peers_gossipsub]
+                if topic in self.pubsub.peer_topics:
+                    gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
+                                                        if peer in self.peers_gossipsub]
 
-                # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
-                selected_peers = GossipSub.select_from_minus(self.degree - num_mesh_peers_in_topic,
-                                                             gossipsub_peers_in_topic, self.mesh[topic])
+                    # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
+                    selected_peers = GossipSub.select_from_minus(self.degree - num_mesh_peers_in_topic,
+                                                                gossipsub_peers_in_topic, self.mesh[topic])
 
-                for peer in selected_peers:
-                    # Add peer to mesh[topic]
-                    self.mesh[topic].append(peer)
+                    for peer in selected_peers:
+                        # Add peer to mesh[topic]
+                        self.mesh[topic].append(peer)
 
-                    # Emit GRAFT(topic) control message to peer
-                    await self.emit_graft(topic, peer)
+                        # Emit GRAFT(topic) control message to peer
+                        await self.emit_graft(topic, peer)
 
             if num_mesh_peers_in_topic > self.degree_high:
                 # Select |mesh[topic]| - D peers from mesh[topic]

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -191,15 +191,16 @@ class GossipSub(IPubsubRouter):
             # There are less than D peers (let this number be x)
             # in the fanout for a topic (or the topic is not in the fanout).
             # Selects the remaining number of peers (D-x) from peers.gossipsub[topic].
-            gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
-                                        if peer in self.peers_gossipsub]
-            selected_peers = \
-                GossipSub.select_from_minus(self.degree - fanout_size,
-                                            gossipsub_peers_in_topic,
-                                            fanout_peers)
+            if topic in self.pubsub.peer_topics:
+                gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
+                                            if peer in self.peers_gossipsub]
+                selected_peers = \
+                    GossipSub.select_from_minus(self.degree - fanout_size,
+                                                gossipsub_peers_in_topic,
+                                                fanout_peers)
 
-            # Combine fanout peers with selected peers
-            fanout_peers += selected_peers
+                # Combine fanout peers with selected peers
+                fanout_peers += selected_peers
 
         # Add fanout peers to mesh and notifies them with a GRAFT(topic) control message.
         for peer in fanout_peers:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -269,11 +269,14 @@ class GossipSub(IPubsubRouter):
             if num_mesh_peers_in_topic < self.degree_low:
                 if topic in self.pubsub.peer_topics:
                     gossipsub_peers_in_topic = [peer for peer in self.pubsub.peer_topics[topic]
-                                                        if peer in self.peers_gossipsub]
+                                                if peer in self.peers_gossipsub]
 
                     # Select D - |mesh[topic]| peers from peers.gossipsub[topic] - mesh[topic]
-                    selected_peers = GossipSub.select_from_minus(self.degree - num_mesh_peers_in_topic,
-                                                                gossipsub_peers_in_topic, self.mesh[topic])
+                    selected_peers = GossipSub.select_from_minus(
+                        self.degree - num_mesh_peers_in_topic,
+                        gossipsub_peers_in_topic,
+                        self.mesh[topic]
+                    )
 
                     for peer in selected_peers:
                         # Add peer to mesh[topic]

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -13,20 +13,20 @@ SUPPORTED_PROTOCOLS = ["/gossipsub/1.0.0"]
 @pytest.mark.asyncio
 async def test_join():
     # Create libp2p hosts
-    num_hosts = 10
+    num_hosts = 4
     hosts_indices = list(range(num_hosts))
     libp2p_hosts = await create_libp2p_hosts(num_hosts)
 
     # Create pubsub, gossipsub instances
     pubsubs, gossipsubs = create_pubsub_and_gossipsub_instances(libp2p_hosts, \
                                                                 SUPPORTED_PROTOCOLS, \
-                                                                10, 9, 11, 30, 3, 5, 0.5)
+                                                                4, 3, 5, 30, 3, 5, 0.5)
 
     topic = "test_join"
     central_node_index = 0
     # Remove index of central host from the indices
     hosts_indices.remove(central_node_index)
-    num_subscribed_peer = 6
+    num_subscribed_peer = 2
     subscribed_peer_indices = random.sample(hosts_indices, num_subscribed_peer)
 
     # All pubsub except the one of central node subscribe to topic
@@ -57,6 +57,8 @@ async def test_join():
     # Central node subscribes the topic
     await pubsubs[central_node_index].subscribe(topic)
 
+    await asyncio.sleep(2)
+
     # Check that the gossipsub of central node no longer has fanout for the topic
     assert topic not in gossipsubs[central_node_index].fanout
 
@@ -66,7 +68,7 @@ async def test_join():
             assert str(libp2p_hosts[central_node_index].get_id()) in gossipsubs[i].mesh[topic]
         else:
             assert str(libp2p_hosts[i].get_id()) not in gossipsubs[central_node_index].mesh[topic]
-            assert str(libp2p_hosts[central_node_index].get_id()) not in gossipsubs[i].mesh[topic]
+            assert topic not in gossipsubs[i].mesh
 
     await cleanup()
 

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -54,7 +54,7 @@ async def test_join():
     # Check that the gossipsub of central node does not have a mesh for the topic
     assert topic not in gossipsubs[central_node_index].mesh
 
-    # Central node subscribe message origin
+    # Central node subscribes the topic
     await pubsubs[central_node_index].subscribe(topic)
 
     # Check that the gossipsub of central node no longer has fanout for the topic

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -51,7 +51,7 @@ async def test_join():
 
     # Check that the gossipsub of central node has fanout for the topic
     assert topic in gossipsubs[central_node_index].fanout
-    # Check that the gossipsub of central node does not has mesh for the topic
+    # Check that the gossipsub of central node does not have a mesh for the topic
     assert topic not in gossipsubs[central_node_index].mesh
 
     # Central node subscribe message origin

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -63,8 +63,10 @@ async def test_join():
     for i in hosts_indices:
         if i in subscribed_peer_indices:
             assert str(libp2p_hosts[i].get_id()) in gossipsubs[central_node_index].mesh[topic]
+            assert str(libp2p_hosts[central_node_index].get_id()) in gossipsubs[i].mesh[topic]
         else:
             assert str(libp2p_hosts[i].get_id()) not in gossipsubs[central_node_index].mesh[topic]
+            assert str(libp2p_hosts[central_node_index].get_id()) not in gossipsubs[i].mesh[topic]
 
     await cleanup()
 

--- a/tests/pubsub/utils.py
+++ b/tests/pubsub/utils.py
@@ -122,3 +122,8 @@ async def connect_some(hosts, degree):
     #         await connect(host, neighbor)
 
     #         j += 1
+
+async def one_to_all_connect(hosts, central_host_index):
+    for i, host in enumerate(hosts):
+        if i != central_host_index:
+            await connect(hosts[central_host_index], host)


### PR DESCRIPTION
### What was wrong?
Incorrect condition check in https://github.com/libp2p/py-libp2p/blob/b001256f5f184f6685c88a16a78ab199dff954c5/libp2p/pubsub/gossipsub.py#L206


### How was it fixed?
- Remove the line
- Also add an if-topic-already-in-mesh check to prevent re-joining a topic

#### Refactor `gossipsub.join`

This was intended for the fix but then I wonder if a refactor would improve the readability of this function. If not, I will revert the refactor and just apply the fix.

#### Also fixed
- [x] select gossipsub peers which did subscribe to the topic in mesh heartbeat