### PR TITLE
Add type hint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -128,6 +128,8 @@ disable=print-statement,
         dict-keys-not-iterating,
         dict-values-not-iterating,
         missing-docstring,
+        cyclic-import,
+        duplicate-code,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -24,6 +24,9 @@ from .host_interface import IHost
 # telling it to listen on the given listen addresses.
 
 
+StreamHandlerFn = Callable[[INetStream], Coroutine[Any, Any, None]]
+
+
 class BasicHost(IHost):
 
     _network: Swarm
@@ -31,7 +34,7 @@ class BasicHost(IHost):
     peerstore: PeerStore
 
     # default options constructor
-    def __init__(self, network: Swarm, router: KadmeliaPeerRouter=None) -> None:
+    def __init__(self, network: Swarm, router: KadmeliaPeerRouter = None) -> None:
         self._network = network
         self._router = router
         self.peerstore = self._network.peerstore
@@ -72,7 +75,7 @@ class BasicHost(IHost):
                 addrs.append(addr.encapsulate(p2p_part))
         return addrs
 
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], Coroutine[Any, Any, None]]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: StreamHandlerFn) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Callable,
+    Coroutine,
     List,
     Sequence,
 )
@@ -83,7 +84,7 @@ class BasicHost(IHost):
                 addrs.append(addr.encapsulate(p2p_part))
         return addrs
 
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], None]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], Coroutine[Any, Any, None]]) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -1,6 +1,33 @@
+from typing import (
+    Any,
+    Callable,
+    List,
+    Sequence,
+)
+
 import multiaddr
 
-from .host_interface import IHost
+from .host_interface import (
+    IHost,
+)
+from libp2p.network.swarm import (
+    Swarm
+)
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
+from libp2p.peer.peerstore import (
+    PeerStore,
+)
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
+)
+from libp2p.routing.kademlia.kademlia_peer_router import (
+    KadmeliaPeerRouter,
+)
 
 # Upon host creation, host takes in options,
 # including the list of addresses on which to listen.
@@ -10,48 +37,53 @@ from .host_interface import IHost
 
 class BasicHost(IHost):
 
+    _network: Swarm
+    router: KadmeliaPeerRouter
+    peerstore: PeerStore
+
     # default options constructor
-    def __init__(self, network, router=None):
+    def __init__(self, network: Swarm, router: KadmeliaPeerRouter=None) -> None:
         self._network = network
         self._router = router
         self.peerstore = self._network.peerstore
 
-    def get_id(self):
+    def get_id(self) -> ID:
         """
         :return: peer_id of host
         """
         return self._network.get_peer_id()
 
-    def get_network(self):
+    def get_network(self) -> Swarm:
         """
         :return: network instance of host
         """
         return self._network
 
-    def get_peerstore(self):
+    def get_peerstore(self) -> PeerStore:
         """
         :return: peerstore of the host (same one as in its network instance)
         """
         return self.peerstore
 
-    def get_mux(self):
+    # FIXME: Replace with correct return type
+    def get_mux(self) -> Any:
         """
         :return: mux instance of host
         """
 
-    def get_addrs(self):
+    def get_addrs(self) -> List[multiaddr.Multiaddr]:
         """
         :return: all the multiaddr addresses this host is listening too
         """
         p2p_part = multiaddr.Multiaddr('/p2p/{}'.format(self.get_id().pretty()))
 
-        addrs = []
+        addrs: List[multiaddr.Multiaddr] = []
         for transport in self._network.listeners.values():
             for addr in transport.get_addrs():
                 addrs.append(addr.encapsulate(p2p_part))
         return addrs
 
-    def set_stream_handler(self, protocol_id, stream_handler):
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], None]) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream
@@ -62,16 +94,15 @@ class BasicHost(IHost):
 
     # protocol_id can be a list of protocol_ids
     # stream will decide which protocol_id to run on
-    async def new_stream(self, peer_id, protocol_ids):
+    async def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> INetStream:
         """
         :param peer_id: peer_id that host is connecting
         :param protocol_id: protocol id that stream runs on
-        :return: true if successful
+        :return: stream: new stream created
         """
-        stream = await self._network.new_stream(peer_id, protocol_ids)
-        return stream
+        return await self._network.new_stream(peer_id, protocol_ids)
 
-    async def connect(self, peer_info):
+    async def connect(self, peer_info: PeerInfo) -> None:
         """
         connect ensures there is a connection between this host and the peer with
         given peer_info.peer_id. connect will absorb the addresses in peer_info into its internal

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -8,27 +8,15 @@ from typing import (
 
 import multiaddr
 
-from .host_interface import (
-    IHost,
-)
-from libp2p.network.swarm import (
-    Swarm
-)
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.peer.peerinfo import (
-    PeerInfo,
-)
-from libp2p.peer.peerstore import (
-    PeerStore,
-)
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
-from libp2p.routing.kademlia.kademlia_peer_router import (
-    KadmeliaPeerRouter,
-)
+from libp2p.network.swarm import Swarm
+from libp2p.peer.id import ID
+from libp2p.peer.peerinfo import PeerInfo
+from libp2p.peer.peerstore import PeerStore
+
+from libp2p.network.stream.net_stream_interface import INetStream
+from libp2p.routing.kademlia.kademlia_peer_router import KadmeliaPeerRouter
+
+from .host_interface import IHost
 
 # Upon host creation, host takes in options,
 # including the list of addresses on which to listen.

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -1,17 +1,17 @@
 from typing import (
     Any,
+    Awaitable,
     Callable,
-    Coroutine,
     List,
     Sequence,
 )
 
 import multiaddr
 
-from libp2p.network.swarm import Swarm
+from libp2p.network.network_interface import INetwork
 from libp2p.peer.id import ID
 from libp2p.peer.peerinfo import PeerInfo
-from libp2p.peer.peerstore import PeerStore
+from libp2p.peer.peerstore_interface import IPeerStore
 
 from libp2p.network.stream.net_stream_interface import INetStream
 from libp2p.routing.kademlia.kademlia_peer_router import KadmeliaPeerRouter
@@ -24,17 +24,17 @@ from .host_interface import IHost
 # telling it to listen on the given listen addresses.
 
 
-StreamHandlerFn = Callable[[INetStream], Coroutine[Any, Any, None]]
+StreamHandlerFn = Callable[[INetStream], Awaitable[None]]
 
 
 class BasicHost(IHost):
 
-    _network: Swarm
+    _network: INetwork
     router: KadmeliaPeerRouter
-    peerstore: PeerStore
+    peerstore: IPeerStore
 
     # default options constructor
-    def __init__(self, network: Swarm, router: KadmeliaPeerRouter = None) -> None:
+    def __init__(self, network: INetwork, router: KadmeliaPeerRouter = None) -> None:
         self._network = network
         self._router = router
         self.peerstore = self._network.peerstore
@@ -45,13 +45,13 @@ class BasicHost(IHost):
         """
         return self._network.get_peer_id()
 
-    def get_network(self) -> Swarm:
+    def get_network(self) -> INetwork:
         """
         :return: network instance of host
         """
         return self._network
 
-    def get_peerstore(self) -> PeerStore:
+    def get_peerstore(self) -> IPeerStore:
         """
         :return: peerstore of the host (same one as in its network instance)
         """

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -12,10 +12,11 @@ import multiaddr
 from libp2p.network.swarm import Swarm
 from libp2p.peer.id import ID
 from libp2p.peer.peerinfo import PeerInfo
-from libp2p.peer.peerstore import PeerStore
 
 from libp2p.network.stream.net_stream_interface import INetStream
-from libp2p.routing.kademlia.kademlia_peer_router import KadmeliaPeerRouter
+
+
+StreamHandlerFn = Callable[[INetStream], Coroutine[Any, Any, None]]
 
 
 class IHost(ABC):
@@ -46,7 +47,7 @@ class IHost(ABC):
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], Coroutine[Any, Any, None]]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: StreamHandlerFn) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream
@@ -57,7 +58,9 @@ class IHost(ABC):
     # protocol_id can be a list of protocol_ids
     # stream will decide which protocol_id to run on
     @abstractmethod
-    def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> Coroutine[Any, Any, INetStream]:
+    def new_stream(self,
+                   peer_id: ID,
+                   protocol_ids: Sequence[str]) -> Coroutine[Any, Any, INetStream]:
         """
         :param peer_id: peer_id that host is connecting
         :param protocol_ids: protocol ids that stream can run on

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -1,34 +1,63 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Sequence,
+)
+
+import multiaddr
+
+from libp2p.network.swarm import (
+    Swarm
+)
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
+from libp2p.peer.peerstore import (
+    PeerStore,
+)
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
+)
+from libp2p.routing.kademlia.kademlia_peer_router import (
+    KadmeliaPeerRouter,
+)
 
 
 class IHost(ABC):
 
     @abstractmethod
-    def get_id(self):
+    def get_id(self) -> ID:
         """
         :return: peer_id of host
         """
 
     @abstractmethod
-    def get_network(self):
+    def get_network(self) -> Swarm:
         """
         :return: network instance of host
         """
 
+    # FIXME: Replace with correct return type
     @abstractmethod
-    def get_mux(self):
+    def get_mux(self) -> Any:
         """
         :return: mux instance of host
         """
 
     @abstractmethod
-    def get_addrs(self):
+    def get_addrs(self) -> List[multiaddr.Multiaddr]:
         """
         :return: all the multiaddr addresses this host is listening too
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id, stream_handler):
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], None]) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream
@@ -39,15 +68,15 @@ class IHost(ABC):
     # protocol_id can be a list of protocol_ids
     # stream will decide which protocol_id to run on
     @abstractmethod
-    def new_stream(self, peer_id, protocol_ids):
+    def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> Coroutine[Any, Any, INetStream]:
         """
         :param peer_id: peer_id that host is connecting
         :param protocol_ids: protocol ids that stream can run on
-        :return: true if successful
+        :return: stream: new stream created
         """
 
     @abstractmethod
-    def connect(self, peer_info):
+    def connect(self, peer_info: PeerInfo) -> Coroutine[Any, Any, None]:
         """
         connect ensures there is a connection between this host and the peer with
         given peer_info.peer_id. connect will absorb the addresses in peer_info into its internal

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -57,7 +57,7 @@ class IHost(ABC):
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], None]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[INetStream], Coroutine[Any, Any, None]]) -> bool:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -59,8 +59,8 @@ class IHost(ABC):
     # stream will decide which protocol_id to run on
     @abstractmethod
     async def new_stream(self,
-                   peer_id: ID,
-                   protocol_ids: Sequence[str]) -> INetStream:
+                         peer_id: ID,
+                         protocol_ids: Sequence[str]) -> INetStream:
         """
         :param peer_id: peer_id that host is connecting
         :param protocol_ids: protocol ids that stream can run on

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -1,22 +1,22 @@
 from abc import ABC, abstractmethod
 from typing import (
     Any,
+    Awaitable,
     Callable,
-    Coroutine,
     List,
     Sequence,
 )
 
 import multiaddr
 
-from libp2p.network.swarm import Swarm
+from libp2p.network.network_interface import INetwork
 from libp2p.peer.id import ID
 from libp2p.peer.peerinfo import PeerInfo
 
 from libp2p.network.stream.net_stream_interface import INetStream
 
 
-StreamHandlerFn = Callable[[INetStream], Coroutine[Any, Any, None]]
+StreamHandlerFn = Callable[[INetStream], Awaitable[None]]
 
 
 class IHost(ABC):
@@ -28,7 +28,7 @@ class IHost(ABC):
         """
 
     @abstractmethod
-    def get_network(self) -> Swarm:
+    def get_network(self) -> INetwork:
         """
         :return: network instance of host
         """
@@ -58,9 +58,9 @@ class IHost(ABC):
     # protocol_id can be a list of protocol_ids
     # stream will decide which protocol_id to run on
     @abstractmethod
-    def new_stream(self,
+    async def new_stream(self,
                    peer_id: ID,
-                   protocol_ids: Sequence[str]) -> Coroutine[Any, Any, INetStream]:
+                   protocol_ids: Sequence[str]) -> INetStream:
         """
         :param peer_id: peer_id that host is connecting
         :param protocol_ids: protocol ids that stream can run on
