### PR TITLE
Skip protobuf files in linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
+FILES_TO_LINT = libp2p tests examples setup.py
+
+format:
+	black $(FILES_TO_LINT)
+	isort --recursive $(FILES_TO_LINT)
+
 lintroll:
 	# NOTE: disabling `mypy` until we get typing sorted in this repo
 	# mypy -p libp2p -p examples --config-file {toxinidir}/mypy.ini
-	black --check  examples libp2p/__init__.py libp2p/host libp2p/kademlia libp2p/network libp2p/peer libp2p/protocol_muxer libp2p/pubsub/*.py libp2p/routing libp2p/security libp2p/stream_muxer libp2p/transport tests setup.py
-	isort --recursive --check-only examples libp2p/__init__.py libp2p/host libp2p/kademlia libp2p/network libp2p/peer libp2p/protocol_muxer libp2p/pubsub/*.py libp2p/routing libp2p/security libp2p/stream_muxer libp2p/transport tests setup.py
+	# TODO: add flake8
+	black --check $(FILES_TO_LINT)
+	isort --recursive --check-only $(FILES_TO_LINT)
 
 protobufs:
 	cd libp2p/pubsub/pb && protoc --python_out=. rpc.proto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.black]
+line-length = 88
+target_version = ['py37']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | \w*_pb2\w*\.py  # pb2 files
+)
+'''

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [flake8]
 max-line-length= 100
-exclude=
+exclude=*_pb2*.py
 ignore=
 
 [isort]
@@ -18,6 +18,7 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+skip_glob=*_pb2*.py
 
 [testenv]
 deps =


### PR DESCRIPTION
Exclude protobuf files in `isort`, `black`, and `flake8`, as the discussion in https://github.com/libp2p/py-libp2p/pull/206#issuecomment-517897526.