### PR TITLE
Use a different ECC backend `fastecdsa` with a compatible serializer

### DIFF
--- a/libp2p/security/secio/transport.py
+++ b/libp2p/security/secio/transport.py
@@ -283,7 +283,7 @@ async def _establish_session_parameters(
 
     remote_ephemeral_public_key_bytes = remote_exchange.ephemeral_public_key
     remote_ephemeral_public_key = ECCPublicKey.from_bytes(
-        remote_ephemeral_public_key_bytes
+        remote_ephemeral_public_key_bytes, curve_param
     )
     remote_encryption_parameters.ephemeral_public_key = remote_ephemeral_public_key
     remote_selection = (

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         "lru-dict>=1.1.6",
         "protobuf==3.9.0",
         "coincurve>=10.0.0,<11.0.0",
+        "fastecdsa==1.7.4",
     ],
     extras_require=extras_require,
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),


### PR DESCRIPTION
This library has the ``SEC1`` encoder which is compatible
with the serialization of ECC keys/points used in the Go libp2p impl