@@ -68,7 +68,7 @@ class IHost(ABC):
         """
 
     @abstractmethod
-    def connect(self, peer_info: PeerInfo) -> Coroutine[Any, Any, None]:
+    async def connect(self, peer_info: PeerInfo) -> None:
         """
         connect ensures there is a connection between this host and the peer with
         given peer_info.peer_id. connect will absorb the addresses in peer_info into its internal

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -9,24 +9,13 @@ from typing import (
 
 import multiaddr
 
-from libp2p.network.swarm import (
-    Swarm
-)
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.peer.peerinfo import (
-    PeerInfo,
-)
-from libp2p.peer.peerstore import (
-    PeerStore,
-)
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
-from libp2p.routing.kademlia.kademlia_peer_router import (
-    KadmeliaPeerRouter,
-)
+from libp2p.network.swarm import Swarm
+from libp2p.peer.id import ID
+from libp2p.peer.peerinfo import PeerInfo
+from libp2p.peer.peerstore import PeerStore
+
+from libp2p.network.stream.net_stream_interface import INetStream
+from libp2p.routing.kademlia.kademlia_peer_router import KadmeliaPeerRouter
 
 
 class IHost(ABC):

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -1,8 +1,22 @@
+import asyncio
+
 from .raw_connection_interface import IRawConnection
 
 class RawConnection(IRawConnection):
 
-    def __init__(self, ip, port, reader, writer, initiator):
+    conn_ip: str
+    conn_port: str
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+    _next_id: int
+    initiator: bool
+
+    def __init__(self,
+                 ip: str,
+                 port: str,
+                 reader: asyncio.StreamReader,
+                 writer: asyncio.StreamWriter,
+                 initiator: bool) -> None:
         # pylint: disable=too-many-arguments
         self.conn_ip = ip
         self.conn_port = port
@@ -11,12 +25,12 @@ class RawConnection(IRawConnection):
         self._next_id = 0 if initiator else 1
         self.initiator = initiator
 
-    async def write(self, data):
+    async def write(self, data: bytes) -> None:
         self.writer.write(data)
         self.writer.write("\n".encode())
         await self.writer.drain()
 
-    async def read(self):
+    async def read(self) -> bytes:
         line = await self.reader.readline()
         adjusted_line = line.decode().rstrip('\n')
 
@@ -24,10 +38,10 @@ class RawConnection(IRawConnection):
         # encoding and decoding
         return adjusted_line.encode()
 
-    def close(self):
+    def close(self) -> None:
         self.writer.close()
 
-    def next_stream_id(self):
+    def next_stream_id(self) -> int:
         """
         Get next available stream id
         :return: next available stream id for the connection

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -35,7 +35,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], None]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], Coroutine[Any, Any, None]]) -> bool:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -3,7 +3,6 @@ from abc import (
     abstractmethod,
 )
 from typing import (
-    Any,
     Awaitable,
     Callable,
     Dict,
@@ -59,8 +58,8 @@ class INetwork(ABC):
 
     @abstractmethod
     async def new_stream(self,
-                   peer_id: ID,
-                   protocol_ids: Sequence[str]) -> INetStream:
+                         peer_id: ID,
+                         protocol_ids: Sequence[str]) -> INetStream:
         """
         :param peer_id: peer_id of destination
         :param protocol_ids: available protocol ids to use for stream

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -8,12 +8,11 @@ from typing import (
 
 from multiaddr import Multiaddr
 
+from libp2p.peer.id import ID
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
 from .notifee_interface import INotifee
 from .stream.net_stream import NetStream
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 
 class INetwork(ABC):

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -67,7 +67,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    async def listen(self, *args: Multiaddr) -> bool:
+    async def listen(self, *args: Sequence[Multiaddr]) -> bool:
         """
         :param *args: one or many multiaddrs to start listening on
         :return: True if at least one success

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -1,16 +1,31 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Sequence,
+)
+
+from multiaddr import Multiaddr
+
+from .notifee_interface import INotifee
+from .stream.net_stream import NetStream
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 
 class INetwork(ABC):
 
     @abstractmethod
-    def get_peer_id(self):
+    def get_peer_id(self) -> ID:
         """
         :return: the peer id
         """
 
     @abstractmethod
-    def dial_peer(self, peer_id):
+    def dial_peer(self, peer_id: ID) -> Coroutine[Any, Any, IMuxedConn]:
         """
         dial_peer try to create a connection to peer_id
 
@@ -20,7 +35,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id, stream_handler):
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], None]) -> bool:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance
@@ -28,7 +43,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def new_stream(self, peer_id, protocol_ids):
+    def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> Coroutine[Any, Any, NetStream]:
         """
         :param peer_id: peer_id of destination
         :param protocol_ids: available protocol ids to use for stream
@@ -36,14 +51,14 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def listen(self, *args):
+    def listen(self, *args: Multiaddr) -> Coroutine[Any, Any, bool]:
         """
         :param *args: one or many multiaddrs to start listening on
         :return: True if at least one success
         """
 
     @abstractmethod
-    def notify(self, notifee):
+    def notify(self, notifee: INotifee) -> bool:
         """
         :param notifee: object implementing Notifee interface
         :return: true if notifee registered successfully, false otherwise

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -1,9 +1,13 @@
-from abc import ABC, abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from typing import (
     Any,
     Callable,
     Coroutine,
     Sequence,
+    TYPE_CHECKING,
 )
 
 from multiaddr import Multiaddr
@@ -11,8 +15,13 @@ from multiaddr import Multiaddr
 from libp2p.peer.id import ID
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
-from .notifee_interface import INotifee
 from .stream.net_stream import NetStream
+
+if TYPE_CHECKING:
+    from .notifee_interface import INotifee
+
+
+StreamHandlerFn = Callable[[NetStream], Coroutine[Any, Any, None]]
 
 
 class INetwork(ABC):
@@ -34,7 +43,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], Coroutine[Any, Any, None]]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: StreamHandlerFn) -> bool:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance
@@ -42,7 +51,9 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> Coroutine[Any, Any, NetStream]:
+    def new_stream(self,
+                   peer_id: ID,
+                   protocol_ids: Sequence[str]) -> Coroutine[Any, Any, NetStream]:
         """
         :param peer_id: peer_id of destination
         :param protocol_ids: available protocol ids to use for stream
@@ -57,7 +68,7 @@ class INetwork(ABC):
         """
 
     @abstractmethod
-    def notify(self, notifee: INotifee) -> bool:
+    def notify(self, notifee: 'INotifee') -> bool:
         """
         :param notifee: object implementing Notifee interface
         :return: true if notifee registered successfully, false otherwise

--- a/libp2p/network/notifee_interface.py
+++ b/libp2p/network/notifee_interface.py
@@ -1,44 +1,51 @@
 from abc import ABC, abstractmethod
 
+from multiaddr import Multiaddr
+
+from libp2p.network.network_interface import INetwork
+from libp2p.network.stream.net_stream_interface import INetStream
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
+
 class INotifee(ABC):
 
     @abstractmethod
-    async def opened_stream(self, network, stream):
+    async def opened_stream(self, network: INetwork, stream: INetStream) -> None:
         """
         :param network: network the stream was opened on
         :param stream: stream that was opened
         """
 
     @abstractmethod
-    async def closed_stream(self, network, stream):
+    async def closed_stream(self, network: INetwork, stream: INetStream) -> None:
         """
         :param network: network the stream was closed on
         :param stream: stream that was closed
         """
 
     @abstractmethod
-    async def connected(self, network, conn):
+    async def connected(self, network: INetwork, conn: IMuxedConn) -> None:
         """
         :param network: network the connection was opened on
         :param conn: connection that was opened
         """
 
     @abstractmethod
-    async def disconnected(self, network, conn):
+    async def disconnected(self, network: INetwork, conn: IMuxedConn) -> None:
         """
         :param network: network the connection was closed on
         :param conn: connection that was closed
         """
 
     @abstractmethod
-    async def listen(self, network, multiaddr):
+    async def listen(self, network: INetwork, multiaddr: Multiaddr) -> None:
         """
         :param network: network the listener is listening on
         :param multiaddr: multiaddress listener is listening on
         """
 
     @abstractmethod
-    async def listen_close(self, network, multiaddr):
+    async def listen_close(self, network: INetwork, multiaddr: Multiaddr) -> None:
         """
         :param network: network the connection was opened on
         :param multiaddr: multiaddress listener is no longer listening on

--- a/libp2p/network/notifee_interface.py
+++ b/libp2p/network/notifee_interface.py
@@ -1,52 +1,58 @@
-from abc import ABC, abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import TYPE_CHECKING
 
 from multiaddr import Multiaddr
 
-from libp2p.network.network_interface import INetwork
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 from libp2p.network.stream.net_stream_interface import INetStream
+
+if TYPE_CHECKING:
+    from .network_interface import INetwork
 
 
 class INotifee(ABC):
 
     @abstractmethod
-    async def opened_stream(self, network: INetwork, stream: INetStream) -> None:
+    async def opened_stream(self, network: 'INetwork', stream: INetStream) -> None:
         """
         :param network: network the stream was opened on
         :param stream: stream that was opened
         """
 
     @abstractmethod
-    async def closed_stream(self, network: INetwork, stream: INetStream) -> None:
+    async def closed_stream(self, network: 'INetwork', stream: INetStream) -> None:
         """
         :param network: network the stream was closed on
         :param stream: stream that was closed
         """
 
     @abstractmethod
-    async def connected(self, network: INetwork, conn: IMuxedConn) -> None:
+    async def connected(self, network: 'INetwork', conn: IMuxedConn) -> None:
         """
         :param network: network the connection was opened on
         :param conn: connection that was opened
         """
 
     @abstractmethod
-    async def disconnected(self, network: INetwork, conn: IMuxedConn) -> None:
+    async def disconnected(self, network: 'INetwork', conn: IMuxedConn) -> None:
         """
         :param network: network the connection was closed on
         :param conn: connection that was closed
         """
 
     @abstractmethod
-    async def listen(self, network: INetwork, multiaddr: Multiaddr) -> None:
+    async def listen(self, network: 'INetwork', multiaddr: Multiaddr) -> None:
         """
         :param network: network the listener is listening on
         :param multiaddr: multiaddress listener is listening on
         """
 
     @abstractmethod
-    async def listen_close(self, network: INetwork, multiaddr: Multiaddr) -> None:
+    async def listen_close(self, network: 'INetwork', multiaddr: Multiaddr) -> None:
         """
         :param network: network the connection was opened on
         :param multiaddr: multiaddress listener is no longer listening on

--- a/libp2p/network/notifee_interface.py
+++ b/libp2p/network/notifee_interface.py
@@ -3,8 +3,9 @@ from abc import ABC, abstractmethod
 from multiaddr import Multiaddr
 
 from libp2p.network.network_interface import INetwork
-from libp2p.network.stream.net_stream_interface import INetStream
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
+from libp2p.network.stream.net_stream_interface import INetStream
 
 
 class INotifee(ABC):

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -1,6 +1,7 @@
-from .net_stream_interface import INetStream
-from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
 from libp2p.stream_muxer.mplex.mplex import Mplex
+from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
+
+from .net_stream_interface import INetStream
 
 
 class NetStream(INetStream):

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -1,41 +1,47 @@
 from .net_stream_interface import INetStream
+from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
+from libp2p.stream_muxer.mplex.mplex import Mplex
 
 
 class NetStream(INetStream):
 
-    def __init__(self, muxed_stream):
+    muxed_stream: MplexStream
+    mplex_conn: Mplex
+    protocol_id: str
+
+    def __init__(self, muxed_stream: MplexStream) -> None:
         self.muxed_stream = muxed_stream
         self.mplex_conn = muxed_stream.mplex_conn
         self.protocol_id = None
 
-    def get_protocol(self):
+    def get_protocol(self) -> str:
         """
         :return: protocol id that stream runs on
         """
         return self.protocol_id
 
-    def set_protocol(self, protocol_id):
+    def set_protocol(self, protocol_id: str) -> None:
         """
         :param protocol_id: protocol id that stream runs on
         :return: true if successful
         """
         self.protocol_id = protocol_id
 
-    async def read(self):
+    async def read(self) -> bytes:
         """
         read from stream
         :return: bytes of input until EOF
         """
         return await self.muxed_stream.read()
 
-    async def write(self, data):
+    async def write(self, data: bytes) -> int:
         """
         write to stream
         :return: number of bytes written
         """
         return await self.muxed_stream.write(data)
 
-    async def close(self):
+    async def close(self) -> bool:
         """
         close stream
         :return: true if successful

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -1,16 +1,16 @@
-from libp2p.stream_muxer.mplex.mplex import Mplex
-from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+from libp2p.stream_muxer.muxed_stream_interface import IMuxedStream
 
 from .net_stream_interface import INetStream
 
 
 class NetStream(INetStream):
 
-    muxed_stream: MplexStream
-    mplex_conn: Mplex
+    muxed_stream: IMuxedStream
+    mplex_conn: IMuxedConn
     protocol_id: str
 
-    def __init__(self, muxed_stream: MplexStream) -> None:
+    def __init__(self, muxed_stream: IMuxedStream) -> None:
         self.muxed_stream = muxed_stream
         self.mplex_conn = muxed_stream.mplex_conn
         self.protocol_id = None

--- a/libp2p/network/stream/net_stream_interface.py
+++ b/libp2p/network/stream/net_stream_interface.py
@@ -1,37 +1,41 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Coroutine,
+)
 
 
 class INetStream(ABC):
 
     @abstractmethod
-    def get_protocol(self):
+    def get_protocol(self) -> str:
         """
         :return: protocol id that stream runs on
         """
 
     @abstractmethod
-    def set_protocol(self, protocol_id):
+    def set_protocol(self, protocol_id: str) -> bool:
         """
         :param protocol_id: protocol id that stream runs on
         :return: true if successful
         """
 
     @abstractmethod
-    def read(self):
+    def read(self) -> Coroutine[Any, Any, bytes]:
         """
         reads from the underlying muxed_stream
         :return: bytes of input
         """
 
     @abstractmethod
-    def write(self, _bytes):
+    def write(self, data: bytes) -> Coroutine[Any, Any, int]:
         """
         write to the underlying muxed_stream
         :return: number of bytes written
         """
 
     @abstractmethod
-    def close(self):
+    def close(self) -> Coroutine[Any, Any, bool]:
         """
         close the underlying muxed stream
         :return: true if successful

--- a/libp2p/network/stream/net_stream_interface.py
+++ b/libp2p/network/stream/net_stream_interface.py
@@ -1,15 +1,14 @@
 from abc import ABC, abstractmethod
 from typing import (
     Any,
-    Coroutine,
 )
 
-from libp2p.stream_muxer.mplex.mplex import Mplex
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 
 class INetStream(ABC):
 
-    mplex_conn: Mplex
+    mplex_conn: IMuxedConn
 
     @abstractmethod
     def get_protocol(self) -> str:
@@ -25,21 +24,21 @@ class INetStream(ABC):
         """
 
     @abstractmethod
-    def read(self) -> Coroutine[Any, Any, bytes]:
+    async def read(self) -> bytes:
         """
         reads from the underlying muxed_stream
         :return: bytes of input
         """
 
     @abstractmethod
-    def write(self, data: bytes) -> Coroutine[Any, Any, int]:
+    async def write(self, data: bytes) -> int:
         """
         write to the underlying muxed_stream
         :return: number of bytes written
         """
 
     @abstractmethod
