### PR TITLE
Fix `transport.dial` in swarm

### DIFF
--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -1,6 +1,6 @@
 import asyncio
-from typing import Callable, Dict, List, Sequence
 import logging
+from typing import Callable, Dict, List, Sequence
 
 from multiaddr import Multiaddr
 

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -119,7 +119,7 @@ class Swarm(INetwork):
             multiaddr = self.router.find_peer(peer_id)
         # Dial peer (connection to peer does not yet exist)
         # Transport dials peer (gets back a raw conn)
-        raw_conn = await self.transport.dial(multiaddr, self.self_id)
+        raw_conn = await self.transport.dial(multiaddr)
 
         logger.debug("dialed peer %s over base transport", peer_id)
 

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -6,7 +6,6 @@ from multiaddr import Multiaddr
 
 from libp2p.network.connection.raw_connection import RawConnection
 from libp2p.network.connection.raw_connection_interface import IRawConnection
-from libp2p.peer.id import ID
 from libp2p.transport.listener_interface import IListener
 from libp2p.transport.transport_interface import ITransport
 from libp2p.transport.typing import THandler

--- a/libp2p/transport/transport_interface.py
+++ b/libp2p/transport/transport_interface.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from multiaddr import Multiaddr
 
 from libp2p.network.connection.raw_connection_interface import IRawConnection
-from libp2p.peer.id import ID
 
 from .listener_interface import IListener
 from .typing import THandler
@@ -11,7 +10,7 @@ from .typing import THandler
 
 class ITransport(ABC):
     @abstractmethod
-    async def dial(self, maddr: Multiaddr, self_id: ID) -> IRawConnection:
+    async def dial(self, maddr: Multiaddr) -> IRawConnection:
         """
         dial a transport to peer listening on multiaddr
         :param multiaddr: multiaddr of peer


### PR DESCRIPTION
Currently, CI fails. This fix the error in https://travis-ci.com/libp2p/py-libp2p/jobs/233843093.