### PR TITLE
Ignore typing for `asyncio.wait`

### DIFF
--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -257,6 +257,8 @@ class Swarm(INetwork):
         # TODO: Should be changed to close multisple connections,
         #   if we have several connections per peer in the future.
         connection = self.connections[peer_id]
+        # NOTE: `connection.close` performs `del self.connections[peer_id]` for us,
+        #   so we don't need to remove the entry here.
         await connection.close()
 
         logger.debug("successfully close the connection to peer %s", peer_id)

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -62,7 +62,11 @@ class MplexStream(IMuxedStream):
             self.event_remote_closed.wait()
         )
         done, pending = await asyncio.wait(  # type: ignore
-            [task_event_reset, task_incoming_data_get, task_event_remote_closed],
+            [  # type: ignore
+                task_event_reset,
+                task_incoming_data_get,
+                task_event_remote_closed,
+            ],
             return_when=asyncio.FIRST_COMPLETED,
         )
         for fut in pending:


### PR DESCRIPTION
Fix https://github.com/libp2p/py-libp2p/issues/322. CI failed after `mypy` releasing `0.730`. It seems because in the new version of `mypy` we need one more `# type: ignore` to suppress the typing error of `asyncio.wait`(one is for "add typing for `done` and `pending` and the other is for "the first argument `fs` type mismatch".)

#### Note
This PR doesn't fix the root cause of the error. We should investigate later to solve the typing for `asyncio.wait` later.