-    def close(self) -> Coroutine[Any, Any, bool]:
+    async def close(self) -> bool:
         """
         close the underlying muxed stream
         :return: true if successful

--- a/libp2p/network/stream/net_stream_interface.py
+++ b/libp2p/network/stream/net_stream_interface.py
@@ -4,8 +4,12 @@ from typing import (
     Coroutine,
 )
 
+from libp2p.stream_muxer.mplex.mplex import Mplex
+
 
 class INetStream(ABC):
+
+    mplex_conn: Mplex
 
     @abstractmethod
     def get_protocol(self) -> str:

--- a/libp2p/network/stream/net_stream_interface.py
+++ b/libp2p/network/stream/net_stream_interface.py
@@ -1,7 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import (
-    Any,
-)
 
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -74,7 +74,7 @@ class Swarm(INetwork):
     def get_peer_id(self) -> ID:
         return self.self_id
 
-    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], None]) -> bool:
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], Coroutine[Any, Any, None]]) -> bool:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -1,8 +1,8 @@
 import asyncio
 from typing import (
     Any,
+    Awaitable,
     Callable,
-    Coroutine,
     Dict,
     List,
     Sequence,
@@ -18,10 +18,10 @@ from libp2p.peer.peerstore import PeerStore
 from libp2p.protocol_muxer.multiselect import Multiselect
 from libp2p.protocol_muxer.multiselect_client import MultiselectClient
 from libp2p.routing.interfaces import IPeerRouting
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 from libp2p.transport.upgrader import TransportUpgrader
 from libp2p.transport.transport_interface import ITransport
 from libp2p.transport.listener_interface import IListener
-from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
 
@@ -29,9 +29,10 @@ from .network_interface import INetwork
 from .notifee_interface import INotifee
 from .connection.raw_connection import RawConnection
 from .stream.net_stream import NetStream
+from .stream.net_stream_interface import INetStream
 
 
-StreamHandlerFn = Callable[[NetStream], Coroutine[Any, Any, None]]
+StreamHandlerFn = Callable[[INetStream], Awaitable[None]]
 
 
 class Swarm(INetwork):
@@ -44,7 +45,7 @@ class Swarm(INetwork):
     router: IPeerRouting
     connections: Dict[ID, IMuxedConn]
     listeners: Dict[str, IListener]
-    stream_handlers: Dict[NetStream, Callable[[NetStream], None]]
+    stream_handlers: Dict[INetStream, Callable[[INetStream], None]]
 
     multiselect: Multiselect
     multiselect_client: MultiselectClient
@@ -252,7 +253,7 @@ class Swarm(INetwork):
     # TODO: `disconnect`?
 
 
-GenericProtocolHandlerFn = Callable[[MplexStream], Coroutine[Any, Any, None]]
+GenericProtocolHandlerFn = Callable[[MplexStream], Awaitable[None]]
 
 
 def create_generic_protocol_handler(swarm: Swarm) -> GenericProtocolHandlerFn:

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -1,18 +1,57 @@
 import asyncio
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Sequence,
+)
 
-from libp2p.protocol_muxer.multiselect_client import MultiselectClient
-from libp2p.protocol_muxer.multiselect import Multiselect
-from libp2p.peer.id import id_b58_decode
+from multiaddr import Multiaddr
 
 from .network_interface import INetwork
 from .notifee_interface import INotifee
-from .stream.net_stream import NetStream
 from .connection.raw_connection import RawConnection
+from .stream.net_stream import NetStream
+from libp2p.peer.id import (
+    ID,
+    id_b58_decode,
+)
+from libp2p.peer.peerstore import PeerStore
+from libp2p.protocol_muxer.multiselect import Multiselect
+from libp2p.protocol_muxer.multiselect_client import MultiselectClient
+from libp2p.routing.interfaces import IPeerRouting
+from libp2p.transport.upgrader import TransportUpgrader
+from libp2p.transport.transport_interface import ITransport
+from libp2p.transport.listener_interface import IListener
+from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
 
 class Swarm(INetwork):
     # pylint: disable=too-many-instance-attributes,cell-var-from-loop,too-many-arguments
 
-    def __init__(self, peer_id, peerstore, upgrader, transport, router):
+    self_id: ID
+    peerstore: PeerStore
+    upgrader: TransportUpgrader
+    transport: ITransport
+    router: IPeerRouting
+    connections: Dict[ID, IMuxedConn]
+    listeners: Dict[str, IListener]
+    stream_handlers: Dict[NetStream, Callable[[NetStream], None]]
+
+    multiselect: Multiselect
+    multiselect_client: MultiselectClient
+
+    notifees: List[INotifee]
+
+    def __init__(self,
+                 peer_id: ID,
+                 peerstore: PeerStore,
+                 upgrader: TransportUpgrader,
+                 transport: ITransport,
+                 router: IPeerRouting):
         self.self_id = peer_id
         self.peerstore = peerstore
         self.upgrader = upgrader
@@ -32,10 +71,10 @@ class Swarm(INetwork):
         # Create generic protocol handler
         self.generic_protocol_handler = create_generic_protocol_handler(self)
 
-    def get_peer_id(self):
+    def get_peer_id(self) -> ID:
         return self.self_id
 
-    def set_stream_handler(self, protocol_id, stream_handler):
+    def set_stream_handler(self, protocol_id: str, stream_handler: Callable[[NetStream], None]) -> bool:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance
@@ -44,7 +83,7 @@ class Swarm(INetwork):
         self.multiselect.add_handler(protocol_id, stream_handler)
         return True
 
-    async def dial_peer(self, peer_id):
+    async def dial_peer(self, peer_id: ID) -> IMuxedConn:
         """
         dial_peer try to create a connection to peer_id
         :param peer_id: peer if we want to dial
@@ -87,7 +126,7 @@ class Swarm(INetwork):
 
         return muxed_conn
 
-    async def new_stream(self, peer_id, protocol_ids):
+    async def new_stream(self, peer_id: ID, protocol_ids: Sequence[str]) -> NetStream:
         """
         :param peer_id: peer_id of destination
         :param protocol_id: protocol id
@@ -109,7 +148,7 @@ class Swarm(INetwork):
         muxed_stream = await muxed_conn.open_stream(protocol_ids[0], multiaddr)
 
         # Perform protocol muxing to determine protocol to use
-        selected_protocol = await self.multiselect_client.select_one_of(protocol_ids, muxed_stream)
+        selected_protocol = await self.multiselect_client.select_one_of(list(protocol_ids), muxed_stream)
 
         # Create a net stream with the selected protocol
         net_stream = NetStream(muxed_stream)
@@ -121,7 +160,7 @@ class Swarm(INetwork):
 
         return net_stream
 
-    async def listen(self, *args):
+    async def listen(self, *args: Multiaddr) -> bool:
         """
         :param *args: one or many multiaddrs to start listening on
         :return: true if at least one success
@@ -139,7 +178,7 @@ class Swarm(INetwork):
             if str(multiaddr) in self.listeners:
                 return True
 
-            async def conn_handler(reader, writer):
+            async def conn_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
                 # Read in first message (should be peer_id of initiator) and ack
                 peer_id = id_b58_decode((await reader.read(1024)).decode())
 
@@ -182,7 +221,7 @@ class Swarm(INetwork):
         # No multiaddr succeeded
         return False
 
-    def notify(self, notifee):
+    def notify(self, notifee: INotifee) -> bool:
         """
         :param notifee: object implementing Notifee interface
         :return: true if notifee registered successfully, false otherwise
@@ -192,7 +231,7 @@ class Swarm(INetwork):
             return True
         return False
 
-    def add_router(self, router):
+    def add_router(self, router: IPeerRouting) -> None:
         self.router = router
 
     # TODO: `tear_down`
@@ -204,7 +243,10 @@ class Swarm(INetwork):
     # TODO: `disconnect`?
 
 
-def create_generic_protocol_handler(swarm):
+GenericProtocolHandlerFn = Callable[[MplexStream], Coroutine[Any, Any, None]]
+
+
+def create_generic_protocol_handler(swarm: Swarm) -> GenericProtocolHandlerFn:
     """
     Create a generic protocol handler from the given swarm. We use swarm
     to extract the multiselect module so that generic_protocol_handler
@@ -213,7 +255,7 @@ def create_generic_protocol_handler(swarm):
     """
     multiselect = swarm.multiselect
 
-    async def generic_protocol_handler(muxed_stream):
+    async def generic_protocol_handler(muxed_stream: MplexStream) -> None:
         # Perform protocol muxing to determine protocol to use
         protocol, handler = await multiselect.negotiate(muxed_stream)
 
@@ -228,6 +270,7 @@ def create_generic_protocol_handler(swarm):
         asyncio.ensure_future(handler(net_stream))
 
     return generic_protocol_handler
+
 
 class SwarmException(Exception):
     pass

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -10,10 +10,6 @@ from typing import (
 
 from multiaddr import Multiaddr
 
-from .network_interface import INetwork
-from .notifee_interface import INotifee
-from .connection.raw_connection import RawConnection
-from .stream.net_stream import NetStream
 from libp2p.peer.id import (
     ID,
     id_b58_decode,
@@ -25,8 +21,14 @@ from libp2p.routing.interfaces import IPeerRouting
 from libp2p.transport.upgrader import TransportUpgrader
 from libp2p.transport.transport_interface import ITransport
 from libp2p.transport.listener_interface import IListener
-from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
+from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
+
+from .network_interface import INetwork
+from .notifee_interface import INotifee
+from .connection.raw_connection import RawConnection
+from .stream.net_stream import NetStream
 
 
 class Swarm(INetwork):

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import (
-    Any,
     Awaitable,
     Callable,
     Dict,

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -18,11 +18,11 @@ from libp2p.protocol_muxer.multiselect import Multiselect
 from libp2p.protocol_muxer.multiselect_client import MultiselectClient
 from libp2p.routing.interfaces import IPeerRouting
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+from libp2p.stream_muxer.muxed_stream_interface import IMuxedStream
 from libp2p.transport.upgrader import TransportUpgrader
 from libp2p.transport.transport_interface import ITransport
 from libp2p.transport.listener_interface import IListener
 
-from libp2p.stream_muxer.mplex.mplex_stream import MplexStream
 
 from .network_interface import INetwork
 from .notifee_interface import INotifee
@@ -168,7 +168,7 @@ class Swarm(INetwork):
 
         return net_stream
 
-    async def listen(self, *args: Multiaddr) -> bool:
+    async def listen(self, *args: Sequence[Multiaddr]) -> bool:
         """
         :param *args: one or many multiaddrs to start listening on
         :return: true if at least one success
@@ -252,7 +252,7 @@ class Swarm(INetwork):
     # TODO: `disconnect`?
 
 
-GenericProtocolHandlerFn = Callable[[MplexStream], Awaitable[None]]
+GenericProtocolHandlerFn = Callable[[IMuxedStream], Awaitable[None]]
 
 
 def create_generic_protocol_handler(swarm: Swarm) -> GenericProtocolHandlerFn:
@@ -264,7 +264,7 @@ def create_generic_protocol_handler(swarm: Swarm) -> GenericProtocolHandlerFn:
     """
     multiselect = swarm.multiselect
 
-    async def generic_protocol_handler(muxed_stream: MplexStream) -> None:
+    async def generic_protocol_handler(muxed_stream: IMuxedStream) -> None:
         # Perform protocol muxing to determine protocol to use
         protocol, handler = await multiselect.negotiate(muxed_stream)
 

--- a/libp2p/peer/addrbook_interface.py
+++ b/libp2p/peer/addrbook_interface.py
@@ -1,13 +1,22 @@
 from abc import ABC, abstractmethod
+from typing import (
+    List,
+    Sequence,
+)
+
+
+from multiaddr import Multiaddr
+
+from .id import ID
 
 
 class IAddrBook(ABC):
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     @abstractmethod
-    def add_addr(self, peer_id, addr, ttl):
+    def add_addr(self, peer_id: ID, addr: Multiaddr, ttl: int) -> None:
         """
         Calls add_addrs(peer_id, [addr], ttl)
         :param peer_id: the peer to add address for
@@ -16,7 +25,7 @@ class IAddrBook(ABC):
         """
 
     @abstractmethod
-    def add_addrs(self, peer_id, addrs, ttl):
+    def add_addrs(self, peer_id: ID, addrs: Sequence[Multiaddr], ttl: int) -> None:
         """
         Adds addresses for a given peer all with the same time-to-live. If one of the
         addresses already exists for the peer and has a longer TTL, no operation should take place.
