### PR TITLE
Remove forced debug level

### DIFF
--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -25,7 +25,6 @@ from .host_interface import IHost
 
 
 logger = logging.getLogger("libp2p.network.basic_host")
-logger.setLevel(logging.DEBUG)
 
 
 class BasicHost(IHost):

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -28,7 +28,6 @@ from .notifee_interface import INotifee
 from .stream.net_stream_interface import INetStream
 
 logger = logging.getLogger("libp2p.network.swarm")
-logger.setLevel(logging.DEBUG)
 
 
 class Swarm(INetwork):

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -12,7 +12,6 @@ from .pubsub_router_interface import IPubsubRouter
 PROTOCOL_ID = TProtocol("/floodsub/1.0.0")
 
 logger = logging.getLogger("libp2p.pubsub.floodsub")
-logger.setLevel(logging.DEBUG)
 
 
 class FloodSub(IPubsubRouter):

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -17,7 +17,6 @@ from .pubsub_router_interface import IPubsubRouter
 PROTOCOL_ID = TProtocol("/meshsub/1.0.0")
 
 logger = logging.getLogger("libp2p.pubsub.gossipsub")
-logger.setLevel(logging.DEBUG)
 
 
 class GossipSub(IPubsubRouter):

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("libp2p.pubsub")
-logger.setLevel(logging.DEBUG)
 
 
 def get_msg_id(msg: rpc_pb2.Message) -> Tuple[bytes, bytes]:


### PR DESCRIPTION
As a best practice, the debug level should be set by the calling applications (example codes or unit tests fixtures if you want!).

Having it forced as debug was killing my whole logging system (as it is configurable, logger per logger or global).