### PR TITLE
Add a little more loggings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pip-wheel-metadata
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -21,7 +21,7 @@ from .host_interface import IHost
 class BasicHost(IHost):
 
     _network: INetwork
-    router: KadmeliaPeerRouter
+    _router: KadmeliaPeerRouter
     peerstore: IPeerStore
 
     # default options constructor
@@ -56,7 +56,7 @@ class BasicHost(IHost):
 
     def get_addrs(self) -> List[multiaddr.Multiaddr]:
         """
-        :return: all the multiaddr addresses this host is listening too
+        :return: all the multiaddr addresses this host is listening to
         """
         p2p_part = multiaddr.Multiaddr("/p2p/{}".format(self.get_id().pretty()))
 
@@ -68,23 +68,22 @@ class BasicHost(IHost):
 
     def set_stream_handler(
         self, protocol_id: TProtocol, stream_handler: StreamHandlerFn
-    ) -> bool:
+    ) -> None:
         """
-        set stream handler for host
+        set stream handler for given `protocol_id`
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler function
-        :return: true if successful
         """
-        return self._network.set_stream_handler(protocol_id, stream_handler)
+        self._network.set_stream_handler(protocol_id, stream_handler)
 
-    # protocol_id can be a list of protocol_ids
-    # stream will decide which protocol_id to run on
+    # `protocol_ids` can be a list of `protocol_id`
+    # stream will decide which `protocol_id` to run on
     async def new_stream(
         self, peer_id: ID, protocol_ids: Sequence[TProtocol]
     ) -> INetStream:
         """
         :param peer_id: peer_id that host is connecting
-        :param protocol_id: protocol id that stream runs on
+        :param protocol_ids: available protocol ids to use for stream
         :return: stream: new stream created
         """
         return await self._network.new_stream(peer_id, protocol_ids)
@@ -92,12 +91,11 @@ class BasicHost(IHost):
     async def connect(self, peer_info: PeerInfo) -> None:
         """
         connect ensures there is a connection between this host and the peer with
-        given peer_info.peer_id. connect will absorb the addresses in peer_info into its internal
+        given `peer_info.peer_id`. connect will absorb the addresses in peer_info into its internal
         peerstore. If there is not an active connection, connect will issue a
-        dial, and block until a connection is open, or an error is
-        returned.
+        dial, and block until a connection is opened, or an error is returned.
 
-        :param peer_info: peer_info of the host we want to connect to
+        :param peer_info: peer_info of the peer we want to connect to
         :type peer_info: peer.peerinfo.PeerInfo
         """
         self.peerstore.add_addrs(peer_info.peer_id, peer_info.addrs, 10)

--- a/libp2p/host/host_interface.py
+++ b/libp2p/host/host_interface.py
@@ -33,18 +33,17 @@ class IHost(ABC):
     @abstractmethod
     def get_addrs(self) -> List[multiaddr.Multiaddr]:
         """
-        :return: all the multiaddr addresses this host is listening too
+        :return: all the multiaddr addresses this host is listening to
         """
 
     @abstractmethod
     def set_stream_handler(
         self, protocol_id: TProtocol, stream_handler: StreamHandlerFn
-    ) -> bool:
+    ) -> None:
         """
         set stream handler for host
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler function
-        :return: true if successful
         """
 
     # protocol_id can be a list of protocol_ids
@@ -55,7 +54,7 @@ class IHost(ABC):
     ) -> INetStream:
         """
         :param peer_id: peer_id that host is connecting
-        :param protocol_ids: protocol ids that stream can run on
+        :param protocol_ids: available protocol ids to use for stream
         :return: stream: new stream created
         """
 
@@ -65,10 +64,9 @@ class IHost(ABC):
         connect ensures there is a connection between this host and the peer with
         given peer_info.peer_id. connect will absorb the addresses in peer_info into its internal
         peerstore. If there is not an active connection, connect will issue a
-        dial, and block until a connection is open, or an error is
-        returned.
+        dial, and block until a connection is opened, or an error is returned.
 