@@ -27,21 +36,21 @@ class IAddrBook(ABC):
         """
 
     @abstractmethod
-    def addrs(self, peer_id):
+    def addrs(self, peer_id: ID) -> List[Multiaddr]:
         """
         :param peer_id: peer to get addresses of
         :return: all known (and valid) addresses for the given peer
         """
 
     @abstractmethod
-    def clear_addrs(self, peer_id):
+    def clear_addrs(self, peer_id: ID) -> None:
         """
         Removes all previously stored addresses
         :param peer_id: peer to remove addresses of
         """
 
     @abstractmethod
-    def peers_with_addrs(self):
+    def peers_with_addrs(self) -> List[ID]:
         """
         :return: all of the peer IDs stored with addresses
         """

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -1,13 +1,13 @@
+import hashlib
 from typing import (
     Union,
 )
 
-from Crypto.PublicKey.RSA import (
-    RsaKey,
-)
-import hashlib
 import base58
+
 import multihash
+
+from Crypto.PublicKey.RSA import RsaKey
 
 # MaxInlineKeyLength is the maximum length a key can be for it to be inlined in
 # the peer ID.

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -25,7 +25,8 @@ class ID:
     def __init__(self, id_str: str) -> None:
         self._id_str = id_str
 
-    def to_bytes(self) -> bytes:
+    # FIXME: Should return type `bytes`
+    def to_bytes(self) -> str:
         return self._id_str
 
     def get_raw_id(self) -> str:

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -1,3 +1,10 @@
+from typing import (
+    Union,
+)
+
+from Crypto.PublicKey.RSA import (
+    RsaKey,
+)
 import hashlib
 import base58
 import multihash
@@ -13,67 +20,71 @@ MAX_INLINE_KEY_LENGTH = 42
 
 class ID:
 
-    def __init__(self, id_str):
+    _id_str: str
+
+    def __init__(self, id_str: str) -> None:
         self._id_str = id_str
 
     def to_bytes(self) -> bytes:
         return self._id_str
 
-    def get_raw_id(self):
+    def get_raw_id(self) -> str:
         return self._id_str
 
-    def pretty(self):
+    def pretty(self) -> str:
         return base58.b58encode(self._id_str).decode()
 
-    def get_xor_id(self):
+    def get_xor_id(self) -> int:
         return int(digest(self.get_raw_id()).hex(), 16)
 
-    def __str__(self):
+    def __str__(self) -> str:
         pid = self.pretty()
         return pid
 
     __repr__ = __str__
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         #pylint: disable=protected-access
+        if not isinstance(other, ID):
+            return NotImplemented
         return self._id_str == other._id_str
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self._id_str)
 
 
-def id_b58_encode(peer_id):
+def id_b58_encode(peer_id: ID) -> str:
     """
     return a b58-encoded string
     """
     #pylint: disable=protected-access
-    return base58.b58encode(peer_id._id_str).decode()
+    return base58.b58encode(peer_id.get_raw_id()).decode()
 
 
-def id_b58_decode(peer_id_str):
+def id_b58_decode(peer_id_str: str) -> ID:
     """
     return a base58-decoded peer ID
     """
     return ID(base58.b58decode(peer_id_str))
 
 
-def id_from_public_key(key):
+def id_from_public_key(key: RsaKey) -> ID:
     # export into binary format
     key_bin = key.exportKey("DER")
 
-    algo = multihash.Func.sha2_256
+    algo: int = multihash.Func.sha2_256
     # TODO: seems identity is not yet supported in pymultihash
     # if len(b) <= MAX_INLINE_KEY_LENGTH:
     #     algo multihash.func.identity
 
-    mh_digest = multihash.digest(key_bin, algo)
+    mh_digest: multihash.Multihash = multihash.digest(key_bin, algo)
     return ID(mh_digest.encode())
 
 
-def id_from_private_key(key):
+def id_from_private_key(key: RsaKey) -> ID:
     return id_from_public_key(key.publickey())
 
-def digest(string):
-    if not isinstance(string, bytes):
-        string = str(string).encode('utf8')
-    return hashlib.sha1(string).digest()
+def digest(data: Union[str, bytes]) -> bytes:
+    if not isinstance(data, bytes):
+        data_bytes = str(data).encode('utf8')
+    return hashlib.sha1(data_bytes).digest()

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -20,16 +20,15 @@ MAX_INLINE_KEY_LENGTH = 42
 
 class ID:
 
-    _id_str: str
+    _id_str: bytes
 
-    def __init__(self, id_str: str) -> None:
+    def __init__(self, id_str: bytes) -> None:
         self._id_str = id_str
 
-    # FIXME: Should return type `bytes`
-    def to_bytes(self) -> str:
+    def to_bytes(self) -> bytes:
         return self._id_str
 
-    def get_raw_id(self) -> str:
+    def get_raw_id(self) -> bytes:
         return self._id_str
 
     def pretty(self) -> str:
@@ -86,6 +85,6 @@ def id_from_private_key(key: RsaKey) -> ID:
     return id_from_public_key(key.publickey())
 
 def digest(data: Union[str, bytes]) -> bytes:
-    if not isinstance(data, bytes):
-        data = str(data).encode('utf8')
+    if isinstance(data, str):
+        data = data.encode('utf8')
     return hashlib.sha1(data).digest()

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -86,5 +86,5 @@ def id_from_private_key(key: RsaKey) -> ID:
 
 def digest(data: Union[str, bytes]) -> bytes:
     if not isinstance(data, bytes):
-        data_bytes = str(data).encode('utf8')
-    return hashlib.sha1(data_bytes).digest()
+        data = str(data).encode('utf8')
+    return hashlib.sha1(data).digest()

--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -39,10 +39,10 @@ class PeerData(IPeerData):
     def clear_addrs(self) -> None:
         self.addrs = []
 
-    def put_metadata(self, key: Any, val: Any) -> None:
+    def put_metadata(self, key: str, val: Any) -> None:
         self.metadata[key] = val
 
-    def get_metadata(self, key: Any) -> Any:
+    def get_metadata(self, key: str) -> Any:
         if key in self.metadata:
             return self.metadata[key]
         raise PeerDataError("key not found")

--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -31,7 +31,7 @@ class PeerData(IPeerData):
         self.protocols = list(protocols)
 
     def add_addrs(self, addrs: Sequence[Multiaddr]) -> None:
-        self.addrs.extend(list(addrs))
+        self.addrs.extend(addrs)
 
     def get_addrs(self) -> List[Multiaddr]:
         return self.addrs

--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -1,35 +1,48 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Sequence,
+)
+
+from multiaddr import Multiaddr
+
 from .peerdata_interface import IPeerData
 
 
 class PeerData(IPeerData):
 
-    def __init__(self):
+    metadata: Dict[Any, Any]
+    protocols: List[str]
+    addrs: List[Multiaddr]
+
+    def __init__(self) -> None:
         self.metadata = {}
         self.protocols = []
         self.addrs = []
 
-    def get_protocols(self):
+    def get_protocols(self) -> List[str]:
         return self.protocols
 
-    def add_protocols(self, protocols):
-        self.protocols.extend(protocols)
+    def add_protocols(self, protocols: Sequence[str]) -> None:
+        self.protocols.extend(list(protocols))
 
-    def set_protocols(self, protocols):
-        self.protocols = protocols
+    def set_protocols(self, protocols: Sequence[str]) -> None:
+        self.protocols = list(protocols)
 
-    def add_addrs(self, addrs):
-        self.addrs.extend(addrs)
+    def add_addrs(self, addrs: Sequence[Multiaddr]) -> None:
+        self.addrs.extend(list(addrs))
 
-    def get_addrs(self):
+    def get_addrs(self) -> List[Multiaddr]:
         return self.addrs
 
-    def clear_addrs(self):
+    def clear_addrs(self) -> None:
         self.addrs = []
 
-    def put_metadata(self, key, val):
+    def put_metadata(self, key: Any, val: Any) -> None:
         self.metadata[key] = val
 
-    def get_metadata(self, key):
+    def get_metadata(self, key: Any) -> Any:
         if key in self.metadata:
             return self.metadata[key]
         raise PeerDataError("key not found")

--- a/libp2p/peer/peerdata_interface.py
+++ b/libp2p/peer/peerdata_interface.py
@@ -1,46 +1,53 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    List,
+    Sequence,
+)
+
+from multiaddr import Multiaddr
 
 
 class IPeerData(ABC):
 
     @abstractmethod
-    def get_protocols(self):
+    def get_protocols(self) -> List[str]:
         """
         :return: all protocols associated with given peer
         """
 
     @abstractmethod
-    def add_protocols(self, protocols):
+    def add_protocols(self, protocols: Sequence[str]) -> None:
         """
         :param protocols: protocols to add
         """
 
     @abstractmethod
-    def set_protocols(self, protocols):
+    def set_protocols(self, protocols: Sequence[str]) -> None:
         """
         :param protocols: protocols to add
         """
 
     @abstractmethod
-    def add_addrs(self, addrs):
+    def add_addrs(self, addrs: Sequence[Multiaddr]) -> None:
         """
         :param addrs: multiaddresses to add
         """
 
     @abstractmethod
-    def get_addrs(self):
+    def get_addrs(self) -> List[Multiaddr]:
         """
         :return: all multiaddresses
         """
 
     @abstractmethod
-    def clear_addrs(self):
+    def clear_addrs(self) -> None:
         """
         Clear all addresses
         """
 
     @abstractmethod
-    def put_metadata(self, key, val):
+    def put_metadata(self, key: Any, val: Any) -> None:
         """
         :param key: key in KV pair
         :param val: val to associate with key
@@ -48,7 +55,7 @@ class IPeerData(ABC):
         """
 
     @abstractmethod
-    def get_metadata(self, key):
+    def get_metadata(self, key: Any) -> Any:
         """
         :param key: key in KV pair
         :return: val for key

--- a/libp2p/peer/peerdata_interface.py
+++ b/libp2p/peer/peerdata_interface.py
@@ -7,6 +7,8 @@ from typing import (
 
 from multiaddr import Multiaddr
 
+from .peermetadata_interface import IPeerMetadata
+
 
 class IPeerData(ABC):
 
@@ -47,7 +49,7 @@ class IPeerData(ABC):
         """
 
     @abstractmethod
-    def put_metadata(self, key: Any, val: Any) -> None:
+    def put_metadata(self, key: str, val: Any) -> None:
         """
         :param key: key in KV pair
         :param val: val to associate with key
@@ -55,7 +57,7 @@ class IPeerData(ABC):
         """
 
     @abstractmethod
-    def get_metadata(self, key: Any) -> Any:
+    def get_metadata(self, key: str) -> IPeerMetadata:
         """
         :param key: key in KV pair
         :return: val for key

--- a/libp2p/peer/peerinfo.py
+++ b/libp2p/peer/peerinfo.py
@@ -17,7 +17,7 @@ class PeerInfo:
     peer_id: ID
     addrs: List[multiaddr.Multiaddr]
 
-    def __init__(self, peer_id: ID, peer_data: PeerData=None) -> None:
+    def __init__(self, peer_id: ID, peer_data: PeerData = None) -> None:
         self.peer_id = peer_id
         self.addrs = peer_data.get_addrs() if peer_data else None
 
@@ -49,7 +49,7 @@ def info_from_p2p_addr(addr: multiaddr.Multiaddr) -> PeerInfo:
         addr = multiaddr.Multiaddr.join(*parts[:-1])
 
     peer_data = PeerData()
-    peer_data.add_addrs(addr)
+    peer_data.add_addrs([addr])
     peer_data.set_protocols([p.code for p in addr.protocols()])
 
     return PeerInfo(peer_id, peer_data)

--- a/libp2p/peer/peerinfo.py
+++ b/libp2p/peer/peerinfo.py
@@ -1,12 +1,23 @@
+from typing import (
+    List,
+)
+
 import multiaddr
 
-from .id import id_b58_decode
+from .id import (
+    ID,
+    id_b58_decode,
+)
 from .peerdata import PeerData
 
 
 class PeerInfo:
     # pylint: disable=too-few-public-methods
-    def __init__(self, peer_id, peer_data=None):
+
+    peer_id: ID
+    addrs: List[multiaddr.Multiaddr]
+
+    def __init__(self, peer_id: ID, peer_data: PeerData=None) -> None:
         self.peer_id = peer_id
         self.addrs = peer_data.get_addrs() if peer_data else None
 
@@ -30,16 +41,16 @@ def info_from_p2p_addr(addr: multiaddr.Multiaddr) -> PeerInfo:
         )
 
     # make sure the /p2p value parses as a peer.ID
-    peer_id_str = p2p_part.value_for_protocol(multiaddr.protocols.P_P2P)
-    peer_id = id_b58_decode(peer_id_str)
+    peer_id_str: str = p2p_part.value_for_protocol(multiaddr.protocols.P_P2P)
+    peer_id: ID = id_b58_decode(peer_id_str)
 
     # we might have received just an / p2p part, which means there's no addr.
     if len(parts) > 1:
         addr = multiaddr.Multiaddr.join(*parts[:-1])
 
     peer_data = PeerData()
-    peer_data.addrs = [addr]
-    peer_data.protocols = [p.code for p in addr.protocols()]
+    peer_data.add_addrs(addr)
+    peer_data.set_protocols([p.code for p in addr.protocols()])
 
     return PeerInfo(peer_id, peer_data)
 

--- a/libp2p/peer/peermetadata_interface.py
+++ b/libp2p/peer/peermetadata_interface.py
@@ -1,13 +1,20 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+)
+
+from .id import (
+    ID,
+)
 
 
 class IPeerMetadata(ABC):
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     @abstractmethod
-    def get(self, peer_id, key):
+    def get(self, peer_id: ID, key: Any) -> Any:
         """
         :param peer_id: peer ID to lookup key for
         :param key: key to look up
@@ -16,7 +23,7 @@ class IPeerMetadata(ABC):
         """
 
     @abstractmethod
-    def put(self, peer_id, key, val):
+    def put(self, peer_id: ID, key: Any, val: Any) -> None:
         """
         :param peer_id: peer ID to lookup key for
         :param key: key to associate with peer

--- a/libp2p/peer/peermetadata_interface.py
+++ b/libp2p/peer/peermetadata_interface.py
@@ -14,7 +14,7 @@ class IPeerMetadata(ABC):
         pass
 
     @abstractmethod
-    def get(self, peer_id: ID, key: Any) -> Any:
+    def get(self, peer_id: ID, key: str) -> Any:
         """
         :param peer_id: peer ID to lookup key for
         :param key: key to look up
@@ -23,7 +23,7 @@ class IPeerMetadata(ABC):
         """
 
     @abstractmethod
-    def put(self, peer_id: ID, key: Any, val: Any) -> None:
+    def put(self, peer_id: ID, key: str, val: Any) -> None:
         """
         :param peer_id: peer ID to lookup key for
         :param key: key to associate with peer

--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -58,13 +58,13 @@ class PeerStore(IPeerStore):
     def peer_ids(self) -> List[ID]:
         return list(self.peer_map.keys())
 
-    def get(self, peer_id: ID, key: Any) -> Any:
+    def get(self, peer_id: ID, key: str) -> Any:
         if peer_id in self.peer_map:
             val = self.peer_map[peer_id].get_metadata(key)
             return val
         raise PeerStoreError("peer ID not found")
 
-    def put(self, peer_id: ID, key: Any, val: Any) -> None:
+    def put(self, peer_id: ID, key: str, val: Any) -> None:
         # <<?>>
         # This can output an error, not sure what the possible errors are
         peer = self.__create_or_get_peer(peer_id)

--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -1,3 +1,14 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+)
+
+from multiaddr import Multiaddr
+
+from .id import ID
 from .peerstore_interface import IPeerStore
 from .peerdata import PeerData
 from .peerinfo import PeerInfo
@@ -5,11 +16,13 @@ from .peerinfo import PeerInfo
 
 class PeerStore(IPeerStore):
 
-    def __init__(self):
+    peer_map: Dict[ID, PeerData]
+
+    def __init__(self) -> None:
         IPeerStore.__init__(self)
         self.peer_map = {}
 
