### PR TITLE
Add more linting

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,7 @@ disallow_any_generics = True
 disallow_untyped_calls = True
 warn_redundant_casts = True
 warn_unused_configs = True
+warn_unreachable = True
 strict_equality = True
 
 [mypy-libp2p.kademlia.*]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ extras_require = {
         "black==19.3b0",
         "isort==4.3.21",
         "flake8>=3.7.7,<4.0.0",
+        "flake8-bugbear",
     ],
     "dev": ["tox>=3.13.2,<4.0.0", "docformatter"],
 }

--- a/tests_interop/daemon.py
+++ b/tests_interop/daemon.py
@@ -32,7 +32,9 @@ async def try_until_success(coro_func, timeout=TIMEOUT_DURATION):
             break
         if (time.monotonic() - t_start) >= timeout:
             # timeout
-            assert False, f"{coro_func} is still failing after `{timeout}` seconds"
+            raise AssertionError(
+                f"{coro_func} is still failing after `{timeout}` seconds"
+            )
         await asyncio.sleep(0.01)
 
 

--- a/tests_interop/daemon.py
+++ b/tests_interop/daemon.py
@@ -5,6 +5,7 @@ from typing import Any, List
 import multiaddr
 from multiaddr import Multiaddr
 from p2pclient import Client
+import pytest
 
 from libp2p.peer.id import ID
 from libp2p.peer.peerinfo import PeerInfo, info_from_p2p_addr
@@ -32,9 +33,7 @@ async def try_until_success(coro_func, timeout=TIMEOUT_DURATION):
             break
         if (time.monotonic() - t_start) >= timeout:
             # timeout
-            raise AssertionError(
-                f"{coro_func} is still failing after `{timeout}` seconds"
-            )
+            pytest.fail(f"{coro_func} is still failing after `{timeout}` seconds")
         await asyncio.sleep(0.01)
 
 


### PR DESCRIPTION
* Add `warn_unreachable = True` config for mypy
* Add flake8-bugbear. No version restriction due to flake8-bugbear using https://calver.org/ not semantic versioning.

Possibly closes https://github.com/libp2p/py-libp2p/issues/333