### PR TITLE
Detect closed `Mplex`

### DIFF
--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -23,6 +23,10 @@ from .host_interface import IHost
 
 
 class BasicHost(IHost):
+    """
+    BasicHost is a wrapper of a `INetwork` implementation. It performs protocol negotiation
+    on a stream with multistream-select right after a stream is initialized.
+    """
 
     _network: INetwork
     _router: KadmeliaPeerRouter
@@ -31,7 +35,6 @@ class BasicHost(IHost):
     multiselect: Multiselect
     multiselect_client: MultiselectClient
 
-    # default options constructor
     def __init__(self, network: INetwork, router: KadmeliaPeerRouter = None) -> None:
         self._network = network
         self._network.set_stream_handler(self._swarm_stream_handler)
@@ -69,6 +72,7 @@ class BasicHost(IHost):
         """
         :return: all the multiaddr addresses this host is listening to
         """
+        # TODO: We don't need "/p2p/{peer_id}" postfix actually.
         p2p_part = multiaddr.Multiaddr("/p2p/{}".format(self.get_id().pretty()))
 
         addrs: List[multiaddr.Multiaddr] = []
@@ -87,8 +91,6 @@ class BasicHost(IHost):
         """
         self.multiselect.add_handler(protocol_id, stream_handler)
 
-    # `protocol_ids` can be a list of `protocol_id`
-    # stream will decide which `protocol_id` to run on
     async def new_stream(
         self, peer_id: ID, protocol_ids: Sequence[TProtocol]
     ) -> INetStream:

--- a/libp2p/network/connection/swarm_connection.py
+++ b/libp2p/network/connection/swarm_connection.py
@@ -50,11 +50,12 @@ class SwarmConn(INetConn):
             task.cancel()
 
     async def _handle_new_streams(self) -> None:
-        # TODO: Break the loop when anything wrong in the connection.
         while True:
             try:
                 stream = await self.conn.accept_stream()
             except MuxedConnUnavailable:
+                # If there is anything wrong in the MuxedConn,
+                # we should break the loop and close the connection.
                 break
             # Asynchronously handle the accepted stream, to avoid blocking the next stream.
             await self.run_task(self._handle_muxed_stream(stream))

--- a/libp2p/network/connection/swarm_connection.py
+++ b/libp2p/network/connection/swarm_connection.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, List, Set, Tuple
 from libp2p.network.connection.net_connection_interface import INetConn
 from libp2p.network.stream.net_stream import NetStream
 from libp2p.stream_muxer.abc import IMuxedConn, IMuxedStream
+from libp2p.stream_muxer.exceptions import MuxedConnUnavailable
 
 if TYPE_CHECKING:
     from libp2p.network.swarm import Swarm  # noqa: F401
@@ -34,17 +35,27 @@ class SwarmConn(INetConn):
         if self.event_closed.is_set():
             return
         self.event_closed.set()
+        self.swarm.remove_conn(self)
+
         await self.conn.close()
+
+        # This is just for cleaning up state. The connection has already been closed.
+        # We *could* optimize this but it really isn't worth it.
+        for stream in self.streams:
+            await stream.reset()
+        # Schedule `self._notify_disconnected` to make it execute after `close` is finished.
+        asyncio.ensure_future(self._notify_disconnected())
+
         for task in self._tasks:
             task.cancel()
-
-        # TODO: Reset streams for local.
-        # TODO: Notify closed.
 
     async def _handle_new_streams(self) -> None:
         # TODO: Break the loop when anything wrong in the connection.
         while True:
-            stream = await self.conn.accept_stream()
+            try:
+                stream = await self.conn.accept_stream()
+            except MuxedConnUnavailable:
+                break
             # Asynchronously handle the accepted stream, to avoid blocking the next stream.
             await self.run_task(self._handle_muxed_stream(stream))
 
@@ -57,10 +68,15 @@ class SwarmConn(INetConn):
 
     async def _add_stream(self, muxed_stream: IMuxedStream) -> NetStream:
         net_stream = NetStream(muxed_stream)
+        self.streams.add(net_stream)
         # Call notifiers since event occurred
         for notifee in self.swarm.notifees:
             await notifee.opened_stream(self.swarm, net_stream)
         return net_stream
+
+    async def _notify_disconnected(self) -> None:
+        for notifee in self.swarm.notifees:
+            await notifee.disconnected(self.swarm, self.conn)
 
     async def start(self) -> None:
         await self.run_task(self._handle_new_streams())

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -278,7 +278,6 @@ class Swarm(INetwork):
         return swarm_conn
 
     def remove_conn(self, swarm_conn: SwarmConn) -> None:
-        print(f"!@# remove_conn: {swarm_conn}")
         peer_id = swarm_conn.conn.peer_id
         # TODO: Should be changed to remove the exact connection,
         #   if we have several connections per peer in the future.

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -262,7 +262,6 @@ class Swarm(INetwork):
         if peer_id not in self.connections:
             return
         connection = self.connections[peer_id]
-        del self.connections[peer_id]
         await connection.close()
 
         logger.debug("successfully close the connection to peer %s", peer_id)
@@ -277,3 +276,10 @@ class Swarm(INetwork):
             await notifee.connected(self, muxed_conn)
         await swarm_conn.start()
         return swarm_conn
+
+    def remove_conn(self, swarm_conn: SwarmConn) -> None:
+        print(f"!@# remove_conn: {swarm_conn}")
+        peer_id = swarm_conn.conn.peer_id
+        # TODO: Should be changed to remove the exact connection,
+        #   if we have several connections per peer in the future.
+        del self.connections[peer_id]

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -261,12 +261,18 @@ class Swarm(INetwork):
     async def close_peer(self, peer_id: ID) -> None:
         if peer_id not in self.connections:
             return
+        # TODO: Should be changed to close multisple connections,
+        #   if we have several connections per peer in the future.
         connection = self.connections[peer_id]
         await connection.close()
 
         logger.debug("successfully close the connection to peer %s", peer_id)
 
     async def add_conn(self, muxed_conn: IMuxedConn) -> SwarmConn:
+        """
+        Add a `IMuxedConn` to `Swarm` as a `SwarmConn`, notify "connected",
+        and start to monitor the connection for its new streams and disconnection.
+        """
         swarm_conn = SwarmConn(muxed_conn, self)
         # Store muxed_conn with peer id
         self.connections[muxed_conn.peer_id] = swarm_conn
@@ -278,7 +284,12 @@ class Swarm(INetwork):
         return swarm_conn
 
     def remove_conn(self, swarm_conn: SwarmConn) -> None:
+        """
+        Simply remove the connection from Swarm's records, without closing the connection.
+        """
         peer_id = swarm_conn.conn.peer_id
+        if peer_id not in self.connections:
+            return
         # TODO: Should be changed to remove the exact connection,
         #   if we have several connections per peer in the future.
         del self.connections[peer_id]

--- a/libp2p/stream_muxer/exceptions.py
+++ b/libp2p/stream_muxer/exceptions.py
@@ -5,7 +5,11 @@ class MuxedConnError(BaseLibp2pError):
     pass
 
 
-class MuxedConnShutdown(MuxedConnError):
+class MuxedConnShuttingDown(MuxedConnError):
+    pass
+
+
+class MuxedConnClosed(MuxedConnError):
     pass
 
 

--- a/libp2p/stream_muxer/exceptions.py
+++ b/libp2p/stream_muxer/exceptions.py
@@ -5,11 +5,7 @@ class MuxedConnError(BaseLibp2pError):
     pass
 
 
-class MuxedConnShuttingDown(MuxedConnError):
-    pass
-
-
-class MuxedConnClosed(MuxedConnError):
+class MuxedConnUnavailable(MuxedConnError):
     pass
 
 

--- a/libp2p/stream_muxer/mplex/exceptions.py
+++ b/libp2p/stream_muxer/mplex/exceptions.py
@@ -1,7 +1,6 @@
 from libp2p.stream_muxer.exceptions import (
-    MuxedConnClosed,
     MuxedConnError,
-    MuxedConnShuttingDown,
+    MuxedConnUnavailable,
     MuxedStreamClosed,
     MuxedStreamEOF,
     MuxedStreamReset,
@@ -12,11 +11,7 @@ class MplexError(MuxedConnError):
     pass
 
 
-class MplexShuttingDown(MuxedConnShuttingDown):
-    pass
-
-
-class MplexClosed(MuxedConnClosed):
+class MplexUnavailable(MuxedConnUnavailable):
     pass
 
 

--- a/libp2p/stream_muxer/mplex/exceptions.py
+++ b/libp2p/stream_muxer/mplex/exceptions.py
@@ -1,7 +1,7 @@
 from libp2p.stream_muxer.exceptions import (
+    MuxedConnClosed,
     MuxedConnError,
     MuxedConnShuttingDown,
-    MuxedConnClosed,
     MuxedStreamClosed,
     MuxedStreamEOF,
     MuxedStreamReset,

--- a/libp2p/stream_muxer/mplex/exceptions.py
+++ b/libp2p/stream_muxer/mplex/exceptions.py
@@ -1,6 +1,7 @@
 from libp2p.stream_muxer.exceptions import (
     MuxedConnError,
-    MuxedConnShutdown,
+    MuxedConnShuttingDown,
+    MuxedConnClosed,
     MuxedStreamClosed,
     MuxedStreamEOF,
     MuxedStreamReset,
@@ -11,7 +12,11 @@ class MplexError(MuxedConnError):
     pass
 
 
-class MplexShutdown(MuxedConnShutdown):
+class MplexShuttingDown(MuxedConnShuttingDown):
+    pass
+
+
+class MplexClosed(MuxedConnClosed):
     pass
 
 

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any  # noqa: F401
 from typing import Awaitable, Dict, List, Optional, Tuple
 
+from libp2p.io.exceptions import IncompleteReadError
 from libp2p.peer.id import ID
 from libp2p.security.secure_conn_interface import ISecureConn
 from libp2p.stream_muxer.abc import IMuxedConn, IMuxedStream
@@ -184,7 +185,11 @@ class Mplex(IMuxedConn):
                 channel_id, flag, message = await self._wait_until_shutting_down_or_closed(
                     self.read_message()
                 )
-            except (MplexUnavailable, ConnectionResetError) as error:
+            except (
+                MplexUnavailable,
+                ConnectionResetError,
+                IncompleteReadError,
+            ) as error:
                 print(f"!@# handle_incoming: read_message: exception={error}")
                 break
             if channel_id is not None and flag is not None and message is not None:

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -178,107 +178,101 @@ class Mplex(IMuxedConn):
         """
         Read a message off of the secured connection and add it to the corresponding message buffer
         """
-        # TODO Deal with other types of messages using flag (currently _)
 
         while True:
             try:
                 channel_id, flag, message = await self._wait_until_shutting_down_or_closed(
                     self.read_message()
                 )
-            except (
-                MplexUnavailable,
-                ConnectionResetError,
-                IncompleteReadError,
-            ) as error:
+            except MplexUnavailable as error:
                 print(f"!@# handle_incoming: read_message: exception={error}")
                 break
-            if channel_id is not None and flag is not None and message is not None:
-                stream_id = StreamID(channel_id=channel_id, is_initiator=bool(flag & 1))
-                is_stream_id_seen: bool
-                stream: MplexStream
-                async with self.streams_lock:
-                    is_stream_id_seen = stream_id in self.streams
-                    if is_stream_id_seen:
-                        stream = self.streams[stream_id]
-                # Other consequent stream message should wait until the stream get accepted
-                # TODO: Handle more tags, and refactor `HeaderTags`
-                if flag == HeaderTags.NewStream.value:
-                    if is_stream_id_seen:
-                        # `NewStream` for the same id is received twice...
-                        # TODO: Shutdown
-                        pass
-                    mplex_stream = await self._initialize_stream(
-                        stream_id, message.decode()
+            stream_id = StreamID(channel_id=channel_id, is_initiator=bool(flag & 1))
+            is_stream_id_seen: bool
+            stream: MplexStream
+            async with self.streams_lock:
+                is_stream_id_seen = stream_id in self.streams
+                if is_stream_id_seen:
+                    stream = self.streams[stream_id]
+            if flag == HeaderTags.NewStream.value:
+                if is_stream_id_seen:
+                    # `NewStream` for the same id is received twice...
+                    # TODO: Shutdown
+                    pass
+                mplex_stream = await self._initialize_stream(
+                    stream_id, message.decode()
+                )
+                try:
+                    await self._wait_until_shutting_down_or_closed(
+                        self.new_stream_queue.put(mplex_stream)
                     )
-                    try:
-                        await self._wait_until_shutting_down_or_closed(
-                            self.new_stream_queue.put(mplex_stream)
-                        )
-                    except MplexUnavailable:
-                        break
-                elif flag in (
-                    HeaderTags.MessageInitiator.value,
-                    HeaderTags.MessageReceiver.value,
-                ):
-                    if not is_stream_id_seen:
-                        # We receive a message of the stream `stream_id` which is not accepted
-                        #   before. It is abnormal. Possibly disconnect?
-                        # TODO: Warn and emit logs about this.
+                except MplexUnavailable:
+                    break
+            elif flag in (
+                HeaderTags.MessageInitiator.value,
+                HeaderTags.MessageReceiver.value,
+            ):
+                if not is_stream_id_seen:
+                    # We receive a message of the stream `stream_id` which is not accepted
+                    #   before. It is abnormal. Possibly disconnect?
+                    # TODO: Warn and emit logs about this.
+                    continue
+                async with stream.close_lock:
+                    if stream.event_remote_closed.is_set():
+                        # TODO: Warn "Received data from remote after stream was closed by them. (len = %d)"  # noqa: E501
                         continue
-                    async with stream.close_lock:
-                        if stream.event_remote_closed.is_set():
-                            # TODO: Warn "Received data from remote after stream was closed by them. (len = %d)"  # noqa: E501
-                            continue
-                    try:
-                        await self._wait_until_shutting_down_or_closed(
-                            stream.incoming_data.put(message)
-                        )
-                    except MplexUnavailable:
-                        break
-                elif flag in (
-                    HeaderTags.CloseInitiator.value,
-                    HeaderTags.CloseReceiver.value,
-                ):
-                    if not is_stream_id_seen:
+                try:
+                    await self._wait_until_shutting_down_or_closed(
+                        stream.incoming_data.put(message)
+                    )
+                except MplexUnavailable:
+                    break
+            elif flag in (
+                HeaderTags.CloseInitiator.value,
+                HeaderTags.CloseReceiver.value,
+            ):
+                if not is_stream_id_seen:
+                    continue
+                # NOTE: If remote is already closed, then return: Technically a bug
+                #   on the other side. We should consider killing the connection.
+                async with stream.close_lock:
+                    if stream.event_remote_closed.is_set():
                         continue
-                    # NOTE: If remote is already closed, then return: Technically a bug
-                    #   on the other side. We should consider killing the connection.
-                    async with stream.close_lock:
-                        if stream.event_remote_closed.is_set():
-                            continue
-                    is_local_closed: bool
-                    async with stream.close_lock:
-                        stream.event_remote_closed.set()
-                        is_local_closed = stream.event_local_closed.is_set()
-                    # If local is also closed, both sides are closed. Then, we should clean up
-                    #   the entry of this stream, to avoid others from accessing it.
-                    if is_local_closed:
-                        async with self.streams_lock:
-                            del self.streams[stream_id]
-                elif flag in (
-                    HeaderTags.ResetInitiator.value,
-                    HeaderTags.ResetReceiver.value,
-                ):
-                    if not is_stream_id_seen:
-                        # This is *ok*. We forget the stream on reset.
-                        continue
-                    async with stream.close_lock:
-                        if not stream.event_remote_closed.is_set():
-                            stream.event_reset.set()
-
-                            stream.event_remote_closed.set()
-                        # If local is not closed, we should close it.
-                        if not stream.event_local_closed.is_set():
-                            stream.event_local_closed.set()
+                is_local_closed: bool
+                async with stream.close_lock:
+                    stream.event_remote_closed.set()
+                    is_local_closed = stream.event_local_closed.is_set()
+                # If local is also closed, both sides are closed. Then, we should clean up
+                #   the entry of this stream, to avoid others from accessing it.
+                if is_local_closed:
                     async with self.streams_lock:
                         del self.streams[stream_id]
-                else:
-                    # TODO: logging
-                    if is_stream_id_seen:
-                        await stream.reset()
+            elif flag in (
+                HeaderTags.ResetInitiator.value,
+                HeaderTags.ResetReceiver.value,
+            ):
+                if not is_stream_id_seen:
+                    # This is *ok*. We forget the stream on reset.
+                    continue
+                async with stream.close_lock:
+                    if not stream.event_remote_closed.is_set():
+                        stream.event_reset.set()
+
+                        stream.event_remote_closed.set()
+                    # If local is not closed, we should close it.
+                    if not stream.event_local_closed.is_set():
+                        stream.event_local_closed.set()
+                async with self.streams_lock:
+                    del self.streams[stream_id]
+            else:
+                # TODO: logging
+                if is_stream_id_seen:
+                    await stream.reset()
 
             # Force context switch
             await asyncio.sleep(0)
+        # If we enter here, it means this connection is shutting down.
+        # We should clean the things up.
         await self._cleanup()
 
     async def read_message(self) -> Tuple[int, int, bytes]:
@@ -290,15 +284,19 @@ class Mplex(IMuxedConn):
         # FIXME: No timeout is used in Go implementation.
         # Timeout is set to a relatively small value to alleviate wait time to exit
         #  loop in handle_incoming
-        header = await decode_uvarint_from_stream(self.secured_conn)
-        # TODO: Handle the case of EOF and other exceptions?
         try:
+            header = await decode_uvarint_from_stream(self.secured_conn)
             message = await asyncio.wait_for(
                 read_varint_prefixed_bytes(self.secured_conn), timeout=5
             )
-        except asyncio.TimeoutError:
-            # TODO: Investigate what we should do if time is out.
-            return None, None, None
+        except (ConnectionResetError, IncompleteReadError) as error:
+            raise MplexUnavailable(
+                "failed to read messages correctly from the underlying connection"
+            ) from error
+        except asyncio.TimeoutError as error:
+            raise MplexUnavailable(
+                "failed to read more message body within the timeout"
+            ) from error
 
         flag = header & 0x07
         channel_id = header >> 3

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -4,6 +4,7 @@ from typing import Awaitable, Dict, List, Optional, Tuple
 
 from libp2p.exceptions import ParseError
 from libp2p.io.exceptions import IncompleteReadError
+from libp2p.network.connection.exceptions import RawConnError
 from libp2p.peer.id import ID
 from libp2p.security.secure_conn_interface import ISecureConn
 from libp2p.stream_muxer.abc import IMuxedConn, IMuxedStream
@@ -203,8 +204,7 @@ class Mplex(IMuxedConn):
             message = await asyncio.wait_for(
                 read_varint_prefixed_bytes(self.secured_conn), timeout=5
             )
-        # TODO: Catch RawConnError?
-        except (ParseError, IncompleteReadError) as error:
+        except (ParseError, RawConnError, IncompleteReadError) as error:
             raise MplexUnavailable(
                 "failed to read messages correctly from the underlying connection"
             ) from error

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -14,8 +14,8 @@ from libp2p.utils import (
 )
 
 from .constants import HeaderTags
-from .exceptions import MplexClosed, MplexShuttingDown
 from .datastructures import StreamID
+from .exceptions import MplexClosed, MplexShuttingDown
 from .mplex_stream import MplexStream
 
 MPLEX_PROTOCOL_ID = TProtocol("/mplex/6.7.0")

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -204,7 +204,11 @@ class MplexStream(IMuxedStream):
             self.event_remote_closed.set()
 
         async with self.mplex_conn.streams_lock:
-            del self.mplex_conn.streams[self.stream_id]
+            if (
+                self.mplex_conn.streams is not None
+                and self.stream_id in self.mplex_conn.streams
+            ):
+                del self.mplex_conn.streams[self.stream_id]
 
     # TODO deadline not in use
     def set_deadline(self, ttl: int) -> bool:

--- a/libp2p/utils.py
+++ b/libp2p/utils.py
@@ -41,14 +41,8 @@ async def decode_uvarint_from_stream(reader: Reader) -> int:
         if shift > SHIFT_64_BIT_MAX:
             raise ParseError("TODO: better exception msg: Integer is too large...")
 
-        byte = await reader.read(1)
-
-        try:
-            value = byte[0]
-        except IndexError:
-            raise ParseError(
-                "Unexpected end of stream while parsing LEB128 encoded integer"
-            )
+        byte = await read_exactly(reader, 1)
+        value = byte[0]
 
         res += (value & LOW_MASK) << shift
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -112,7 +112,7 @@ class PubsubFactory(factory.Factory):
 
 
 async def swarm_pair_factory(is_secure: bool) -> Tuple[Swarm, Swarm]:
-    swarms = await ListeningSwarmFactory.create_batch_and_listen(2)
+    swarms = await ListeningSwarmFactory.create_batch_and_listen(is_secure, 2)
     await connect_swarm(swarms[0], swarms[1])
     return swarms[0], swarms[1]
 

--- a/tests/interop/test_bindings.py
+++ b/tests/interop/test_bindings.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from .utils import connect
@@ -21,4 +23,5 @@ async def test_connect(hosts, p2pds):
     # Test: `disconnect` from Go
     await p2pd.control.disconnect(host.get_id())
     # FIXME: Failed to handle disconnect
-    # assert len(host.get_network().connections) == 0
+    await asyncio.sleep(0.01)
+    assert len(host.get_network().connections) == 0

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -2,13 +2,22 @@ import asyncio
 
 import pytest
 
-from tests.factories import net_stream_pair_factory
+from tests.factories import net_stream_pair_factory, swarm_pair_factory
 
 
 @pytest.fixture
-async def net_stream_pair():
-    stream_0, host_0, stream_1, host_1 = await net_stream_pair_factory()
+async def net_stream_pair(is_host_secure):
+    stream_0, host_0, stream_1, host_1 = await net_stream_pair_factory(is_host_secure)
     try:
         yield stream_0, stream_1
     finally:
         await asyncio.gather(*[host_0.close(), host_1.close()])
+
+
+@pytest.fixture
+async def swarm_pair(is_host_secure):
+    swarm_0, swarm_1 = await swarm_pair_factory(is_host_secure)
+    try:
+        yield swarm_0, swarm_1
+    finally:
+        await asyncio.gather(*[swarm_0.close(), swarm_1.close()])

--- a/tests/network/test_swarm.py
+++ b/tests/network/test_swarm.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from tests.factories import SwarmFactory
+from tests.utils import connect_swarm
+
+
+@pytest.mark.asyncio
+async def test_swarm_close_peer(is_host_secure):
+    swarms = await SwarmFactory.create_batch_and_listen(is_host_secure, 3)
+    # 0 <> 1 <> 2
+    await connect_swarm(swarms[0], swarms[1])
+    await connect_swarm(swarms[1], swarms[2])
+
+    # peer 1 closes peer 0
+    await swarms[1].close_peer(swarms[0].get_peer_id())
+    await asyncio.sleep(0.01)
+    # 0  1 <> 2
+    assert len(swarms[0].connections) == 0
+    assert (
+        len(swarms[1].connections) == 1
+        and swarms[2].get_peer_id() in swarms[1].connections
+    )
+
+    # peer 1 is closed by peer 2
+    await swarms[2].close_peer(swarms[1].get_peer_id())
+    await asyncio.sleep(0.01)
+    # 0  1  2
+    assert len(swarms[1].connections) == 0 and len(swarms[2].connections) == 0
+
+    await connect_swarm(swarms[0], swarms[1])
+    # 0 <> 1  2
+    assert (
+        len(swarms[0].connections) == 1
+        and swarms[1].get_peer_id() in swarms[0].connections
+    )
+    assert (
+        len(swarms[1].connections) == 1
+        and swarms[0].get_peer_id() in swarms[1].connections
+    )
+    # peer 0 closes peer 1
+    await swarms[0].close_peer(swarms[1].get_peer_id())
+    await asyncio.sleep(0.01)
+    # 0  1  2
+    assert len(swarms[1].connections) == 0 and len(swarms[2].connections) == 0
+
+    # Clean up
+    await asyncio.gather(*[swarm.close() for swarm in swarms])

--- a/tests/network/test_swarm.py
+++ b/tests/network/test_swarm.py
@@ -2,8 +2,41 @@ import asyncio
 
 import pytest
 
+from libp2p.network.exceptions import SwarmException
 from tests.factories import ListeningSwarmFactory
 from tests.utils import connect_swarm
+
+
+@pytest.mark.asyncio
+async def test_swarm_dial_peer(is_host_secure):
+    swarms = await ListeningSwarmFactory.create_batch_and_listen(is_host_secure, 3)
+    # Test: No addr found.
+    with pytest.raises(SwarmException):
+        await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    # Test: len(addr) in the peerstore is 0.
+    swarms[0].peerstore.add_addrs(swarms[1].get_peer_id(), [], 10000)
+    with pytest.raises(SwarmException):
+        await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    # Test: Succeed if addrs of the peer_id are present in the peerstore.
+    addrs = tuple(
+        addr
+        for transport in swarms[1].listeners.values()
+        for addr in transport.get_addrs()
+    )
+    swarms[0].peerstore.add_addrs(swarms[1].get_peer_id(), addrs, 10000)
+    await swarms[0].dial_peer(swarms[1].get_peer_id())
+    assert swarms[0].get_peer_id() in swarms[1].connections
+    assert swarms[1].get_peer_id() in swarms[0].connections
+
+    # Test: Reuse connections when we already have ones with a peer.
+    conn_to_1 = swarms[0].connections[swarms[1].get_peer_id()]
+    conn = await swarms[0].dial_peer(swarms[1].get_peer_id())
+    assert conn is conn_to_1
+
+    # Clean up
+    await asyncio.gather(*[swarm.close() for swarm in swarms])
 
 
 @pytest.mark.asyncio
@@ -47,3 +80,14 @@ async def test_swarm_close_peer(is_host_secure):
 
     # Clean up
     await asyncio.gather(*[swarm.close() for swarm in swarms])
+
+
+@pytest.mark.asyncio
+async def test_swarm_remove_conn(swarm_pair):
+    swarm_0, swarm_1 = swarm_pair
+    conn_0 = swarm_0.connections[swarm_1.get_peer_id()]
+    swarm_0.remove_conn(conn_0)
+    assert swarm_1.get_peer_id() not in swarm_0.connections
+    # Test: Remove twice. There should not be errors.
+    swarm_0.remove_conn(conn_0)
+    assert swarm_1.get_peer_id() not in swarm_0.connections

--- a/tests/network/test_swarm.py
+++ b/tests/network/test_swarm.py
@@ -2,13 +2,13 @@ import asyncio
 
 import pytest
 
-from tests.factories import SwarmFactory
+from tests.factories import ListeningSwarmFactory
 from tests.utils import connect_swarm
 
 
 @pytest.mark.asyncio
 async def test_swarm_close_peer(is_host_secure):
-    swarms = await SwarmFactory.create_batch_and_listen(is_host_secure, 3)
+    swarms = await ListeningSwarmFactory.create_batch_and_listen(is_host_secure, 3)
     # 0 <> 1 <> 2
     await connect_swarm(swarms[0], swarms[1])
     await connect_swarm(swarms[1], swarms[2])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,19 @@ from libp2p.peer.peerinfo import info_from_p2p_addr
 from tests.constants import MAX_READ_LEN
 
 
+async def connect_swarm(swarm_0, swarm_1):
+    peer_id = swarm_1.get_peer_id()
+    addrs = tuple(
+        addr
+        for transport in swarm_1.listeners.values()
+        for addr in transport.get_addrs()
+    )
+    swarm_0.peerstore.add_addrs(peer_id, addrs, 10000)
+    await swarm_0.dial_peer(peer_id)
+    assert swarm_0.get_peer_id() in swarm_1.connections
+    assert swarm_1.get_peer_id() in swarm_0.connections
+
+
 async def connect(node1, node2):
     """
     Connect node1 to node2


### PR DESCRIPTION
- Depends on https://github.com/libp2p/py-libp2p/pull/303.
- Add events `event_shutting_down` and `event_closed` to `Mplex`. `event_shutting_down` indicates `Mplex` is shutting down, while `event_closed` indicates `Mplex` is totally closed and should not be used anymore. The core logic is in `handle_incoming`. Every possible awaiting action in `handle_incoming` is wrapped with `self._wait_until_shutting_down_or_closed`, which asynchronously waits for `event_closed` or `event_shutting_down` or the action to be ready to execute. If any of these two events is triggered, `handle_incoming` break out of the loop and execute `cleanup`.