-        :param peer_info: peer_info of the host we want to connect to
+        :param peer_info: peer_info of the peer we want to connect to
         :type peer_info: peer.peerinfo.PeerInfo
         """
 

--- a/libp2p/network/network_interface.py
+++ b/libp2p/network/network_interface.py
@@ -40,11 +40,10 @@ class INetwork(ABC):
     @abstractmethod
     def set_stream_handler(
         self, protocol_id: TProtocol, stream_handler: StreamHandlerFn
-    ) -> bool:
+    ) -> None:
         """
         :param protocol_id: protocol id used on stream
         :param stream_handler: a stream handler instance
-        :return: true if successful
         """
 
     @abstractmethod

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -34,7 +34,6 @@ class NetStream(INetStream):
     def set_protocol(self, protocol_id: TProtocol) -> None:
         """
         :param protocol_id: protocol id that stream runs on
-        :return: true if successful
         """
         self.protocol_id = protocol_id
 
@@ -64,7 +63,6 @@ class NetStream(INetStream):
     async def close(self) -> None:
         """
         close stream
-        :return: true if successful
         """
         await self.muxed_stream.close()
 

--- a/libp2p/network/stream/net_stream_interface.py
+++ b/libp2p/network/stream/net_stream_interface.py
@@ -16,10 +16,9 @@ class INetStream(ReadWriteCloser):
         """
 
     @abstractmethod
-    def set_protocol(self, protocol_id: TProtocol) -> bool:
+    def set_protocol(self, protocol_id: TProtocol) -> None:
         """
         :param protocol_id: protocol id that stream runs on
-        :return: true if successful
         """
 
     @abstractmethod

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -126,10 +126,10 @@ class Swarm(INetwork):
         try:
             secured_conn = await self.upgrader.upgrade_security(raw_conn, peer_id, True)
         except SecurityUpgradeFailure as error:
-            error_msg = "fail to upgrade security for peer %s" % peer_id
-            logger.debug(error_msg)
+            error_msg = "fail to upgrade security for peer %s"
+            logger.debug(error_msg, peer_id)
             await raw_conn.close()
-            raise SwarmException(error_msg) from error
+            raise SwarmException(error_msg % peer_id) from error
 
         logger.debug("upgraded security for peer %s", peer_id)
 
@@ -138,10 +138,10 @@ class Swarm(INetwork):
                 secured_conn, self.generic_protocol_handler, peer_id
             )
         except MuxerUpgradeFailure as error:
-            error_msg = "fail to upgrade mux for peer %s" % peer_id
-            logger.debug(error_msg)
+            error_msg = "fail to upgrade mux for peer %s"
+            logger.debug(error_msg, peer_id)
             await secured_conn.close()
-            raise SwarmException(error_msg) from error
+            raise SwarmException(error_msg % peer_id) from error
 
         logger.debug("upgraded mux for peer %s", peer_id)
 
@@ -232,10 +232,10 @@ class Swarm(INetwork):
                         raw_conn, ID(b""), False
                     )
                 except SecurityUpgradeFailure as error:
-                    error_msg = "fail to upgrade security for peer at %s" % peer_addr
-                    logger.debug(error_msg)
+                    error_msg = "fail to upgrade security for peer at %s"
+                    logger.debug(error_msg, peer_addr)
                     await raw_conn.close()
-                    raise SwarmException(error_msg) from error
+                    raise SwarmException(error_msg % peer_addr) from error
                 peer_id = secured_conn.get_remote_peer()
 
                 logger.debug("upgraded security for peer at %s", peer_addr)
@@ -246,10 +246,10 @@ class Swarm(INetwork):
                         secured_conn, self.generic_protocol_handler, peer_id
                     )
                 except MuxerUpgradeFailure as error:
-                    error_msg = "fail to upgrade mux for peer %s" % peer_id
-                    logger.debug(error_msg)
+                    error_msg = "fail to upgrade mux for peer %s"
+                    logger.debug(error_msg, peer_id)
                     await secured_conn.close()
-                    raise SwarmException(error_msg) from error
+                    raise SwarmException(error_msg % peer_id) from error
                 logger.debug("upgraded mux for peer %s", peer_id)
                 # Store muxed_conn with peer id
                 self.connections[peer_id] = muxed_conn

