### PR TITLE
[Trio] Make MplexStream work

### DIFF
--- a/examples/chat/chat.py
+++ b/examples/chat/chat.py
@@ -79,7 +79,10 @@ async def run(port: int, destination: str, localhost: bool) -> None:
 async def async_main_wrapper(*args):
     async with trio_asyncio.open_loop() as loop:
         assert loop == asyncio.get_event_loop()
-        await run(*args)
+        stopped_event = trio.Event()
+        await trio_asyncio.run_asyncio(run, *args)
+        await stopped_event.wait()
+
 
 def main() -> None:
     description = """

--- a/examples/chat/chat.py
+++ b/examples/chat/chat.py
@@ -1,11 +1,11 @@
 import argparse
 import asyncio
-import trio_asyncio
-import trio
 import sys
 import urllib.request
 
 import multiaddr
+import trio
+import trio_asyncio
 
 from libp2p import new_node
 from libp2p.network.stream.net_stream_interface import INetStream
@@ -42,7 +42,9 @@ async def run(port: int, destination: str, localhost: bool) -> None:
     transport_opt = f"/ip4/{ip}/tcp/{port}"
     host = new_node(transport_opt=[transport_opt])
 
-    await trio_asyncio.run_asyncio(host.get_network().listen,multiaddr.Multiaddr(transport_opt) )
+    await trio_asyncio.run_asyncio(
+        host.get_network().listen, multiaddr.Multiaddr(transport_opt)
+    )
 
     if not destination:  # its the server
 
@@ -70,7 +72,9 @@ async def run(port: int, destination: str, localhost: bool) -> None:
 
         # Start a stream with the destination.
         # Multiaddress of the destination peer is fetched from the peerstore using 'peerId'.
-        stream = await trio_asyncio.run_asyncio(host.new_stream, *(info.peer_id, [PROTOCOL_ID]))
+        stream = await trio_asyncio.run_asyncio(
+            host.new_stream, *(info.peer_id, [PROTOCOL_ID])
+        )
 
         asyncio.ensure_future(read_data(stream))
         asyncio.ensure_future(write_data(stream))
@@ -118,6 +122,7 @@ def main() -> None:
         raise RuntimeError("was not able to determine a local port")
 
     trio_asyncio.run(run, *(args.port, args.destination, args.localhost))
+
 
 if __name__ == "__main__":
     main()

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -24,18 +24,6 @@ from libp2p.transport.upgrader import TransportUpgrader
 from libp2p.typing import TProtocol
 
 
-async def cleanup_done_tasks() -> None:
-    """clean up asyncio done tasks to free up resources."""
-    while True:
-        for task in asyncio.all_tasks():
-            if task.done():
-                await task
-
-        # Need not run often
-        # Some sleep necessary to context switch
-        await asyncio.sleep(3)
-
-
 def generate_new_rsa_identity() -> KeyPair:
     return create_new_key_pair()
 
@@ -154,8 +142,5 @@ async def new_node(
         host = RoutedHost(key_pair.public_key, swarm_opt, disc_opt)
     else:
         host = BasicHost(key_pair.public_key, swarm_opt)
-
-    # Kick off cleanup job
-    asyncio.ensure_future(cleanup_done_tasks())
 
     return host

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Sequence
 
 from libp2p.crypto.keys import KeyPair

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -97,7 +97,7 @@ def initialize_default_swarm(
     return Swarm(id_opt, peerstore, upgrader, transport)
 
 
-async def new_node(
+def new_node(
     key_pair: KeyPair = None,
     swarm_opt: INetwork = None,
     transport_opt: Sequence[str] = None,

--- a/libp2p/io/trio.py
+++ b/libp2p/io/trio.py
@@ -1,9 +1,10 @@
-import trio
-from trio import SocketStream
-from libp2p.io.abc import ReadWriteCloser
-from libp2p.io.exceptions import IOException
 import logging
 
+import trio
+from trio import SocketStream
+
+from libp2p.io.abc import ReadWriteCloser
+from libp2p.io.exceptions import IOException
 
 logger = logging.getLogger("libp2p.io.trio")
 

--- a/libp2p/io/trio.py
+++ b/libp2p/io/trio.py
@@ -1,0 +1,32 @@
+import trio
+from trio import SocketStream
+from libp2p.io.abc import ReadWriteCloser
+from libp2p.io.exceptions import IOException
+import logging
+
+
+logger = logging.getLogger("libp2p.io.trio")
+
+
+class TrioReadWriteCloser(ReadWriteCloser):
+    stream: SocketStream
+
+    def __init__(self, stream: SocketStream) -> None:
+        self.stream = stream
+
+    async def write(self, data: bytes) -> None:
+        """Raise `RawConnError` if the underlying connection breaks."""
+        try:
+            await self.stream.send_all(data)
+        except (trio.ClosedResourceError, trio.BrokenResourceError) as error:
+            raise IOException(error)
+
+    async def read(self, n: int = -1) -> bytes:
+        max_bytes = n if n != -1 else None
+        try:
+            return await self.stream.receive_some(max_bytes)
+        except (trio.ClosedResourceError, trio.BrokenResourceError) as error:
+            raise IOException(error)
+
+    async def close(self) -> None:
+        await self.stream.aclose()

--- a/libp2p/kademlia/__init__.py
+++ b/libp2p/kademlia/__init__.py
@@ -1,3 +1,2 @@
-"""Kademlia is a Python implementation of the Kademlia protocol which utilizes
-the asyncio library."""
+"""Kademlia is a Python implementation of the Kademlia protocol."""
 __version__ = "2.0"

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -1,9 +1,10 @@
 import trio
 
+from libp2p.io.abc import ReadWriteCloser
 from libp2p.io.exceptions import IOException
+
 from .exceptions import RawConnError
 from .raw_connection_interface import IRawConnection
-from libp2p.io.abc import ReadWriteCloser
 
 
 class RawConnection(IRawConnection):

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -1,42 +1,25 @@
-import asyncio
+import trio
 
+from libp2p.io.exceptions import IOException
 from .exceptions import RawConnError
 from .raw_connection_interface import IRawConnection
+from libp2p.io.abc import ReadWriteCloser
 
 
 class RawConnection(IRawConnection):
-    reader: asyncio.StreamReader
-    writer: asyncio.StreamWriter
+    read_write_closer: ReadWriteCloser
     is_initiator: bool
 
-    _drain_lock: asyncio.Lock
-
-    def __init__(
-        self,
-        reader: asyncio.StreamReader,
-        writer: asyncio.StreamWriter,
-        initiator: bool,
-    ) -> None:
-        self.reader = reader
-        self.writer = writer
+    def __init__(self, read_write_closer: ReadWriteCloser, initiator: bool) -> None:
+        self.read_write_closer = read_write_closer
         self.is_initiator = initiator
-
-        self._drain_lock = asyncio.Lock()
 
     async def write(self, data: bytes) -> None:
         """Raise `RawConnError` if the underlying connection breaks."""
         try:
-            self.writer.write(data)
-        except ConnectionResetError as error:
+            await self.read_write_closer.write(data)
+        except IOException as error:
             raise RawConnError(error)
-        # Reference: https://github.com/ethereum/lahja/blob/93610b2eb46969ff1797e0748c7ac2595e130aef/lahja/asyncio/endpoint.py#L99-L102  # noqa: E501
-        # Use a lock to serialize drain() calls. Circumvents this bug:
-        # https://bugs.python.org/issue29930
-        async with self._drain_lock:
-            try:
-                await self.writer.drain()
-            except ConnectionResetError as error:
-                raise RawConnError(error)
 
     async def read(self, n: int = -1) -> bytes:
         """