-    def __create_or_get_peer(self, peer_id):
+    def __create_or_get_peer(self, peer_id: ID) -> PeerData:
         """
         Returns the peer data for peer_id or creates a new
         peer data (and stores it in peer_map) if peer
@@ -23,65 +36,65 @@ class PeerStore(IPeerStore):
         self.peer_map[peer_id] = data
         return self.peer_map[peer_id]
 
-    def peer_info(self, peer_id):
+    def peer_info(self, peer_id: ID) -> Optional[PeerInfo]:
         if peer_id in self.peer_map:
-            peer = self.peer_map[peer_id]
-            return PeerInfo(peer_id, peer)
+            peer_data = self.peer_map[peer_id]
+            return PeerInfo(peer_id, peer_data)
         return None
 
-    def get_protocols(self, peer_id):
+    def get_protocols(self, peer_id: ID) -> List[str]:
         if peer_id in self.peer_map:
             return self.peer_map[peer_id].get_protocols()
         raise PeerStoreError("peer ID not found")
 
-    def add_protocols(self, peer_id, protocols):
+    def add_protocols(self, peer_id: ID, protocols: Sequence[str]) -> None:
         peer = self.__create_or_get_peer(peer_id)
-        peer.add_protocols(protocols)
+        peer.add_protocols(list(protocols))
 
-    def set_protocols(self, peer_id, protocols):
+    def set_protocols(self, peer_id: ID, protocols: Sequence[str]) -> None:
         peer = self.__create_or_get_peer(peer_id)
-        peer.set_protocols(protocols)
+        peer.set_protocols(list(protocols))
 
-    def peers(self):
+    def peer_ids(self) -> List[ID]:
         return list(self.peer_map.keys())
 
-    def get(self, peer_id, key):
+    def get(self, peer_id: ID, key: Any) -> Any:
         if peer_id in self.peer_map:
             val = self.peer_map[peer_id].get_metadata(key)
             return val
         raise PeerStoreError("peer ID not found")
 
-    def put(self, peer_id, key, val):
+    def put(self, peer_id: ID, key: Any, val: Any) -> None:
         # <<?>>
         # This can output an error, not sure what the possible errors are
         peer = self.__create_or_get_peer(peer_id)
         peer.put_metadata(key, val)
 
-    def add_addr(self, peer_id, addr, ttl):
+    def add_addr(self, peer_id: ID, addr: Multiaddr, ttl: int) -> None:
         self.add_addrs(peer_id, [addr], ttl)
 
-    def add_addrs(self, peer_id, addrs, ttl):
+    def add_addrs(self, peer_id: ID, addrs: Sequence[Multiaddr], ttl: int) -> None:
         # Ignore ttl for now
         peer = self.__create_or_get_peer(peer_id)
-        peer.add_addrs(addrs)
+        peer.add_addrs(list(addrs))
 
-    def addrs(self, peer_id):
+    def addrs(self, peer_id: ID) -> List[Multiaddr]:
         if peer_id in self.peer_map:
             return self.peer_map[peer_id].get_addrs()
         raise PeerStoreError("peer ID not found")
 
-    def clear_addrs(self, peer_id):
+    def clear_addrs(self, peer_id: ID) -> None:
         # Only clear addresses if the peer is in peer map
         if peer_id in self.peer_map:
             self.peer_map[peer_id].clear_addrs()
 
-    def peers_with_addrs(self):
+    def peers_with_addrs(self) -> List[ID]:
         # Add all peers with addrs at least 1 to output
-        output = []
+        output: List[ID] = []
 
-        for key in self.peer_map:
-            if len(self.peer_map[key].get_addrs()) >= 1:
-                output.append(key)
+        for peer_id in self.peer_map:
+            if len(self.peer_map[peer_id].get_addrs()) >= 1:
+                output.append(peer_id)
         return output
 
 

--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -9,9 +9,9 @@ from typing import (
 from multiaddr import Multiaddr
 
 from .id import ID
-from .peerstore_interface import IPeerStore
 from .peerdata import PeerData
 from .peerinfo import PeerInfo
+from .peerstore_interface import IPeerStore
 
 
 class PeerStore(IPeerStore):

--- a/libp2p/peer/peerstore_interface.py
+++ b/libp2p/peer/peerstore_interface.py
@@ -5,9 +5,9 @@ from typing import (
 )
 
 
+from .addrbook_interface import IAddrBook
 from .id import ID
 from .peerinfo import PeerInfo
-from .addrbook_interface import IAddrBook
 from .peermetadata_interface import IPeerMetadata
 
 

--- a/libp2p/peer/peerstore_interface.py
+++ b/libp2p/peer/peerstore_interface.py
@@ -1,24 +1,31 @@
 from abc import abstractmethod
+from typing import (
+    List,
+    Sequence,
+)
 
+
+from .id import ID
+from .peerinfo import PeerInfo
 from .addrbook_interface import IAddrBook
 from .peermetadata_interface import IPeerMetadata
 
 
 class IPeerStore(IAddrBook, IPeerMetadata):
 
-    def __init__(self):
+    def __init__(self) -> None:
         IPeerMetadata.__init__(self)
         IAddrBook.__init__(self)
 
     @abstractmethod
-    def peer_info(self, peer_id):
+    def peer_info(self, peer_id: ID) -> PeerInfo:
         """
         :param peer_id: peer ID to get info for
         :return: peer info object
         """
 
     @abstractmethod
-    def get_protocols(self, peer_id):
+    def get_protocols(self, peer_id: ID) -> List[str]:
         """
         :param peer_id: peer ID to get protocols for
         :return: protocols (as strings)
@@ -26,7 +33,7 @@ class IPeerStore(IAddrBook, IPeerMetadata):
         """
 
     @abstractmethod
-    def add_protocols(self, peer_id, protocols):
+    def add_protocols(self, peer_id: ID, protocols: Sequence[str]) -> None:
         """
         :param peer_id: peer ID to add protocols for
         :param protocols: protocols to add
@@ -34,7 +41,7 @@ class IPeerStore(IAddrBook, IPeerMetadata):
         """
 
     @abstractmethod
-    def set_protocols(self, peer_id, protocols):
+    def set_protocols(self, peer_id: ID, protocols: Sequence[str]) -> None:
         """
         :param peer_id: peer ID to set protocols for
         :param protocols: protocols to set
@@ -42,7 +49,7 @@ class IPeerStore(IAddrBook, IPeerMetadata):
         """
 
     @abstractmethod
-    def peers(self):
+    def peer_ids(self) -> List[ID]:
         """
         :return: all of the peer IDs stored in peer store
         """

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -1,5 +1,7 @@
 from typing import (
     Iterable,
+    List,
+    Sequence,
 )
 
 from libp2p.peer.id import (
@@ -8,23 +10,31 @@ from libp2p.peer.id import (
 )
 
 from .pb import rpc_pb2
+from .pubsub import Pubsub
 from .pubsub_router_interface import IPubsubRouter
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
+)
 
 
 class FloodSub(IPubsubRouter):
     # pylint: disable=no-member
 
-    def __init__(self, protocols):
+    protocols: List[str]
+
+    pubsub: Pubsub
+
+    def __init__(self, protocols: Sequence[str]) -> None:
         self.protocols = protocols
         self.pubsub = None
 
-    def get_protocols(self):
+    def get_protocols(self) -> List[str]:
         """
         :return: the list of protocols supported by the router
         """
         return self.protocols
 
-    def attach(self, pubsub):
+    def attach(self, pubsub: Pubsub) -> None:
         """
         Attach is invoked by the PubSub constructor to attach the router to a
         freshly initialized PubSub instance.
@@ -32,19 +42,19 @@ class FloodSub(IPubsubRouter):
         """
         self.pubsub = pubsub
 
-    def add_peer(self, peer_id, protocol_id):
+    def add_peer(self, peer_id: ID, protocol_id: str):
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add
         """
 
-    def remove_peer(self, peer_id):
+    def remove_peer(self, peer_id: ID):
         """
         Notifies the router that a peer has been disconnected
         :param peer_id: id of peer to remove
         """
 
-    async def handle_rpc(self, rpc, sender_peer_id):
+    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID):
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
@@ -80,7 +90,7 @@ class FloodSub(IPubsubRouter):
             #   Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/master/comm.go#L107
             await stream.write(rpc_msg.SerializeToString())
 
-    async def join(self, topic):
+    async def join(self, topic: str):
         """
         Join notifies the router that we want to receive and
         forward messages in a topic. It is invoked after the
@@ -88,7 +98,7 @@ class FloodSub(IPubsubRouter):
         :param topic: topic to join
         """
 
-    async def leave(self, topic):
+    async def leave(self, topic: str):
         """
         Leave notifies the router that we are no longer interested in a topic.
         It is invoked after the unsubscription announcement.

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -42,8 +42,7 @@ class FloodSub(IPubsubRouter):
         """
         self.pubsub = pubsub
 
-    # FIXME: Should be changed to type 'peer.ID'
-    def add_peer(self, peer_id: str, protocol_id: str) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -51,8 +51,7 @@ class FloodSub(IPubsubRouter):
         :param peer_id: id of peer to remove
         """
 
-    # FIXME: Should be changed to type 'peer.ID'
-    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: str) -> None:
+    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID) -> None:
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -25,7 +25,7 @@ class FloodSub(IPubsubRouter):
     pubsub: Pubsub
 
     def __init__(self, protocols: Sequence[str]) -> None:
-        self.protocols = protocols
+        self.protocols = list(protocols)
         self.pubsub = None
 
     def get_protocols(self) -> List[str]:
@@ -42,19 +42,21 @@ class FloodSub(IPubsubRouter):
         """
         self.pubsub = pubsub
 
-    def add_peer(self, peer_id: ID, protocol_id: str):
+    # FIXME: Should be changed to type 'peer.ID'
+    def add_peer(self, peer_id: str, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add
         """
 
-    def remove_peer(self, peer_id: ID):
+    def remove_peer(self, peer_id: ID) -> None:
         """
         Notifies the router that a peer has been disconnected
         :param peer_id: id of peer to remove
         """
 
-    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID):
+    # FIXME: Should be changed to type 'peer.ID'
+    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: str) -> None:
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
@@ -90,7 +92,7 @@ class FloodSub(IPubsubRouter):
             #   Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/master/comm.go#L107
             await stream.write(rpc_msg.SerializeToString())
 
-    async def join(self, topic: str):
+    async def join(self, topic: str) -> None:
         """
         Join notifies the router that we want to receive and
         forward messages in a topic. It is invoked after the
@@ -98,7 +100,7 @@ class FloodSub(IPubsubRouter):
         :param topic: topic to join
         """
 
-    async def leave(self, topic: str):
+    async def leave(self, topic: str) -> None:
         """
         Leave notifies the router that we are no longer interested in a topic.
         It is invoked after the unsubscription announcement.

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -12,9 +12,6 @@ from libp2p.peer.id import (
 from .pb import rpc_pb2
 from .pubsub import Pubsub
 from .pubsub_router_interface import IPubsubRouter
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
 
 
 class FloodSub(IPubsubRouter):

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -60,9 +60,9 @@ class GossipSub(IPubsubRouter):
                  degree_low: int,
                  degree_high: int,
                  time_to_live: int,
-                 gossip_window: int=3,
-                 gossip_history: int=5,
-                 heartbeat_interval: int=120) -> None:
+                 gossip_window: int = 3,
+                 gossip_history: int = 5,
+                 heartbeat_interval: int = 120) -> None:
         # pylint: disable=too-many-arguments
         self.protocols = list(protocols)
         self.pubsub = None
@@ -78,6 +78,9 @@ class GossipSub(IPubsubRouter):
         # Create topic --> list of peers mappings
         self.mesh = {}
         self.fanout = {}
+
+        # Create peer --> protocol mapping
+        self.peers_to_protocol = {}
 
         # Create topic --> time since last publish map
         self.time_since_last_publish = {}
@@ -449,7 +452,9 @@ class GossipSub(IPubsubRouter):
         self.mcache.shift()
 
     @staticmethod
-    def select_from_minus(num_to_select: int, pool: Sequence[Any], minus: Sequence[Any]) -> List[Any]:
+    def select_from_minus(num_to_select: int,
+                          pool: Sequence[Any],
+                          minus: Sequence[Any]) -> List[Any]:
         """
         Select at most num_to_select subset of elements from the set (pool - minus) randomly.
         :param num_to_select: number of elements to randomly select
@@ -510,7 +515,7 @@ class GossipSub(IPubsubRouter):
         # Add all unknown message ids (ids that appear in ihave_msg but not in seen_seqnos) to list
         # of messages we want to request
         # FIXME: Update type of message ID
-        msg_ids_wanted = [
+        msg_ids_wanted: List[Any] = [
             msg_id
             for msg_id in ihave_msg.messageIDs
             if literal_eval(msg_id) not in seen_seqnos_and_peers

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 import asyncio
 import random
 from typing import (
@@ -8,8 +9,6 @@ from typing import (
     MutableSet,
     Sequence,
 )
-
-from ast import literal_eval
 
 from libp2p.peer.id import (
     ID,

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -533,6 +533,7 @@ class GossipSub(IPubsubRouter):
         from_id_str = sender_peer_id
 
         # FIXME: Update type of message ID
+        # FIXME: Find a better way to parse the msg ids
         msg_ids: List[Any] = [literal_eval(msg) for msg in iwant_msg.messageIDs]
         msgs_to_forward: List[rpc_pb2.Message] = []
         for msg_id_iwant in msg_ids:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -109,8 +109,7 @@ class GossipSub(IPubsubRouter):
         # TODO: Start after delay
         asyncio.ensure_future(self.heartbeat())
 
-    # FIXME: Shoudl be changed to type 'peer.ID'
-    def add_peer(self, peer_id: str, protocol_id: str) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add

--- a/libp2p/pubsub/mcache.py
+++ b/libp2p/pubsub/mcache.py
@@ -1,11 +1,25 @@
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from .pb import rpc_pb2
+
+
 class MessageCache:
 
     class CacheEntry:
         # pylint: disable=too-few-public-methods
+
+        mid: Tuple[bytes, bytes]
+        topics: List[str]
+
         """
         A logical representation of an entry in the mcache's _history_.
         """
-        def __init__(self, mid, topics):
+        def __init__(self, mid: Tuple[bytes, bytes], topics: List[str]) -> None:
             """
             Constructor.
             :param mid: (seqno, from_id) of the msg
@@ -14,7 +28,14 @@ class MessageCache:
             self.mid = mid
             self.topics = topics
 
-    def __init__(self, window_size, history_size):
+    window_size: int
+    history_size: int
+
+    msgs: Dict[Tuple[bytes, bytes], rpc_pb2.Message]
+
+    history = List[List[CacheEntry]]
+
+    def __init__(self, window_size: int, history_size: int) -> None:
         """
         Constructor.
         :param window_size: Size of the window desired.
@@ -34,12 +55,12 @@ class MessageCache:
         for _ in range(history_size):
             self.history.append([])
 
-    def put(self, msg):
+    def put(self, msg: rpc_pb2.Message) -> None:
         """
         Put a message into the mcache.
         :param msg: The rpc message to put in. Should contain seqno and from_id
         """
-        mid = (msg.seqno, msg.from_id)
+        mid: Tuple[bytes, bytes] = (msg.seqno, msg.from_id)
         self.msgs[mid] = msg
 
         if not self.history[0]:
@@ -47,7 +68,7 @@ class MessageCache:
 
         self.history[0].append(self.CacheEntry(mid, msg.topicIDs))
 
-    def get(self, mid):
+    def get(self, mid: Tuple[bytes, bytes]) -> Optional[rpc_pb2.Message]:
         """
         Get a message from the mcache.
         :param mid: (seqno, from_id) of the message to get.
