### PR TITLE
Encapsulate the concept of a stream to the stream multiplexer

### DIFF
--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -9,7 +9,6 @@ class RawConnection(IRawConnection):
     initiator: bool
 
     _drain_lock: asyncio.Lock
-    _next_id: int
 
     def __init__(
         self,
@@ -22,7 +21,6 @@ class RawConnection(IRawConnection):
         self.initiator = initiator
 
         self._drain_lock = asyncio.Lock()
-        self._next_id = 0 if initiator else 1
 
     async def write(self, data: bytes) -> None:
         self.writer.write(data)
@@ -41,12 +39,3 @@ class RawConnection(IRawConnection):
 
     def close(self) -> None:
         self.writer.close()
-
-    def next_stream_id(self) -> int:
-        """
-        Get next available stream id
-        :return: next available stream id for the connection
-        """
-        next_id = self._next_id
-        self._next_id += 2
-        return next_id

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -4,9 +4,6 @@ from .raw_connection_interface import IRawConnection
 
 
 class RawConnection(IRawConnection):
-
-    conn_ip: str
-    conn_port: str
     reader: asyncio.StreamReader
     writer: asyncio.StreamWriter
     initiator: bool
@@ -16,14 +13,10 @@ class RawConnection(IRawConnection):
 
     def __init__(
         self,
-        ip: str,
-        port: str,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
         initiator: bool,
     ) -> None:
-        self.conn_ip = ip
-        self.conn_port = port
         self.reader = reader
         self.writer = writer
         self.initiator = initiator

--- a/libp2p/network/connection/raw_connection_interface.py
+++ b/libp2p/network/connection/raw_connection_interface.py
@@ -19,7 +19,3 @@ class IRawConnection(ABC):
     @abstractmethod
     def close(self) -> None:
         pass
-
-    @abstractmethod
-    def next_stream_id(self) -> int:
-        pass

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -204,13 +204,7 @@ class Swarm(INetwork):
             ) -> None:
                 # Upgrade reader/write to a net_stream and pass \
                 # to appropriate stream handler (using multiaddr)
-                raw_conn = RawConnection(
-                    maddr.value_for_protocol("ip4"),
-                    maddr.value_for_protocol("tcp"),
-                    reader,
-                    writer,
-                    False,
-                )
+                raw_conn = RawConnection(reader, writer, False)
 
                 # Per, https://discuss.libp2p.io/t/multistream-security/130, we first secure
                 # the conn and then mux the conn

--- a/libp2p/security/base_session.py
+++ b/libp2p/security/base_session.py
@@ -30,10 +30,6 @@ class BaseSession(ISecureConn):
 
         self.initiator = self.conn.initiator
 
-    # TODO clean up how this is passed around?
-    def next_stream_id(self) -> int:
-        return self.conn.next_stream_id()
-
     async def write(self, data: bytes) -> None:
         await self.conn.write(data)
 

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -3,7 +3,6 @@ from typing import Dict, Optional, Tuple
 
 from multiaddr import Multiaddr
 
-from libp2p.network.connection.raw_connection_interface import IRawConnection
 from libp2p.network.typing import GenericProtocolHandlerFn
 from libp2p.peer.id import ID
 from libp2p.security.secure_conn_interface import ISecureConn
@@ -24,7 +23,6 @@ class Mplex(IMuxedConn):
     """
 
     secured_conn: ISecureConn
-    raw_conn: IRawConnection
     peer_id: ID
     # TODO: `dataIn` in go implementation. Should be size of 8.
     # TODO: Also, `dataIn` is closed indicating EOF in Go. We don't have similar strategies

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -70,12 +70,12 @@ class TCP(ITransport):
         :param self_id: peer_id of the dialer (to send to receiver)
         :return: `RawConnection` if successful
         """
-        host = maddr.value_for_protocol("ip4")
-        port = maddr.value_for_protocol("tcp")
+        self.host = maddr.value_for_protocol("ip4")
+        self.port = int(maddr.value_for_protocol("tcp"))
 
-        reader, writer = await asyncio.open_connection(host, int(port))
+        reader, writer = await asyncio.open_connection(self.host, self.port)
 
-        return RawConnection(host, port, reader, writer, True)
+        return RawConnection(reader, writer, True)
 
     def create_listener(self, handler_function: THandler) -> TCPListener:
         """


### PR DESCRIPTION
`RawConnection` provided a "stream id" used to track individual streams opened over a given connection by the stream multiplexer (e.g. `mplex`).

the particular stream multiplexer implementation should keep track of stream IDs and not burden the connection concept so we move that logic to the appropriate place