### PR TITLE
Update flake8 ignore rules

### DIFF
--- a/examples/chat/chat.py
+++ b/examples/chat/chat.py
@@ -53,9 +53,10 @@ async def run(port, destination, localhost):
         print(
             f"Run 'python ./examples/chat/chat.py"
             + localhost_opt
-            + f" -p {int(port) + 1} -d /ip4/{ip}/tcp/{port}/p2p/{host.get_id().pretty()}' on another console.\n"
+            + f" -p {int(port) + 1} -d /ip4/{ip}/tcp/{port}/p2p/{host.get_id().pretty()}'"
+            + " on another console."
         )
-        print("\nWaiting for incoming connection\n\n")
+        print("Waiting for incoming connection...")
 
     else:  # its the client
         maddr = multiaddr.Multiaddr(destination)

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -143,7 +143,7 @@ class Pubsub:
 
             # NOTE: Check if `rpc_incoming.control` is set through `HasField`.
             #   This is necessary because `control` is an optional field in pb2.
-            #   Ref: https://developers.google.com/protocol-buffers/docs/reference/python-generated#singular-fields-proto2
+            #   Ref: https://developers.google.com/protocol-buffers/docs/reference/python-generated#singular-fields-proto2  # noqa: E501
             if rpc_incoming.HasField("control"):
                 # Pass rpc to router so router could perform custom logic
                 await self.router.handle_rpc(rpc_incoming, peer_id)

--- a/tests/peer/test_peerinfo.py
+++ b/tests/peer/test_peerinfo.py
@@ -8,6 +8,7 @@ from libp2p.peer.peerdata import PeerData
 from libp2p.peer.peerinfo import InvalidAddrError, PeerInfo, info_from_p2p_addr
 
 ALPHABETS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+VALID_MULTI_ADDR_STR = "/ip4/127.0.0.1/tcp/8000/p2p/3YgLAeMKSAPcGqZkAt8mREqhQXmJT8SN8VCMN4T6ih4GNX9wvK8mWJnWZ1qA2mLdCQ"  # noqa: E501
 
 
 def test_init_():
@@ -47,9 +48,7 @@ def test_info_from_p2p_addr_invalid(addr):
 
 
 def test_info_from_p2p_addr_valid():
-    m_addr = multiaddr.Multiaddr(
-        "/ip4/127.0.0.1/tcp/8000/p2p/3YgLAeMKSAPcGqZkAt8mREqhQXmJT8SN8VCMN4T6ih4GNX9wvK8mWJnWZ1qA2mLdCQ"
-    )
+    m_addr = multiaddr.Multiaddr(VALID_MULTI_ADDR_STR)
     info = info_from_p2p_addr(m_addr)
     assert (
         info.peer_id.pretty()

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [flake8]
 max-line-length = 100
 exclude = *_pb2*.py
-ignore = E203, E266, E501, W503
+ignore = E203, W503
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
 


### PR DESCRIPTION
Removes some rules from the ignore list. We take the option to opt-out of the rule via the special case `# noqa: $RULE` comment syntax in the places where we want to obvious opt-out but otherwise have the rule in place.

The main example here is for line lengths, where we generally want to disallow lines over a certain length.