### PR TITLE
Internalize the protobuf serialization to the concept of a `Key`

### DIFF
--- a/libp2p/crypto/keys.py
+++ b/libp2p/crypto/keys.py
@@ -32,11 +32,28 @@ class Key(ABC):
         """
         ...
 
+    def _serialize_to_protobuf(self) -> protobuf.PublicKey:
+        """
+        Return the protobuf representation of this ``Key``.
+        """
+        key_type = self.get_type().value
+        data = self.to_bytes()
+        protobuf_key = self.protobuf_constructor(key_type=key_type, data=data)
+        return protobuf_key
+
+    def serialize(self) -> bytes:
+        """
+        Return the canonical serialization of this ``Key``.
+        """
+        return self._serialize_to_protobuf().SerializeToString()
+
 
 class PublicKey(Key):
     """
     A ``PublicKey`` represents a cryptographic public key.
     """
+
+    protobuf_constructor = protobuf.PublicKey
 
     @abstractmethod
     def verify(self, data: bytes, signature: bytes) -> bool:
@@ -45,17 +62,13 @@ class PublicKey(Key):
         """
         ...
 
-    def serialize_to_protobuf(self) -> protobuf.PublicKey:
-        key_type = self.get_type().value
-        data = self.to_bytes()
-        protobuf_key = protobuf.PublicKey(key_type=key_type, data=data)
-        return protobuf_key
-
 
 class PrivateKey(Key):
     """
     A ``PrivateKey`` represents a cryptographic private key.
     """
+
+    protobuf_constructor = protobuf.PrivateKey
 
     @abstractmethod
     def sign(self, data: bytes) -> bytes:
@@ -64,12 +77,6 @@ class PrivateKey(Key):
     @abstractmethod
     def get_public_key(self) -> PublicKey:
         ...
-
-    def serialize_to_protobuf(self) -> protobuf.PrivateKey:
-        key_type = self.get_type().value
-        data = self.to_bytes()
-        protobuf_key = protobuf.PrivateKey(key_type=key_type, data=data)
-        return protobuf_key
 
 
 @dataclass(frozen=True)

--- a/libp2p/crypto/keys.py
+++ b/libp2p/crypto/keys.py
@@ -32,28 +32,11 @@ class Key(ABC):
         """
         ...
 
-    def _serialize_to_protobuf(self) -> protobuf.PublicKey:
-        """
-        Return the protobuf representation of this ``Key``.
-        """
-        key_type = self.get_type().value
-        data = self.to_bytes()
-        protobuf_key = self.protobuf_constructor(key_type=key_type, data=data)
-        return protobuf_key
-
-    def serialize(self) -> bytes:
-        """
-        Return the canonical serialization of this ``Key``.
-        """
-        return self._serialize_to_protobuf().SerializeToString()
-
 
 class PublicKey(Key):
     """
     A ``PublicKey`` represents a cryptographic public key.
     """
-
-    protobuf_constructor = protobuf.PublicKey
 
     @abstractmethod
     def verify(self, data: bytes, signature: bytes) -> bool:
@@ -61,6 +44,21 @@ class PublicKey(Key):
         Verify that ``signature`` is the cryptographic signature of the hash of ``data``.
         """
         ...
+
+    def _serialize_to_protobuf(self) -> protobuf.PublicKey:
+        """
+        Return the protobuf representation of this ``Key``.
+        """
+        key_type = self.get_type().value
+        data = self.to_bytes()
+        protobuf_key = protobuf.PublicKey(key_type=key_type, data=data)
+        return protobuf_key
+
+    def serialize(self) -> bytes:
+        """
+        Return the canonical serialization of this ``Key``.
+        """
+        return self._serialize_to_protobuf().SerializeToString()
 
 
 class PrivateKey(Key):
@@ -77,6 +75,21 @@ class PrivateKey(Key):
     @abstractmethod
     def get_public_key(self) -> PublicKey:
         ...
+
+    def _serialize_to_protobuf(self) -> protobuf.PrivateKey:
+        """
+        Return the protobuf representation of this ``Key``.
+        """
+        key_type = self.get_type().value
+        data = self.to_bytes()
+        protobuf_key = protobuf.PrivateKey(key_type=key_type, data=data)
+        return protobuf_key
+
+    def serialize(self) -> bytes:
+        """
+        Return the canonical serialization of this ``Key``.
+        """
+        return self._serialize_to_protobuf().SerializeToString()
 
 
 @dataclass(frozen=True)

--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -7,13 +7,6 @@ import multihash
 from libp2p.crypto.keys import PublicKey
 
 
-def _serialize_public_key(key: PublicKey) -> bytes:
-    """
-    Serializes ``key`` in the way expected to form valid peer ids.
-    """
-    return key.serialize_to_protobuf().SerializeToString()
-
-
 class ID:
     _bytes: bytes
     _xor_id: int = None
@@ -62,7 +55,7 @@ class ID:
 
     @classmethod
     def from_pubkey(cls, key: PublicKey) -> "ID":
-        serialized_key = _serialize_public_key(key)
+        serialized_key = key.serialize()
         algo = multihash.Func.sha2_256
         mh_digest = multihash.digest(serialized_key, algo)
         return cls(mh_digest.encode())

--- a/tests/peer/test_peerid.py
+++ b/tests/peer/test_peerid.py
@@ -92,7 +92,7 @@ def test_id_from_public_key():
     key_pair = create_new_key_pair()
     public_key = key_pair.public_key
 
-    key_bin = public_key.serialize_to_protobuf().SerializeToString()
+    key_bin = public_key.serialize()
     algo = multihash.Func.sha2_256
     mh_digest = multihash.digest(key_bin, algo)
     expected = ID(mh_digest.encode())


### PR DESCRIPTION
Given its use across various components of `libp2p` (not just peer IDs),
it makes the abstraction cleaner to pull the serialization into the
key class and expose the canonical serialization to bytes.