### PR TITLE
Remove code coverage check from CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# py-libp2p [![Build Status](https://travis-ci.com/libp2p/py-libp2p.svg?branch=master)](https://travis-ci.com/libp2p/py-libp2p) [![codecov](https://codecov.io/gh/libp2p/py-libp2p/branch/master/graph/badge.svg)](https://codecov.io/gh/libp2p/py-libp2p) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/py-libp2p/Lobby)[![Freenode](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+# py-libp2p [![Build Status](https://travis-ci.com/libp2p/py-libp2p.svg?branch=master)](https://travis-ci.com/libp2p/py-libp2p)  [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/py-libp2p/Lobby)[![Freenode](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,8 @@ classifiers = [f"Programming Language :: Python :: {version}" for version in ["3
 
 extras_require = {
     "test": [
-        "codecov>=2.0.15,<3.0.0",
         "factory-boy>=2.12.0,<3.0.0",
         "pytest>=4.6.3,<5.0.0",
-        "pytest-cov>=2.7.1,<3.0.0",
         "pytest-asyncio>=0.10.0,<1.0.0",
     ],
     "lint": [

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,7 @@ deps =
 passenv = CI TRAVIS TRAVIS_*
 extras = test
 commands =
-    pytest --cov=./libp2p tests/
-    codecov
+    pytest tests/
 basepython =
     py37: python3.7
 


### PR DESCRIPTION
Removes the check so that we don't fail CI while we are changing (potentially large) parts of this repo as we work towards interop.