### PR TITLE
Restore `initiator` flag to `BaseSession` type

### DIFF
--- a/libp2p/security/base_session.py
+++ b/libp2p/security/base_session.py
@@ -20,13 +20,14 @@ class BaseSession(ISecureConn):
         self,
         local_peer: ID,
         local_private_key: PrivateKey,
+        initiator: bool,
         peer_id: Optional[ID] = None,
     ) -> None:
         self.local_peer = local_peer
         self.local_private_key = local_private_key
         self.remote_peer_id = peer_id
         self.remote_permanent_pubkey = None
-        self.initiator = peer_id is not None
+        self.initiator = initiator
 
     def get_local_peer(self) -> ID:
         return self.local_peer

--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -27,9 +27,10 @@ class InsecureSession(BaseSession):
         local_peer: ID,
         local_private_key: PrivateKey,
         conn: ReadWriteCloser,
+        initiator: bool,
         peer_id: Optional[ID] = None,
     ) -> None:
-        super().__init__(local_peer, local_private_key, peer_id)
+        super().__init__(local_peer, local_private_key, initiator, peer_id)
         self.conn = conn
 
     async def write(self, data: bytes) -> int:
@@ -99,7 +100,7 @@ class InsecureTransport(BaseSecureTransport):
         for an inbound connection (i.e. we are not the initiator)
         :return: secure connection object (that implements secure_conn_interface)
         """
-        session = InsecureSession(self.local_peer, self.local_private_key, conn)
+        session = InsecureSession(self.local_peer, self.local_private_key, conn, False)
         await session.run_handshake()
         return session
 
@@ -110,7 +111,7 @@ class InsecureTransport(BaseSecureTransport):
         :return: secure connection object (that implements secure_conn_interface)
         """
         session = InsecureSession(
-            self.local_peer, self.local_private_key, conn, peer_id
+            self.local_peer, self.local_private_key, conn, True, peer_id
         )
         await session.run_handshake()
         return session


### PR DESCRIPTION
Incorrectly used the presence or absence of a remote peer ID to determine the `initiator`; before this PR, we have a remote peer ID in either case (when authenticating over `secio`). Now just ferry the information correctly to maintain the flag downstream of the security upgrade.