### PR TITLE
Add pytest xdist and fix some issues w/ parallelizing tests

### DIFF
--- a/libp2p/host/ping.py
+++ b/libp2p/host/ping.py
@@ -13,9 +13,8 @@ logger = logging.getLogger("libp2p.host.ping")
 
 
 async def _handle_ping(stream: INetStream, peer_id: PeerID) -> bool:
-    """
-    Return a boolean indicating if we expect more pings from the peer at ``peer_id``.
-    """
+    """Return a boolean indicating if we expect more pings from the peer at
+    ``peer_id``."""
     try:
         payload = await asyncio.wait_for(stream.read(PING_LENGTH), RESP_TIMEOUT)
     except asyncio.TimeoutError as error:
@@ -40,10 +39,8 @@ async def _handle_ping(stream: INetStream, peer_id: PeerID) -> bool:
 
 
 async def handle_ping(stream: INetStream) -> None:
-    """
-    ``handle_ping`` responds to incoming ping requests until one side
-    errors or closes the ``stream``.
-    """
+    """``handle_ping`` responds to incoming ping requests until one side errors
+    or closes the ``stream``."""
     peer_id = stream.muxed_conn.peer_id
 
     while True:

--- a/libp2p/kademlia/network.py
+++ b/libp2p/kademlia/network.py
@@ -55,7 +55,7 @@ class KademliaServer:
     def _create_protocol(self):
         return self.protocol_class(self.node, self.storage, self.ksize)
 
-    async def listen(self, port, interface="0.0.0.0"):
+    async def listen(self, port=0, interface="0.0.0.0"):
         """
         Start listening on the given port.
 
@@ -65,8 +65,15 @@ class KademliaServer:
         listen = loop.create_datagram_endpoint(
             self._create_protocol, local_addr=(interface, port)
         )
-        log.info("Node %i listening on %s:%i", self.node.xor_id, interface, port)
         self.transport, self.protocol = await listen
+        socket = self.transport.get_extra_info("socket")
+        self.address = socket.getsockname()
+        log.info(
+            "Node %i listening on %s:%i",
+            self.node.xor_id,
+            self.address[0],
+            self.address[1],
+        )
         # finally, schedule refreshing table
         self.refresh_table()
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ extras_require = {
         "factory-boy>=2.12.0,<3.0.0",
         "pytest>=4.6.3,<5.0.0",
         "pytest-asyncio>=0.10.0,<1.0.0",
+        "pytest-xdist>=1.30.0",
     ],
     "lint": [
         "mypy>=0.701,<1.0",

--- a/tests/host/test_routed_host.py
+++ b/tests/host/test_routed_host.py
@@ -14,7 +14,7 @@ from tests.utils import (
 
 @pytest.mark.asyncio
 async def test_host_routing_success():
-    routers = await set_up_routers([5678, 5679])
+    routers = await set_up_routers()
     transports = [["/ip4/127.0.0.1/tcp/0"], ["/ip4/127.0.0.1/tcp/0"]]
     transport_disc_opt_list = zip(transports, routers)
     (host_a, host_b) = await set_up_nodes_by_transport_and_disc_opt(
@@ -43,7 +43,7 @@ async def test_host_routing_success():
 
 @pytest.mark.asyncio
 async def test_host_routing_fail():
-    routers = await set_up_routers([5678, 5679])
+    routers = await set_up_routers()
     transports = [["/ip4/127.0.0.1/tcp/0"], ["/ip4/127.0.0.1/tcp/0"]]
     transport_disc_opt_list = zip(transports, routers)
     (host_a, host_b) = await set_up_nodes_by_transport_and_disc_opt(

--- a/tests/kademlia/test_basic.py
+++ b/tests/kademlia/test_basic.py
@@ -6,15 +6,15 @@ from libp2p.kademlia.network import KademliaServer
 @pytest.mark.asyncio
 async def test_example():
     node_a = KademliaServer()
-    await node_a.listen(5678)
+    await node_a.listen()
 
     node_b = KademliaServer()
-    await node_b.listen(5679)
+    await node_b.listen()
 
     # Bootstrap the node by connecting to other known nodes, in this case
     # replace 123.123.123.123 with the IP of another node and optionally
     # give as many ip/port combos as you can for other nodes.
-    await node_b.bootstrap([("127.0.0.1", 5678)])
+    await node_b.bootstrap([node_a.address])
 
     # set a value for the key "my-key" on the network
     value = "my-value"

--- a/tests/kademlia/test_providers.py
+++ b/tests/kademlia/test_providers.py
@@ -6,11 +6,11 @@ from libp2p.kademlia.network import KademliaServer
 @pytest.mark.asyncio
 async def test_example():
     node_a = KademliaServer()
-    await node_a.listen(5801)
+    await node_a.listen()
 
     node_b = KademliaServer()
-    await node_b.listen(5802)
-    await node_b.bootstrap([("127.0.0.1", 5801)])
+    await node_b.listen()
+    await node_b.bootstrap([node_a.address])
 
     key = "hello"
     value = "world"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ async def set_up_nodes_by_transport_and_disc_opt(transport_disc_opt_list):
     return tuple(nodes_list)
 
 
-async def set_up_routers(router_confs=[0, 0]):
+async def set_up_routers(router_confs=(0, 0)):
     """The default ``router_confs`` selects two free ports local to this
     machine."""
     bootstrap_node = KademliaServer()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,9 +46,8 @@ async def set_up_nodes_by_transport_and_disc_opt(transport_disc_opt_list):
 
 
 async def set_up_routers(router_confs=[0, 0]):
-    """
-    The default ``router_confs`` selects two free ports local to this machine.
-    """
+    """The default ``router_confs`` selects two free ports local to this
+    machine."""
     bootstrap_node = KademliaServer()
     await bootstrap_node.listen(router_confs[0])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,10 @@ async def set_up_nodes_by_transport_and_disc_opt(transport_disc_opt_list):
     return tuple(nodes_list)
 
 
-async def set_up_routers(router_confs):
+async def set_up_routers(router_confs=[0, 0]):
+    """
+    The default ``router_confs`` selects two free ports local to this machine.
+    """
     bootstrap_node = KademliaServer()
     await bootstrap_node.listen(router_confs[0])
 
@@ -54,7 +57,7 @@ async def set_up_routers(router_confs):
         node = KademliaServer()
         await node.listen(port)
 
-        await node.bootstrap_node(("127.0.0.1", router_confs[0]))
+        await node.bootstrap_node(bootstrap_node.address)
         routers.append(KadmeliaPeerRouter(node))
     return routers
 


### PR DESCRIPTION
Fixes #342.

Adding `pytest-xdist` reveals some issues where tests were not easily parallelizable w/ hard-code ports. Fix those tests by allowing the OS to choose a free port as needed.