### PR TITLE
Add flake8 and change flake8 configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-ignore = E203, E266, E501, W503
-max-line-length = 80
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ format:
 lintroll:
 	# NOTE: disabling `mypy` until we get typing sorted in this repo
 	# mypy -p libp2p -p examples --config-file {toxinidir}/mypy.ini
-	# TODO: add flake8
 	black --check $(FILES_TO_LINT)
 	isort --recursive --check-only $(FILES_TO_LINT)
 	flake8 $(FILES_TO_LINT)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ lintroll:
 	# TODO: add flake8
 	black --check $(FILES_TO_LINT)
 	isort --recursive --check-only $(FILES_TO_LINT)
+	flake8 $(FILES_TO_LINT)
 
 protobufs:
 	cd libp2p/pubsub/pb && protoc --python_out=. rpc.proto

--- a/libp2p/security/insecure_security.py
+++ b/libp2p/security/insecure_security.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, cast
 
 from libp2p.security.secure_conn_interface import ISecureConn
 from libp2p.security.secure_transport_interface import ISecureTransport
@@ -6,7 +6,6 @@ from libp2p.security.secure_transport_interface import ISecureTransport
 if TYPE_CHECKING:
     from libp2p.network.connection.raw_connection_interface import IRawConnection
     from libp2p.peer.id import ID
-    from .secure_conn_interface import ISecureConn
     from .typing import TSecurityDetails
 
 

--- a/libp2p/security/security_multistream.py
+++ b/libp2p/security/security_multistream.py
@@ -7,7 +7,6 @@ from libp2p.protocol_muxer.multiselect_client import MultiselectClient
 if TYPE_CHECKING:
     from libp2p.network.connection.raw_connection_interface import IRawConnection
     from libp2p.peer.id import ID
-    from .typing import TSecurityDetails
     from .secure_conn_interface import ISecureConn
     from .secure_transport_interface import ISecureTransport
 

--- a/libp2p/security/typing.py
+++ b/libp2p/security/typing.py
@@ -1,3 +1,3 @@
-from typing import Any, Dict, NewType, TypeVar
+from typing import Dict, NewType
 
 TSecurityDetails = NewType("TSecurityDetails", Dict[str, str])

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -3,7 +3,6 @@ import asyncio
 import multiaddr
 
 from libp2p.network.connection.raw_connection import RawConnection
-from libp2p.peer.id import ID
 
 from ..listener_interface import IListener
 from ..transport_interface import ITransport

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,12 @@ extras_require = {
         "pytest-cov>=2.7.1,<3.0.0",
         "pytest-asyncio>=0.10.0,<1.0.0",
     ],
-    "lint": ["mypy>=0.701,<1.0", "black==19.3b0", "isort==4.3.21"],
+    "lint": [
+        "mypy>=0.701,<1.0",
+        "black==19.3b0",
+        "isort==4.3.21",
+        "flake8>=3.7.7,<4.0.0",
+    ],
     "dev": ["tox>=3.13.2,<4.0.0"],
 }
 

--- a/tests/examples/test_chat.py
+++ b/tests/examples/test_chat.py
@@ -1,9 +1,7 @@
 import asyncio
 
-import multiaddr
 import pytest
 
-from libp2p import new_node
 from libp2p.peer.peerinfo import info_from_p2p_addr
 from libp2p.protocol_muxer.multiselect_client import MultiselectClientError
 from tests.utils import cleanup, set_up_nodes_by_transport_opt

--- a/tests/pubsub/factories.py
+++ b/tests/pubsub/factories.py
@@ -1,5 +1,3 @@
-import functools
-
 import factory
 
 from libp2p import initialize_default_swarm

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,11 @@ envlist =
     lint
 
 [flake8]
-max-line-length= 100
-exclude=*_pb2*.py
-ignore=
+max-line-length = 100
+exclude = *_pb2*.py
+ignore = E203, E266, E501, W503
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
 
 [isort]
 force_sort_within_sections=True


### PR DESCRIPTION
This merges the flake8 settings from #178 .

- Add `flake8` settings, to conform with `black`, thanks to the work from @abn .
- Move `flake8` settings from `.flake8` to `tox.ini`.
- Run `flake8` in `Makefile`.
- Fix `flake8` errors in the existing code.