@@ -46,10 +29,9 @@ class RawConnection(IRawConnection):
         Raise `RawConnError` if the underlying connection breaks
         """
         try:
-            return await self.reader.read(n)
-        except ConnectionResetError as error:
+            return await self.read_write_closer.read(n)
+        except IOException as error:
             raise RawConnError(error)
 
     async def close(self) -> None:
-        self.writer.close()
-        await self.writer.wait_closed()
+        await self.read_write_closer.close()

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import TYPE_CHECKING
 
 import trio

--- a/libp2p/tools/utils.py
+++ b/libp2p/tools/utils.py
@@ -17,7 +17,7 @@ from libp2p.typing import StreamHandlerFn, TProtocol
 from .constants import MAX_READ_LEN
 
 
-async def connect_swarm(swarm_0: Swarm, swarm_1: Swarm) -> None:
+async def connect_swarm(swarm_0: Swarm, swarm_1: Swarm, nursery: trio.Nursery) -> None:
     peer_id = swarm_1.get_peer_id()
     addrs = tuple(
         addr
@@ -25,7 +25,7 @@ async def connect_swarm(swarm_0: Swarm, swarm_1: Swarm) -> None:
         for addr in transport.get_addrs()
     )
     swarm_0.peerstore.add_addrs(peer_id, addrs, 10000)
-    await swarm_0.dial_peer(peer_id)
+    await swarm_0.dial_peer(peer_id, nursery)
     assert swarm_0.get_peer_id() in swarm_1.connections
     assert swarm_1.get_peer_id() in swarm_0.connections
 
@@ -43,7 +43,9 @@ async def set_up_nodes_by_transport_opt(
     nodes_list = []
     for transport_opt in transport_opt_list:
         node = new_node(transport_opt=transport_opt)
-        await node.get_network().listen(multiaddr.Multiaddr(transport_opt[0]), nursery=nursery)
+        await node.get_network().listen(
+            multiaddr.Multiaddr(transport_opt[0]), nursery=nursery
+        )
         nodes_list.append(node)
     return tuple(nodes_list)
 

--- a/libp2p/tools/utils.py
+++ b/libp2p/tools/utils.py
@@ -1,3 +1,4 @@
+import trio
 from typing import List, Sequence, Tuple
 
 import multiaddr
@@ -37,12 +38,12 @@ async def connect(node1: IHost, node2: IHost) -> None:
 
 
 async def set_up_nodes_by_transport_opt(
-    transport_opt_list: Sequence[Sequence[str]]
+    transport_opt_list: Sequence[Sequence[str]], nursery: trio.Nursery
 ) -> Tuple[BasicHost, ...]:
     nodes_list = []
     for transport_opt in transport_opt_list:
-        node = await new_node(transport_opt=transport_opt)
-        await node.get_network().listen(multiaddr.Multiaddr(transport_opt[0]))
+        node = new_node(transport_opt=transport_opt)
+        await node.get_network().listen(multiaddr.Multiaddr(transport_opt[0]), nursery=nursery)
         nodes_list.append(node)
     return tuple(nodes_list)
 

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -1,18 +1,18 @@
 import asyncio
-import trio
+import logging
 from socket import socket
 from typing import List
 
 from multiaddr import Multiaddr
+import trio
 
+from libp2p.io.trio import TrioReadWriteCloser
 from libp2p.network.connection.raw_connection import RawConnection
 from libp2p.network.connection.raw_connection_interface import IRawConnection
 from libp2p.transport.exceptions import OpenConnectionError
 from libp2p.transport.listener_interface import IListener
 from libp2p.transport.transport_interface import ITransport
 from libp2p.transport.typing import THandler
-from libp2p.io.trio import TrioReadWriteCloser
-import logging
 
 logger = logging.getLogger("libp2p.transport.tcp")
 
@@ -44,11 +44,9 @@ class TCPListener(IListener):
 
         listeners = await nursery.start(
             serve_tcp,
-            *(
-                handler,
-                int(maddr.value_for_protocol("tcp")),
-                maddr.value_for_protocol("ip4"),
-            ),
+            handler,
+            int(maddr.value_for_protocol("tcp")),
+            maddr.value_for_protocol("ip4"),
         )
         # self.server = await asyncio.start_server(
         #     self.handler,
@@ -57,7 +55,6 @@ class TCPListener(IListener):
         # )
         socket = listeners[0].socket
         self.multiaddrs.append(_multiaddr_from_socket(socket))
-        logger.debug("Multiaddrs %s", self.multiaddrs)
 
         return True
 

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -48,11 +48,6 @@ class TCPListener(IListener):
             int(maddr.value_for_protocol("tcp")),
             maddr.value_for_protocol("ip4"),
         )
-        # self.server = await asyncio.start_server(
-        #     self.handler,
-        #     maddr.value_for_protocol("ip4"),
-        #     maddr.value_for_protocol("tcp"),
-        # )
         socket = listeners[0].socket
         self.multiaddrs.append(_multiaddr_from_socket(socket))
 

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from socket import socket
 from typing import List

--- a/libp2p/transport/typing.py
+++ b/libp2p/transport/typing.py
@@ -1,11 +1,12 @@
-from asyncio import StreamReader, StreamWriter
+
 from typing import Awaitable, Callable, Mapping, Type
 
 from libp2p.security.secure_transport_interface import ISecureTransport
 from libp2p.stream_muxer.abc import IMuxedConn
 from libp2p.typing import TProtocol
+from libp2p.io.abc import ReadWriteCloser
 
-THandler = Callable[[StreamReader, StreamWriter], Awaitable[None]]
+THandler = Callable[[ReadWriteCloser], Awaitable[None]]
 TSecurityOptions = Mapping[TProtocol, ISecureTransport]
 TMuxerClass = Type[IMuxedConn]
 TMuxerOptions = Mapping[TProtocol, TMuxerClass]

--- a/libp2p/transport/typing.py
+++ b/libp2p/transport/typing.py
@@ -1,10 +1,9 @@
-
 from typing import Awaitable, Callable, Mapping, Type
 
+from libp2p.io.abc import ReadWriteCloser
 from libp2p.security.secure_transport_interface import ISecureTransport
 from libp2p.stream_muxer.abc import IMuxedConn
 from libp2p.typing import TProtocol
-from libp2p.io.abc import ReadWriteCloser
 
 THandler = Callable[[ReadWriteCloser], Awaitable[None]]
 TSecurityOptions = Mapping[TProtocol, ISecureTransport]

--- a/libp2p/utils.py
+++ b/libp2p/utils.py
@@ -1,13 +1,13 @@
 import itertools
 import math
+from typing import Generic, TypeVar
+
+import trio
 
 from libp2p.exceptions import ParseError
 from libp2p.io.abc import Reader
 
 from .io.utils import read_exactly
-
-from typing import Generic, TypeVar
-import trio
 
 # Unsigned LEB128(varint codec)
 # Reference: https://github.com/ethereum/py-wasm/blob/master/wasm/parsers/leb128.py

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "pytest>=4.6.3,<5.0.0",
         "pytest-asyncio>=0.10.0,<1.0.0",
         "pytest-xdist>=1.30.0",
+        "pytest-trio>=0.5.2",
     ],
     "lint": [
         "mypy>=0.701,<1.0",
@@ -68,6 +69,8 @@ setuptools.setup(
         "coincurve>=10.0.0,<11.0.0",
         "fastecdsa==1.7.4",
         "pynacl==1.3.0",
+        "trio-asyncio>=0.10.0",
+        "trio>=0.13.0",
     ],
     extras_require=extras_require,
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -1,3 +1,4 @@
+import trio
 import multiaddr
 import pytest
 
@@ -6,10 +7,10 @@ from libp2p.tools.constants import MAX_READ_LEN
 from libp2p.tools.utils import set_up_nodes_by_transport_opt
 
 
-@pytest.mark.asyncio
-async def test_simple_messages():
+@pytest.mark.trio
+async def test_simple_messages(nursery):
     transport_opt_list = [["/ip4/127.0.0.1/tcp/0"], ["/ip4/127.0.0.1/tcp/0"]]
-    (node_a, node_b) = await set_up_nodes_by_transport_opt(transport_opt_list)
+    (node_a, node_b) = await set_up_nodes_by_transport_opt(transport_opt_list, nursery)
 
     async def stream_handler(stream):
         while True:
@@ -23,6 +24,7 @@ async def test_simple_messages():
     # Associate the peer with local ip address (see default parameters of Libp2p())
     node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
 
+    
     stream = await node_a.new_stream(node_b.get_id(), ["/echo/1.0.0"])
 
     messages = ["hello" + str(x) for x in range(10)]

--- a/tests/libp2p/test_libp2p.py
+++ b/tests/libp2p/test_libp2p.py
@@ -1,6 +1,6 @@
-import trio
 import multiaddr
 import pytest
+import trio
 
 from libp2p.peer.peerinfo import info_from_p2p_addr
 from libp2p.tools.constants import MAX_READ_LEN
@@ -24,11 +24,11 @@ async def test_simple_messages(nursery):
     # Associate the peer with local ip address (see default parameters of Libp2p())
     node_a.get_peerstore().add_addrs(node_b.get_id(), node_b.get_addrs(), 10)
 
-    
     stream = await node_a.new_stream(node_b.get_id(), ["/echo/1.0.0"])
 
     messages = ["hello" + str(x) for x in range(10)]
     for message in messages:
+
         await stream.write(message.encode())
 
         response = (await stream.read(MAX_READ_LEN)).decode()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import trio
+import pytest
+from libp2p.utils import TrioQueue
+
+
+@pytest.mark.trio
+async def test_trio_queue():
+    queue = TrioQueue()
+
+    async def queue_get(task_status=None):
+        result = await queue.get()
+        task_status.started(result)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(queue.put, 123)
+        result = await nursery.start(queue_get)
+
+    assert result == 123
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-import trio
 import pytest
+import trio
+
 from libp2p.utils import TrioQueue
 
 
@@ -16,4 +17,3 @@ async def test_trio_queue():
         result = await nursery.start(queue_get)
 
     assert result == 123
-


### PR DESCRIPTION
Tried these things in this PR:

- [x] Hack Chat example
- [x] Implemented TrioReadWriteCloser to replace asyncio StreamReader/StreamWriter
- [x] Replace `asyncio.start_server` with `trio.setup_tcp`. This requires blocking conn_handler and passing nursery here and there.
- [x] Implemented IQueue interface, replace `asyncio.Queue` with `TrioQueue`.

### Challenges

- `asyncio.ensure_future` must be replaced with nursery
- No good replacement for `await asyncio.wait(..., return_when=asyncio.FIRST_COMPLETED)`