@@ -58,13 +79,13 @@ class MessageCache:
 
         return None
 
-    def window(self, topic):
+    def window(self, topic: str) -> List[Tuple[bytes, bytes]]:
         """
         Get the window for this topic.
         :param topic: Topic whose message ids we desire.
         :return: List of mids in the current window.
         """
-        mids = []
+        mids: List[Tuple[bytes, bytes]] = []
 
         for entries_list in self.history[: self.window_size]:
             for entry in entries_list:
@@ -74,16 +95,16 @@ class MessageCache:
 
         return mids
 
-    def shift(self):
+    def shift(self) -> None:
         """
         Shift the window over by 1 position, dropping the last element of the history.
         """
-        last_entries = self.history[len(self.history) - 1]
+        last_entries: List[CacheEntry] = self.history[len(self.history) - 1]
 
         for entry in last_entries:
             del self.msgs[entry.mid]
 
-        i = len(self.history) - 2
+        i: int = len(self.history) - 2
 
         while i >= 0:
             self.history[i + 1] = self.history[i]

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -5,12 +5,17 @@ from typing import (
     Any,
     Dict,
     List,
-    Sequence,
     Tuple,
 )
 
 from lru import LRU
 
+
+from .pb import rpc_pb2
+from .pubsub_notifee import PubsubNotifee
+from .pubsub_router_interface import (
+    IPubsubRouter,
+)
 from libp2p.host.host_interface import (
     IHost,
 )
@@ -19,12 +24,6 @@ from libp2p.peer.id import (
 )
 from libp2p.network.stream.net_stream_interface import (
     INetStream,
-)
-
-from .pb import rpc_pb2
-from .pubsub_notifee import PubsubNotifee
-from .pubsub_router_interface import (
-    IPubsubRouter,
 )
 
 
@@ -38,26 +37,32 @@ class Pubsub:
 
     host: IHost
     my_id: ID
+
     router: IPubsubRouter
-    peer_queue: asyncio.Queue
-    protocols: Sequence[str]
-    incoming_msgs_from_peers: asyncio.Queue()
-    outgoing_messages: asyncio.Queue()
+
+    # FIXME: Should be changed to `asyncio.Queue[ID]`
+    peer_queue: asyncio.Queue[str]
+
+    protocols: List[str]
+
+    incoming_msgs_from_peers: asyncio.Queue[rpc_pb2.Message]
+    outgoing_messages: asyncio.Queue[rpc_pb2.Message]
+
     seen_messages: LRU
     my_topics: Dict[str, asyncio.Queue]
     # FIXME: Should be changed to `Dict[str, List[ID]]`
     peer_topics: Dict[str, List[str]]
     # FIXME: Should be changed to `Dict[ID, INetStream]`
     peers: Dict[str, INetStream]
+
     # NOTE: Be sure it is increased atomically everytime.
     counter: int  # uint64
 
-    def __init__(
-            self,
-            host: IHost,
-            router: IPubsubRouter,
-            my_id: ID,
-            cache_size: int = None) -> None:
+    def __init__(self,
+                 host: IHost,
+                 router: IPubsubRouter,
+                 my_id: ID,
+                 cache_size: int = None) -> None:
         """
         Construct a new Pubsub object, which is responsible for handling all
         Pubsub-related messages and relaying messages as appropriate to the
@@ -73,6 +78,7 @@ class Pubsub:
         self.router.attach(self)
 
         # Register a notifee
+        # FIXME: Should be changed to `asyncio.Queue[ID]`
         self.peer_queue = asyncio.Queue()
         self.host.get_network().notify(PubsubNotifee(self.peer_queue))
 
@@ -99,9 +105,11 @@ class Pubsub:
         self.my_topics = {}
 
         # Map of topic to peers to keep track of what peers are subscribed to
+        # FIXME: Should be changed to `Dict[str, ID]`
         self.peer_topics = {}
 
         # Create peers map, which maps peer_id (as string) to stream (to a given peer)
+        # FIXME: Should be changed to `Dict[ID, INetStream]`
         self.peers = {}
 
         self.counter = time.time_ns()
@@ -114,7 +122,7 @@ class Pubsub:
         Generate subscription message with all topics we are subscribed to
         only send hello packet if we have subscribed topics
         """
