### PR TITLE
Fix: `MplexStream` is not parsed

### DIFF
--- a/libp2p/exceptions.py
+++ b/libp2p/exceptions.py
@@ -6,3 +6,7 @@ class ValidationError(BaseLibp2pError):
     """
     Raised when something does not pass a validation check.
     """
+
+
+class ParseError(BaseLibp2pError):
+    pass

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -156,15 +156,10 @@ class Swarm(INetwork):
         if not addrs:
             raise SwarmException("No known addresses to peer")
 
-        multiaddr = addrs[0]
-
         muxed_conn = await self.dial_peer(peer_id)
 
-        # Use muxed conn to open stream, which returns
-        # a muxed stream
-        # TODO: Remove protocol id from being passed into muxed_conn
-        # FIXME: Remove multiaddr from being passed into muxed_conn
-        muxed_stream = await muxed_conn.open_stream(protocol_ids[0], multiaddr)
+        # Use muxed conn to open stream, which returns a muxed stream
+        muxed_stream = await muxed_conn.open_stream()
 
         # Perform protocol muxing to determine protocol to use
         selected_protocol = await self.multiselect_client.select_one_of(

--- a/libp2p/stream_muxer/abc.py
+++ b/libp2p/stream_muxer/abc.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
-from multiaddr import Multiaddr
-
 from libp2p.peer.id import ID
 from libp2p.security.secure_conn_interface import ISecureConn
 from libp2p.stream_muxer.mplex.constants import HeaderTags
@@ -66,20 +64,15 @@ class IMuxedConn(ABC):
         Read a message from `stream_id`'s buffer, non-blockingly.
         """
 
-    # FIXME: Remove multiaddr from being passed into muxed_conn
     @abstractmethod
-    async def open_stream(
-        self, protocol_id: str, multi_addr: Multiaddr
-    ) -> "IMuxedStream":
+    async def open_stream(self) -> "IMuxedStream":
         """
         creates a new muxed_stream
-        :param protocol_id: protocol_id of stream
-        :param multi_addr: multi_addr that stream connects to
-        :return: a new stream
+        :return: a new ``IMuxedStream`` stream
         """
 
     @abstractmethod
-    async def accept_stream(self) -> None:
+    async def accept_stream(self, name: str) -> None:
         """
         accepts a muxed stream opened by the other end
         """

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -10,6 +10,7 @@ class MplexStream(IMuxedStream):
     reference: https://github.com/libp2p/go-mplex/blob/master/stream.go
     """
 
+    name: str
     stream_id: int
     initiator: bool
     mplex_conn: IMuxedConn
@@ -21,13 +22,16 @@ class MplexStream(IMuxedStream):
 
     _buf: bytearray
 
-    def __init__(self, stream_id: int, initiator: bool, mplex_conn: IMuxedConn) -> None:
+    def __init__(
+        self, name: str, stream_id: int, initiator: bool, mplex_conn: IMuxedConn
+    ) -> None:
         """
         create new MuxedStream in muxer
         :param stream_id: stream stream id
         :param initiator: boolean if this is an initiator
         :param mplex_conn: muxed connection of this muxed_stream
         """
+        self.name = name
         self.stream_id = stream_id
         self.initiator = initiator
         self.mplex_conn = mplex_conn


### PR DESCRIPTION
After this PR, we can communicate with Go with streams with no error. I tested the `chat.py` and [`go-libp2p-examples/chat`](https://github.com/libp2p/go-libp2p-examples/tree/master/chat) with Plaintext transport.

- Close https://github.com/libp2p/py-libp2p/pull/175. There is only `Identify` protocol left, which is not necessarily required.
    - Identify protocol: https://github.com/libp2p/py-libp2p/issues/236.
- Fix #259 .