--- a/libp2p/protocol_muxer/multiselect_client.py
+++ b/libp2p/protocol_muxer/multiselect_client.py
@@ -38,24 +38,6 @@ class MultiselectClient(IMultiselectClient):
 
         # Handshake succeeded if this point is reached
 
-    async def select_protocol_or_fail(
-        self, protocol: TProtocol, communicator: IMultiselectCommunicator
-    ) -> TProtocol:
-        """
-        Send message to multiselect selecting protocol
-        and fail if multiselect does not return same protocol
-        :param protocol: protocol to select
-        :param stream: stream to communicate with multiselect over
-        :return: selected protocol
-        """
-        # Perform handshake to ensure multiselect protocol IDs match
-        await self.handshake(communicator)
-
-        # Try to select the given protocol
-        selected_protocol = await self.try_select(communicator, protocol)
-
-        return selected_protocol
-
     async def select_one_of(
         self, protocols: Sequence[TProtocol], communicator: IMultiselectCommunicator
     ) -> TProtocol:

--- a/libp2p/protocol_muxer/multiselect_client_interface.py
+++ b/libp2p/protocol_muxer/multiselect_client_interface.py
@@ -13,16 +13,12 @@ class IMultiselectClient(ABC):
     module in order to select a protocol id to communicate over
     """
 
-    @abstractmethod
-    async def select_protocol_or_fail(
-        self, protocol: TProtocol, communicator: IMultiselectCommunicator
-    ) -> TProtocol:
+    async def handshake(self, communicator: IMultiselectCommunicator) -> None:
         """
-        Send message to multiselect selecting protocol
-        and fail if multiselect does not return same protocol
-        :param protocol: protocol to select
+        Ensure that the client and multiselect
+        are both using the same multiselect protocol
         :param stream: stream to communicate with multiselect over
-        :return: selected protocol
+        :raise Exception: multiselect protocol ID mismatch
         """
 
     @abstractmethod
@@ -35,5 +31,16 @@ class IMultiselectClient(ABC):
         protocol that multiselect agrees on (i.e. that multiselect selects)
         :param protocol: protocol to select
         :param stream: stream to communicate with multiselect over
+        :return: selected protocol
+        """
+
+    async def try_select(
+        self, communicator: IMultiselectCommunicator, protocol: TProtocol
+    ) -> TProtocol:
+        """
+        Try to select the given protocol or raise exception if fails
+        :param communicator: communicator to use to communicate with counterparty
+        :param protocol: protocol to select
+        :raise Exception: error in protocol selection
         :return: selected protocol
         """

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, List, Sequence
 
 from libp2p.peer.id import ID
@@ -9,6 +10,9 @@ from .pubsub import Pubsub
 from .pubsub_router_interface import IPubsubRouter
 
 PROTOCOL_ID = TProtocol("/floodsub/1.0.0")
+
+logger = logging.getLogger("libp2p.pubsub.floodsub")
+logger.setLevel(logging.DEBUG)
 
 
 class FloodSub(IPubsubRouter):
@@ -75,6 +79,9 @@ class FloodSub(IPubsubRouter):
             origin=ID(pubsub_msg.from_id),
         )
         rpc_msg = rpc_pb2.RPC(publish=[pubsub_msg])
+
+        logger.debug("publishing message %s", pubsub_msg)
+
         for peer_id in peers_gen:
             stream = self.pubsub.peers[peer_id]
             # FIXME: We should add a `WriteMsg` similar to write delimited messages.


### PR DESCRIPTION
Was going to take #260 but while I was at it I'm not exactly sure which parts/modules to add loggings to. I was worried adding loggings to too many modules at once will be counterproductive for team at interop when debugging. So this turns into a small PR that adds logging to
- swarm
    - upgrade error in `dial_peer`
    - `new_stream`
    - upgrade error in `conn_handler`
    - `close`
    - `close_peer`
- pubsub
    - message read from stream in `continuously_read_stream`
    - new peer in `_handle_new_peer`
    - `subscribe`/`unsubscribe`
    - `publish`
    - validation error in `push_msg`
- gossipsub
    - `attach`
    - `add_peer`/`remove_peer`
    - `publish`
    - `join`/`leave`
- `floodsub`
    - `publish`