-        packet = rpc_pb2.RPC()
+        packet: rpc_pb2.RPC = rpc_pb2.RPC()
         if self.my_topics:
             for topic_id in self.my_topics:
                 packet.subscriptions.extend([rpc_pb2.RPC.SubOpts(
@@ -131,8 +139,8 @@ class Pubsub:
         peer_id = stream.mplex_conn.peer_id
 
         while True:
-            incoming = (await stream.read())
-            rpc_incoming = rpc_pb2.RPC()
+            incoming: bytes = (await stream.read())
+            rpc_incoming: rpc_pb2.RPC = rpc_pb2.RPC()
             rpc_incoming.ParseFromString(incoming)
 
             if rpc_incoming.publish:
@@ -168,12 +176,12 @@ class Pubsub:
         """
         # Add peer
         # Map peer to stream
-        peer_id = stream.mplex_conn.peer_id
+        peer_id: ID = stream.mplex_conn.peer_id
         self.peers[str(peer_id)] = stream
         self.router.add_peer(peer_id, stream.get_protocol())
 
         # Send hello packet
-        hello = self.get_hello_packet()
+        hello: bytes = self.get_hello_packet()
 
         await stream.write(hello)
         # Pass stream off to stream reader
@@ -188,12 +196,12 @@ class Pubsub:
         """
         while True:
 
-            peer_id = await self.peer_queue.get()
+            peer_id: ID = await self.peer_queue.get()
 
             # Open a stream to peer on existing connection
             # (we know connection exists since that's the only way
             # an element gets added to peer_queue)
-            stream = await self.host.new_stream(peer_id, self.protocols)
+            stream: INetStream = await self.host.new_stream(peer_id, self.protocols)
 
             # Add Peer
             # Map peer to stream
@@ -201,7 +209,7 @@ class Pubsub:
             self.router.add_peer(peer_id, stream.get_protocol())
 
             # Send hello packet
-            hello = self.get_hello_packet()
+            hello: bytes = self.get_hello_packet()
             await stream.write(hello)
 
             # Pass stream off to stream reader
@@ -210,8 +218,9 @@ class Pubsub:
             # Force context switch
             await asyncio.sleep(0)
 
+    # FIXME: type of `origin_id` should be changed to `ID`
     # FIXME: `sub_message` can be further type hinted with mypy_protobuf
-    def handle_subscription(self, origin_id: ID, sub_message: Any) -> None:
+    def handle_subscription(self, origin_id: str, sub_message: Any) -> None:
         """
         Handle an incoming subscription message from a peer. Update internal
         mapping to mark the peer as subscribed or unsubscribed to topics as
@@ -236,7 +245,7 @@ class Pubsub:
     async def handle_talk(self, publish_message: Any) -> None:
         """
         Put incoming message from a peer onto my blocking queue
-        :param talk: RPC.Message format
+        :param publish_message: RPC.Message format
         """
 
         # Check if this message has any topics that we are subscribed to
@@ -247,7 +256,7 @@ class Pubsub:
                 # for each topic
                 await self.my_topics[topic].put(publish_message)
 
-    async def subscribe(self, topic_id: str) -> asyncio.Queue:
+    async def subscribe(self, topic_id: str) -> asyncio.Queue[rpc_pb2.Message]:
         """
         Subscribe ourself to a topic
         :param topic_id: topic_id to subscribe to
@@ -261,7 +270,7 @@ class Pubsub:
         self.my_topics[topic_id] = asyncio.Queue()
 
         # Create subscribe message
-        packet = rpc_pb2.RPC()
+        packet: rpc_pb2.RPC = rpc_pb2.RPC()
         packet.subscriptions.extend([rpc_pb2.RPC.SubOpts(
             subscribe=True,
             topicid=topic_id.encode('utf-8')
@@ -289,7 +298,7 @@ class Pubsub:
         del self.my_topics[topic_id]
 
         # Create unsubscribe message
-        packet = rpc_pb2.RPC()
+        packet: rpc_pb2.RPC = rpc_pb2.RPC()
         packet.subscriptions.extend([rpc_pb2.RPC.SubOpts(
             subscribe=False,
             topicid=topic_id.encode('utf-8')
@@ -301,8 +310,8 @@ class Pubsub:
         # Tell router we are leaving this topic
         await self.router.leave(topic_id)
 
-    # FIXME: `rpc_msg` can be further type hinted with mypy_protobuf
-    async def message_all_peers(self, rpc_msg: Any) -> None:
+    # FIXME: `raw_msg` can be further type hinted with mypy_protobuf
+    async def message_all_peers(self, raw_msg: Any) -> None:
         """
         Broadcast a message to peers
         :param raw_msg: raw contents of the message to broadcast
@@ -311,7 +320,7 @@ class Pubsub:
         # Broadcast message
         for _, stream in self.peers.items():
             # Write message to stream
-            await stream.write(rpc_msg)
+            await stream.write(raw_msg)
 
     async def publish(self, topic_id: str, data: bytes) -> None:
         """

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -306,8 +306,7 @@ class Pubsub:
         # Tell router we are leaving this topic
         await self.router.leave(topic_id)
 
-    # FIXME: `raw_msg` can be further type hinted with mypy_protobuf
-    async def message_all_peers(self, raw_msg: Any) -> None:
+    async def message_all_peers(self, raw_msg: bytes) -> None:
         """
         Broadcast a message to peers
         :param raw_msg: raw contents of the message to broadcast

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -36,16 +36,16 @@ class Pubsub:
 
     router: 'IPubsubRouter'
 
-    peer_queue: asyncio.Queue[ID]
+    peer_queue: 'asyncio.Queue[ID]'
 
     protocols: List[str]
 
-    incoming_msgs_from_peers: asyncio.Queue[rpc_pb2.Message]
-    outgoing_messages: asyncio.Queue[rpc_pb2.Message]
+    incoming_msgs_from_peers: 'asyncio.Queue[rpc_pb2.Message]'
+    outgoing_messages: 'asyncio.Queue[rpc_pb2.Message]'
 
     seen_messages: LRU
 
-    my_topics: Dict[str, asyncio.Queue[rpc_pb2.Message]]
+    my_topics: Dict[str, 'asyncio.Queue[rpc_pb2.Message]']
 
     # FIXME: Should be changed to `Dict[str, List[ID]]`
     peer_topics: Dict[str, List[str]]
@@ -251,7 +251,7 @@ class Pubsub:
                 # for each topic
                 await self.my_topics[topic].put(publish_message)
 
-    async def subscribe(self, topic_id: str) -> asyncio.Queue[rpc_pb2.Message]:
+    async def subscribe(self, topic_id: str) -> 'asyncio.Queue[rpc_pb2.Message]':
         """
         Subscribe ourself to a topic
         :param topic_id: topic_id to subscribe to

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -10,21 +10,14 @@ from typing import (
 
 from lru import LRU
 
+from libp2p.host.host_interface import IHost
+from libp2p.peer.id import ID
+
+from libp2p.network.stream.net_stream_interface import INetStream
 
 from .pb import rpc_pb2
 from .pubsub_notifee import PubsubNotifee
-from .pubsub_router_interface import (
-    IPubsubRouter,
-)
-from libp2p.host.host_interface import (
-    IHost,
-)
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
+from .pubsub_router_interface import IPubsubRouter
 
 
 def get_msg_id(msg: rpc_pb2.Message) -> Tuple[bytes, bytes]:

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -373,6 +373,6 @@ class Pubsub:
         self.seen_messages[msg_id] = 1
 
     def _is_subscribed_to_msg(self, msg: rpc_pb2.Message) -> bool:
-        if not bool(self.my_topics):
+        if not self.my_topics:
             return False
         return all([topic in self.my_topics for topic in msg.topicIDs])

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -6,6 +6,7 @@ from typing import (
     Dict,
     List,
     Tuple,
+    TYPE_CHECKING,
 )
 
 from lru import LRU
@@ -17,7 +18,9 @@ from libp2p.network.stream.net_stream_interface import INetStream
 
 from .pb import rpc_pb2
 from .pubsub_notifee import PubsubNotifee
-from .pubsub_router_interface import IPubsubRouter
+
+if TYPE_CHECKING:
+    from .pubsub_router_interface import IPubsubRouter
 
 
 def get_msg_id(msg: rpc_pb2.Message) -> Tuple[bytes, bytes]:
@@ -31,17 +34,19 @@ class Pubsub:
     host: IHost
     my_id: ID
 
-    router: IPubsubRouter
+    router: 'IPubsubRouter'
 
-    peer_queue: asyncio.Queue[ID]
+    peer_queue: asyncio.Queue
 
     protocols: List[str]
 
-    incoming_msgs_from_peers: asyncio.Queue[rpc_pb2.Message]
-    outgoing_messages: asyncio.Queue[rpc_pb2.Message]
+    incoming_msgs_from_peers: asyncio.Queue
+    outgoing_messages: asyncio.Queue
 
     seen_messages: LRU
+
     my_topics: Dict[str, asyncio.Queue]
+
     # FIXME: Should be changed to `Dict[str, List[ID]]`
     peer_topics: Dict[str, List[str]]
     # FIXME: Should be changed to `Dict[ID, INetStream]`
@@ -52,7 +57,7 @@ class Pubsub:
 
     def __init__(self,
                  host: IHost,
-                 router: IPubsubRouter,
+                 router: 'IPubsubRouter',
                  my_id: ID,
                  cache_size: int = None) -> None:
         """
@@ -247,7 +252,7 @@ class Pubsub:
                 # for each topic
                 await self.my_topics[topic].put(publish_message)
 
-    async def subscribe(self, topic_id: str) -> asyncio.Queue[rpc_pb2.Message]:
+    async def subscribe(self, topic_id: str) -> asyncio.Queue:
         """
         Subscribe ourself to a topic
         :param topic_id: topic_id to subscribe to

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -22,8 +22,8 @@ from libp2p.host.host_interface import (
 from libp2p.peer.id import (
     ID,
 )
-from libp2p.network.stream.net_stream import (
-    NetStream,
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
 )
 
 
@@ -40,8 +40,7 @@ class Pubsub:
 
     router: IPubsubRouter
 
-    # FIXME: Should be changed to `asyncio.Queue[ID]`
-    peer_queue: asyncio.Queue[str]
+    peer_queue: asyncio.Queue[ID]
 
     protocols: List[str]
 
@@ -78,7 +77,6 @@ class Pubsub:
         self.router.attach(self)
 
         # Register a notifee
-        # FIXME: Should be changed to `asyncio.Queue[ID]`
         self.peer_queue = asyncio.Queue()
         self.host.get_network().notify(PubsubNotifee(self.peer_queue))
 
@@ -109,7 +107,7 @@ class Pubsub:
         self.peer_topics = {}
 
         # Create peers map, which maps peer_id (as string) to stream (to a given peer)
-        # FIXME: Should be changed to `Dict[ID, NetStream]`
+        # FIXME: Should be changed to `Dict[ID, INetStream]`
         self.peers = {}
 
         self.counter = time.time_ns()
@@ -130,7 +128,7 @@ class Pubsub:
 
         return packet.SerializeToString()
 
-    async def continuously_read_stream(self, stream: NetStream) -> None:
+    async def continuously_read_stream(self, stream: INetStream) -> None:
         """
         Read from input stream in an infinite loop. Process
         messages from other nodes
@@ -168,7 +166,7 @@ class Pubsub:
             # Force context switch
             await asyncio.sleep(0)
 
-    async def stream_handler(self, stream: NetStream) -> None:
+    async def stream_handler(self, stream: INetStream) -> None:
         """
         Stream handler for pubsub. Gets invoked whenever a new stream is created
         on one of the supported pubsub protocols.
@@ -196,13 +194,12 @@ class Pubsub:
         """
         while True:
 
-            # FIXME: Should be changed to type 'ID'
-            peer_id: str = await self.peer_queue.get()
+            peer_id: ID = await self.peer_queue.get()
 
             # Open a stream to peer on existing connection
             # (we know connection exists since that's the only way
             # an element gets added to peer_queue)
-            stream: NetStream = await self.host.new_stream(peer_id, self.protocols)
+            stream: INetStream = await self.host.new_stream(peer_id, self.protocols)
 
             # Add Peer
             # Map peer to stream

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -22,8 +22,8 @@ from libp2p.host.host_interface import (
 from libp2p.peer.id import (
     ID,
 )
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
+from libp2p.network.stream.net_stream import (
+    NetStream,
 )
 
 
@@ -109,7 +109,7 @@ class Pubsub:
         self.peer_topics = {}
 
         # Create peers map, which maps peer_id (as string) to stream (to a given peer)
-        # FIXME: Should be changed to `Dict[ID, INetStream]`
+        # FIXME: Should be changed to `Dict[ID, NetStream]`
         self.peers = {}
 
         self.counter = time.time_ns()
@@ -130,7 +130,7 @@ class Pubsub:
 
         return packet.SerializeToString()
 
-    async def continuously_read_stream(self, stream: INetStream) -> None:
+    async def continuously_read_stream(self, stream: NetStream) -> None:
         """
         Read from input stream in an infinite loop. Process
         messages from other nodes
@@ -168,7 +168,7 @@ class Pubsub:
             # Force context switch
             await asyncio.sleep(0)
 
-    async def stream_handler(self, stream: INetStream) -> None:
+    async def stream_handler(self, stream: NetStream) -> None:
         """
         Stream handler for pubsub. Gets invoked whenever a new stream is created
         on one of the supported pubsub protocols.
@@ -196,12 +196,13 @@ class Pubsub:
         """
         while True:
 
-            peer_id: ID = await self.peer_queue.get()
+            # FIXME: Should be changed to type 'ID'
+            peer_id: str = await self.peer_queue.get()
 
             # Open a stream to peer on existing connection
             # (we know connection exists since that's the only way
             # an element gets added to peer_queue)
-            stream: INetStream = await self.host.new_stream(peer_id, self.protocols)
+            stream: NetStream = await self.host.new_stream(peer_id, self.protocols)
 
             # Add Peer
             # Map peer to stream

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -4,17 +4,18 @@ from multiaddr import Multiaddr
 
 from libp2p.network.network_interface import INetwork
 from libp2p.network.notifee_interface import INotifee
+from libp2p.peer.id import ID
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 from libp2p.network.stream.net_stream_interface import INetStream
 
 
 class PubsubNotifee(INotifee):
-    # pylint: disable=too-many-instance-attributes, cell-var-from-loop
+    # pylint: disable=too-many-instance-attributes, cell-var-from-loop, unsubscriptable-object
 
-    initiator_peers_queue: asyncio.Queue
+    initiator_peers_queue: asyncio.Queue[ID]
 
-    def __init__(self, initiator_peers_queue: asyncio.Queue) -> None:
+    def __init__(self, initiator_peers_queue: asyncio.Queue[ID]) -> None:
         """
         :param initiator_peers_queue: queue to add new peers to so that pubsub
         can process new peers after we connect to them

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -1,23 +1,45 @@
-from libp2p.network.notifee_interface import INotifee
+from typing import (
+    List,
+    Sequence,
+)
 
+from multiaddr import Multiaddr
+
+from libp2p.network.connection.raw_connection import (
+    RawConnection,
+)
+from libp2p.network.notifee_interface import (
+    INotifee,
+)
+from libp2p.network.network_interface import (
+    INetwork,
+)
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
+)
+from libp2p.peer.id import (
+    ID,
+)
 
 class PubsubNotifee(INotifee):
     # pylint: disable=too-many-instance-attributes, cell-var-from-loop
 
-    def __init__(self, initiator_peers_queue):
+    initiator_peers_queue: List[ID]
+
+    def __init__(self, initiator_peers_queue: Sequence[ID]) -> None:
         """
         :param initiator_peers_queue: queue to add new peers to so that pubsub
         can process new peers after we connect to them
         """
-        self.initiator_peers_queue = initiator_peers_queue
+        self.initiator_peers_queue = List(initiator_peers_queue)
 
-    async def opened_stream(self, network, stream):
+    async def opened_stream(self, network: INetwork, stream: INetStream) -> None:
         pass
 
-    async def closed_stream(self, network, stream):
+    async def closed_stream(self, network: INetwork, stream: INetStream) -> None:
         pass
 
-    async def connected(self, network, conn):
+    async def connected(self, network: INetwork, conn: RawConnection) -> None:
         """
         Add peer_id to initiator_peers_queue, so that this peer_id can be used to
         create a stream and we only want to have one pubsub stream with each peer.
@@ -30,11 +52,11 @@ class PubsubNotifee(INotifee):
         if conn.initiator:
             await self.initiator_peers_queue.put(conn.peer_id)
 
-    async def disconnected(self, network, conn):
+    async def disconnected(self, network: INetwork, conn: RawConnection) -> None:
         pass
 
-    async def listen(self, network, multiaddr):
+    async def listen(self, network: INetwork, multiaddr: Multiaddr) -> None:
         pass
 
-    async def listen_close(self, network, multiaddr):
+    async def listen_close(self, network: INetwork, multiaddr: Multiaddr) -> None:
         pass

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -1,21 +1,26 @@
-import asyncio
+from typing import (
+    TYPE_CHECKING,
+)
 
 from multiaddr import Multiaddr
 
 from libp2p.network.network_interface import INetwork
 from libp2p.network.notifee_interface import INotifee
-from libp2p.peer.id import ID
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 from libp2p.network.stream.net_stream_interface import INetStream
+
+if TYPE_CHECKING:
+    import asyncio
+    from libp2p.peer.id import ID
 
 
 class PubsubNotifee(INotifee):
     # pylint: disable=too-many-instance-attributes, cell-var-from-loop, unsubscriptable-object
 
-    initiator_peers_queue: asyncio.Queue[ID]
+    initiator_peers_queue: 'asyncio.Queue[ID]'
 
-    def __init__(self, initiator_peers_queue: asyncio.Queue[ID]) -> None:
+    def __init__(self, initiator_peers_queue: 'asyncio.Queue[ID]') -> None:
         """
         :param initiator_peers_queue: queue to add new peers to so that pubsub
         can process new peers after we connect to them

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -1,11 +1,7 @@
 import asyncio
-from typing import (
-    Sequence,
-)
 
 from multiaddr import Multiaddr
 
-from libp2p.peer.id import ID
 from libp2p.network.network_interface import INetwork
 from libp2p.network.notifee_interface import INotifee
 from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
@@ -16,9 +12,9 @@ from libp2p.network.stream.net_stream_interface import INetStream
 class PubsubNotifee(INotifee):
     # pylint: disable=too-many-instance-attributes, cell-var-from-loop
 
-    initiator_peers_queue: asyncio.Queue[ID]
+    initiator_peers_queue: asyncio.Queue
 
-    def __init__(self, initiator_peers_queue: asyncio.Queue[ID]) -> None:
+    def __init__(self, initiator_peers_queue: asyncio.Queue) -> None:
         """
         :param initiator_peers_queue: queue to add new peers to so that pubsub
         can process new peers after we connect to them

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -5,21 +5,12 @@ from typing import (
 
 from multiaddr import Multiaddr
 
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.stream_muxer.muxed_connection_interface import (
-    IMuxedConn,
-)
-from libp2p.network.notifee_interface import (
-    INotifee,
-)
-from libp2p.network.network_interface import (
-    INetwork,
-)
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
+from libp2p.peer.id import ID
+from libp2p.network.network_interface import INetwork
+from libp2p.network.notifee_interface import INotifee
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
+
+from libp2p.network.stream.net_stream_interface import INetStream
 
 
 class PubsubNotifee(INotifee):

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -5,8 +5,11 @@ from typing import (
 
 from multiaddr import Multiaddr
 
-from libp2p.stream_muxer.mplex.mplex import (
-    Mplex,
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.stream_muxer.muxed_connection_interface import (
+    IMuxedConn,
 )
 from libp2p.network.notifee_interface import (
     INotifee,
@@ -22,10 +25,9 @@ from libp2p.network.stream.net_stream_interface import (
 class PubsubNotifee(INotifee):
     # pylint: disable=too-many-instance-attributes, cell-var-from-loop
 
-    # FIXME: Should be changed to type 'peer.ID'
-    initiator_peers_queue: asyncio.Queue[str]
+    initiator_peers_queue: asyncio.Queue[ID]
 
-    def __init__(self, initiator_peers_queue: asyncio.Queue[str]) -> None:
+    def __init__(self, initiator_peers_queue: asyncio.Queue[ID]) -> None:
         """
         :param initiator_peers_queue: queue to add new peers to so that pubsub
         can process new peers after we connect to them
@@ -38,7 +40,7 @@ class PubsubNotifee(INotifee):
     async def closed_stream(self, network: INetwork, stream: INetStream) -> None:
         pass
 
-    async def connected(self, network: INetwork, conn: Mplex) -> None:
+    async def connected(self, network: INetwork, conn: IMuxedConn) -> None:
         """
         Add peer_id to initiator_peers_queue, so that this peer_id can be used to
         create a stream and we only want to have one pubsub stream with each peer.
@@ -51,7 +53,7 @@ class PubsubNotifee(INotifee):
         if conn.initiator:
             await self.initiator_peers_queue.put(conn.peer_id)
 
-    async def disconnected(self, network: INetwork, conn: Mplex) -> None:
+    async def disconnected(self, network: INetwork, conn: IMuxedConn) -> None:
         pass
 
     async def listen(self, network: INetwork, multiaddr: Multiaddr) -> None:

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -25,9 +25,8 @@ class IPubsubRouter(ABC):
         :param pubsub: pubsub instance to attach to
         """
 
-    # FIXME: Should be changed to type 'peer.ID'
     @abstractmethod
-    def add_peer(self, peer_id: str, protocol_id: str) -> None:
+    def add_peer(self, peer_id: ID, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -3,11 +3,10 @@ from typing import (
     List,
 )
 
+from libp2p.peer.id import ID
+
 from .pb import rpc_pb2
 from .pubsub import Pubsub
-from libp2p.peer.id import (
-    ID,
-)
 
 class IPubsubRouter(ABC):
 

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -41,9 +41,8 @@ class IPubsubRouter(ABC):
         :param peer_id: id of peer to remove
         """
 
-    # FIXME: Should be changed to type 'peer.ID'
     @abstractmethod
-    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: str) -> None:
+    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID) -> None:
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -1,15 +1,24 @@
 from abc import ABC, abstractmethod
+from typing import (
+    List,
+)
+
+from .pb import rpc_pb2
+from .pubsub import Pubsub
+from libp2p.peer.id import (
+    ID,
+)
 
 class IPubsubRouter(ABC):
 
     @abstractmethod
-    def get_protocols(self):
+    def get_protocols(self) -> List[str]:
         """
         :return: the list of protocols supported by the router
         """
 
     @abstractmethod
-    def attach(self, pubsub):
+    def attach(self, pubsub: Pubsub) -> None:
         """
         Attach is invoked by the PubSub constructor to attach the router to a
         freshly initialized PubSub instance.
@@ -17,21 +26,21 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def add_peer(self, peer_id, protocol_id):
+    def add_peer(self, peer_id: ID, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add
         """
 
     @abstractmethod
-    def remove_peer(self, peer_id):
+    def remove_peer(self, peer_id: ID) -> None:
         """
         Notifies the router that a peer has been disconnected
         :param peer_id: id of peer to remove
         """
 
     @abstractmethod
-    def handle_rpc(self, rpc, sender_peer_id):
+    def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID) -> None:
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
@@ -42,7 +51,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    async def publish(self, msg_forwarder, pubsub_msg):
+    async def publish(self, msg_forwarder: ID, pubsub_msg: rpc_pb2.Message):
         """
         Invoked to forward a new message that has been validated
         :param msg_forwarder: peer_id of message sender
@@ -50,7 +59,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def join(self, topic):
+    def join(self, topic: str) -> None:
         """
         Join notifies the router that we want to receive and
         forward messages in a topic. It is invoked after the
@@ -59,7 +68,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def leave(self, topic):
+    def leave(self, topic: str) -> None:
         """
         Leave notifies the router that we are no longer interested in a topic.
         It is invoked after the unsubscription announcement.

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -25,8 +25,9 @@ class IPubsubRouter(ABC):
         :param pubsub: pubsub instance to attach to
         """
 
+    # FIXME: Should be changed to type 'peer.ID'
     @abstractmethod
-    def add_peer(self, peer_id: ID, protocol_id: str) -> None:
+    def add_peer(self, peer_id: str, protocol_id: str) -> None:
         """
         Notifies the router that a new peer has been connected
         :param peer_id: id of peer to add
@@ -39,8 +40,9 @@ class IPubsubRouter(ABC):
         :param peer_id: id of peer to remove
         """
 
+    # FIXME: Should be changed to type 'peer.ID'
     @abstractmethod
-    def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: ID) -> None:
+    async def handle_rpc(self, rpc: rpc_pb2.ControlMessage, sender_peer_id: str) -> None:
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
@@ -50,8 +52,9 @@ class IPubsubRouter(ABC):
         :param rpc: rpc message
         """
 
+    # FIXME: Should be changed to type 'peer.ID'
     @abstractmethod
-    async def publish(self, msg_forwarder: ID, pubsub_msg: rpc_pb2.Message):
+    async def publish(self, msg_forwarder: ID, pubsub_msg: rpc_pb2.Message) -> None:
         """
         Invoked to forward a new message that has been validated
         :param msg_forwarder: peer_id of message sender
@@ -59,7 +62,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def join(self, topic: str) -> None:
+    async def join(self, topic: str) -> None:
         """
         Join notifies the router that we want to receive and
         forward messages in a topic. It is invoked after the
@@ -68,7 +71,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def leave(self, topic: str) -> None:
+    async def leave(self, topic: str) -> None:
         """
         Leave notifies the router that we are no longer interested in a topic.
         It is invoked after the unsubscription announcement.

--- a/libp2p/pubsub/pubsub_router_interface.py
+++ b/libp2p/pubsub/pubsub_router_interface.py
@@ -1,12 +1,15 @@
 from abc import ABC, abstractmethod
 from typing import (
     List,
+    TYPE_CHECKING,
 )
 
 from libp2p.peer.id import ID
 
 from .pb import rpc_pb2
-from .pubsub import Pubsub
+
+if TYPE_CHECKING:
+    from .pubsub import Pubsub
 
 class IPubsubRouter(ABC):
 
@@ -17,7 +20,7 @@ class IPubsubRouter(ABC):
         """
 
     @abstractmethod
-    def attach(self, pubsub: Pubsub) -> None:
+    def attach(self, pubsub: 'Pubsub') -> None:
         """
         Attach is invoked by the PubSub constructor to attach the router to a
         freshly initialized PubSub instance.

--- a/libp2p/routing/interfaces.py
+++ b/libp2p/routing/interfaces.py
@@ -1,8 +1,8 @@
-from abc import ABC, abstractmethod
-from typing import (
-    Any,
-    Iterable,
+from abc import (
+    ABC,
+    abstractmethod,
 )
+from typing import Iterable
 
 from libp2p.peer.id import ID
 from libp2p.peer.peerinfo import PeerInfo

--- a/libp2p/routing/interfaces.py
+++ b/libp2p/routing/interfaces.py
@@ -1,11 +1,23 @@
 from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Coroutine,
+    Iterable,
+)
+
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
 # pylint: disable=too-few-public-methods
 
 
 class IContentRouting(ABC):
 
     @abstractmethod
-    def provide(self, cid, announce=True):
+    def provide(self, cid: bytes, announce: bool=True) -> None:
         """
         Provide adds the given cid to the content routing system. If announce is True,
         it also announces it, otherwise it is just kept in the local
@@ -13,7 +25,7 @@ class IContentRouting(ABC):
         """
 
     @abstractmethod
-    def find_provider_iter(self, cid, count):
+    def find_provider_iter(self, cid: bytes, count: int) -> Iterable[PeerInfo]:
         """
         Search for peers who are able to provide a given key
         returns an iterator of peer.PeerInfo
@@ -23,7 +35,7 @@ class IContentRouting(ABC):
 class IPeerRouting(ABC):
 
     @abstractmethod
-    def find_peer(self, peer_id):
+    def find_peer(self, peer_id: ID) -> Coroutine[Any, Any, PeerInfo]:
         """
         Find specific Peer
         FindPeer searches for a peer with given peer_id, returns a peer.PeerInfo

--- a/libp2p/routing/interfaces.py
+++ b/libp2p/routing/interfaces.py
@@ -13,7 +13,7 @@ from libp2p.peer.peerinfo import PeerInfo
 class IContentRouting(ABC):
 
     @abstractmethod
-    def provide(self, cid: bytes, announce: bool=True) -> None:
+    def provide(self, cid: bytes, announce: bool = True) -> None:
         """
         Provide adds the given cid to the content routing system. If announce is True,
         it also announces it, otherwise it is just kept in the local

--- a/libp2p/routing/interfaces.py
+++ b/libp2p/routing/interfaces.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import (
     Any,
-    Coroutine,
     Iterable,
 )
 
@@ -31,7 +30,7 @@ class IContentRouting(ABC):
 class IPeerRouting(ABC):
 
     @abstractmethod
-    def find_peer(self, peer_id: ID) -> Coroutine[Any, Any, PeerInfo]:
+    async def find_peer(self, peer_id: ID) -> PeerInfo:
         """
         Find specific Peer
         FindPeer searches for a peer with given peer_id, returns a peer.PeerInfo

--- a/libp2p/routing/interfaces.py
+++ b/libp2p/routing/interfaces.py
@@ -5,12 +5,8 @@ from typing import (
     Iterable,
 )
 
-from libp2p.peer.id import (
-    ID,
-)
-from libp2p.peer.peerinfo import (
-    PeerInfo,
-)
+from libp2p.peer.id import ID
+from libp2p.peer.peerinfo import PeerInfo
 # pylint: disable=too-few-public-methods
 
 

--- a/libp2p/routing/kademlia/kademlia_content_router.py
+++ b/libp2p/routing/kademlia/kademlia_content_router.py
@@ -8,7 +8,7 @@ from libp2p.routing.interfaces import IContentRouting
 
 class KadmeliaContentRouter(IContentRouting):
 
-    def provide(self, cid: bytes, announce: bool=True) -> None:
+    def provide(self, cid: bytes, announce: bool = True) -> None:
         """
         Provide adds the given cid to the content routing system. If announce is True,
         it also announces it, otherwise it is just kept in the local

--- a/libp2p/routing/kademlia/kademlia_content_router.py
+++ b/libp2p/routing/kademlia/kademlia_content_router.py
@@ -1,9 +1,14 @@
+from typing import (
+    Iterable,
+)
+
+from libp2p.peer.peerinfo import PeerInfo
 from libp2p.routing.interfaces import IContentRouting
 
 
 class KadmeliaContentRouter(IContentRouting):
 
-    def provide(self, cid, announce=True):
+    def provide(self, cid: bytes, announce: bool=True) -> None:
         """
         Provide adds the given cid to the content routing system. If announce is True,
         it also announces it, otherwise it is just kept in the local
@@ -12,7 +17,7 @@ class KadmeliaContentRouter(IContentRouting):
         # the DHT finds the closest peers to `key` using the `FIND_NODE` RPC
         # then sends a `ADD_PROVIDER` RPC with its own `PeerInfo` to each of these peers.
 
-    def find_provider_iter(self, cid, count):
+    def find_provider_iter(self, cid: bytes, count: int) -> Iterable[PeerInfo]:
         """
         Search for peers who are able to provide a given key
         returns an iterator of peer.PeerInfo

--- a/libp2p/routing/kademlia/kademlia_peer_router.py
+++ b/libp2p/routing/kademlia/kademlia_peer_router.py
@@ -9,7 +9,6 @@ from libp2p.kademlia.kad_peerinfo import (
 )
 from libp2p.kademlia.network import KademliaServer
 from libp2p.peer.id import ID
-from libp2p.peer.peerinfo import PeerInfo
 from libp2p.routing.interfaces import IPeerRouting
 
 

--- a/libp2p/routing/kademlia/kademlia_peer_router.py
+++ b/libp2p/routing/kademlia/kademlia_peer_router.py
@@ -1,16 +1,26 @@
 import ast
+from typing import (
+    Union,
+)
 
+from libp2p.kademlia.kad_peerinfo import (
+    KadPeerInfo,
+    create_kad_peerinfo,
+)
+from libp2p.kademlia.network import KademliaServer
+from libp2p.peer.id import ID
 from libp2p.routing.interfaces import IPeerRouting
-from libp2p.kademlia.kad_peerinfo import create_kad_peerinfo
 
 
 class KadmeliaPeerRouter(IPeerRouting):
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, dht_server):
+    server: KademliaServer
+
+    def __init__(self, dht_server: KademliaServer) -> None:
         self.server = dht_server
 
-    async def find_peer(self, peer_id):
+    async def find_peer(self, peer_id: ID) -> KadPeerInfo:
         """
         Find a specific peer
         :param peer_id: peer to search for
@@ -21,7 +31,7 @@ class KadmeliaPeerRouter(IPeerRouting):
         value = await self.server.get(xor_id)
         return decode_peerinfo(value)
 
-def decode_peerinfo(encoded):
+def decode_peerinfo(encoded: Union[bytes, str]) -> KadPeerInfo:
     if isinstance(encoded, bytes):
         encoded = encoded.decode()
     try:

--- a/libp2p/routing/kademlia/kademlia_peer_router.py
+++ b/libp2p/routing/kademlia/kademlia_peer_router.py
@@ -9,6 +9,7 @@ from libp2p.kademlia.kad_peerinfo import (
 )
 from libp2p.kademlia.network import KademliaServer
 from libp2p.peer.id import ID
+from libp2p.peer.peerinfo import PeerInfo
 from libp2p.routing.interfaces import IPeerRouting
 
 

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -1,7 +1,8 @@
 import asyncio
 
+from libp2p.stream_muxer.muxed_stream_interface import IMuxedStream
+
 from .utils import get_flag
-from ..muxed_stream_interface import IMuxedStream
 
 
 class MplexStream(IMuxedStream):

--- a/libp2p/stream_muxer/muxed_connection_interface.py
+++ b/libp2p/stream_muxer/muxed_connection_interface.py
@@ -1,10 +1,15 @@
 from abc import ABC, abstractmethod
 
+from libp2p.peer.id import ID
+
 
 class IMuxedConn(ABC):
     """
     reference: https://github.com/libp2p/go-stream-muxer/blob/master/muxer.go
     """
+
+    initiator: bool
+    peer_id: ID
 
     @abstractmethod
     def __init__(self, conn, generic_protocol_handler, peer_id):

--- a/libp2p/stream_muxer/muxed_stream_interface.py
+++ b/libp2p/stream_muxer/muxed_stream_interface.py
@@ -2,17 +2,13 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from typing import (
-    TYPE_CHECKING,
-)
 
-if TYPE_CHECKING:
-    from libp2p.stream_muxer.mplex.mplex import Mplex
+from libp2p.stream_muxer.muxed_connection_interface import IMuxedConn
 
 
 class IMuxedStream(ABC):
 
-    mplex_conn: 'Mplex'
+    mplex_conn: IMuxedConn
 
     @abstractmethod
     def read(self):

--- a/libp2p/stream_muxer/muxed_stream_interface.py
+++ b/libp2p/stream_muxer/muxed_stream_interface.py
@@ -1,11 +1,18 @@
-from abc import ABC, abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    TYPE_CHECKING,
+)
 
-from libp2p.stream_muxer.mplex.mplex import Mplex
+if TYPE_CHECKING:
+    from libp2p.stream_muxer.mplex.mplex import Mplex
 
 
 class IMuxedStream(ABC):
 
-    mplex_conn: Mplex
+    mplex_conn: 'Mplex'
 
     @abstractmethod
     def read(self):

--- a/libp2p/stream_muxer/muxed_stream_interface.py
+++ b/libp2p/stream_muxer/muxed_stream_interface.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
 
+from libp2p.stream_muxer.mplex.mplex import Mplex
+
 
 class IMuxedStream(ABC):
+
+    mplex_conn: Mplex
 
     @abstractmethod
     def read(self):

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -316,20 +316,20 @@ async def test_host_connect():
     transport_opt_list = [["/ip4/127.0.0.1/tcp/0"], ["/ip4/127.0.0.1/tcp/0"]]
     (node_a, node_b) = await set_up_nodes_by_transport_opt(transport_opt_list)
 
-    assert not node_a.get_peerstore().peers()
+    assert not node_a.get_peerstore().peer_ids()
 
     addr = node_b.get_addrs()[0]
     info = info_from_p2p_addr(addr)
     await node_a.connect(info)
 
-    assert len(node_a.get_peerstore().peers()) == 1
+    assert len(node_a.get_peerstore().peer_ids()) == 1
 
     await node_a.connect(info)
 
     # make sure we don't do double connection
-    assert len(node_a.get_peerstore().peers()) == 1
+    assert len(node_a.get_peerstore().peer_ids()) == 1
 
-    assert node_b.get_id() in node_a.get_peerstore().peers()
+    assert node_b.get_id() in node_a.get_peerstore().peer_ids()
     ma_node_b = multiaddr.Multiaddr('/p2p/%s' % node_b.get_id().pretty())
     for addr in node_a.get_peerstore().addrs(node_b.get_id()):
         assert addr.encapsulate(ma_node_b) in node_b.get_addrs()

--- a/tests/peer/test_peerstore.py
+++ b/tests/peer/test_peerstore.py
@@ -55,4 +55,4 @@ def test_peers():
     store.put("peer2", "key", "val")
     store.add_addr("peer3", "/foo", 10)
 
-    assert set(store.peers()) == set(["peer1", "peer2", "peer3"])
+    assert set(store.peer_ids()) == set(["peer1", "peer2", "peer3"])

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,6 @@ basepython =
 basepython = python3
 extras = dev
 commands =
+    # TODO: Add the tests/ folder back to pylint
     pylint --rcfile={toxinidir}/.pylintrc libp2p examples
     mypy -p libp2p -p examples --config-file {toxinidir}/mypy.ini

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,5 @@ basepython =
 basepython = python3
 extras = dev
 commands =
-    pylint --rcfile={toxinidir}/.pylintrc libp2p examples tests
+    pylint --rcfile={toxinidir}/.pylintrc libp2p examples
     mypy -p libp2p -p examples --config-file {toxinidir}/mypy.ini


### PR DESCRIPTION
Add type hints to `host`, `network`, `peer`, pubsub` and `routing` module.
Leave the type hints of protobuf messages to the next PR.