### PR TITLE
Handle stream io error

### DIFF
--- a/libp2p/crypto/rsa.py
+++ b/libp2p/crypto/rsa.py
@@ -24,7 +24,6 @@ class RSAPublicKey(PublicKey):
     def verify(self, data: bytes, signature: bytes) -> bool:
         h = SHA256.new(data)
         try:
-            # NOTE: the typing in ``pycryptodome`` is wrong on the arguments to ``verify``.
             pkcs1_15.new(self.impl).verify(h, signature)
         except (ValueError, TypeError):
             return False
@@ -48,7 +47,6 @@ class RSAPrivateKey(PrivateKey):
 
     def sign(self, data: bytes) -> bytes:
         h = SHA256.new(data)
-        # NOTE: the typing in ``pycryptodome`` is wrong on the arguments to ``sign``.
         return pkcs1_15.new(self.impl).sign(h)
 
     def get_public_key(self) -> PublicKey:

--- a/libp2p/crypto/rsa.py
+++ b/libp2p/crypto/rsa.py
@@ -25,7 +25,7 @@ class RSAPublicKey(PublicKey):
         h = SHA256.new(data)
         try:
             # NOTE: the typing in ``pycryptodome`` is wrong on the arguments to ``verify``.
-            pkcs1_15.new(self.impl).verify(h, signature)  # type: ignore
+            pkcs1_15.new(self.impl).verify(h, signature)
         except (ValueError, TypeError):
             return False
         return True
@@ -49,7 +49,7 @@ class RSAPrivateKey(PrivateKey):
     def sign(self, data: bytes) -> bytes:
         h = SHA256.new(data)
         # NOTE: the typing in ``pycryptodome`` is wrong on the arguments to ``sign``.
-        return pkcs1_15.new(self.impl).sign(h)  # type: ignore
+        return pkcs1_15.new(self.impl).sign(h)
 
     def get_public_key(self) -> PublicKey:
         return RSAPublicKey(self.impl.publickey())

--- a/libp2p/host/ping.py
+++ b/libp2p/host/ping.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from libp2p.network.stream.exceptions import StreamEOF, StreamReset
+from libp2p.network.stream.exceptions import StreamClosed, StreamEOF, StreamReset
 from libp2p.network.stream.net_stream_interface import INetStream
 from libp2p.peer.id import ID as PeerID
 from libp2p.typing import TProtocol
@@ -25,17 +25,24 @@ async def _handle_ping(stream: INetStream, peer_id: PeerID) -> bool:
         logger.debug("Other side closed while waiting for ping from %s", peer_id)
         return False
     except StreamReset as error:
+        print("peer", peer_id, "ping reset")
         logger.debug(
             "Other side reset while waiting for ping from %s: %s", peer_id, error
         )
         raise
     except Exception as error:
+        print("peer", peer_id, "ping", type(error))
         logger.debug("Error while waiting to read ping for %s: %s", peer_id, error)
         raise
 
     logger.debug("Received ping from %s with data: 0x%s", peer_id, payload.hex())
+    print("receive ping from", peer_id)
 
-    await stream.write(payload)
+    try:
+        await stream.write(payload)
+    except StreamClosed:
+        logger.debug("Fail to respond to ping from %s: stream closed", peer_id)
+        raise
     return True
 
 
@@ -44,11 +51,13 @@ async def handle_ping(stream: INetStream) -> None:
     or closes the ``stream``."""
     peer_id = stream.muxed_conn.peer_id
 
+    print("handling ping from", peer_id)
     while True:
         try:
             should_continue = await _handle_ping(stream, peer_id)
             if not should_continue:
                 return
         except Exception:
+            print("error finish ping")
             await stream.reset()
             return

--- a/libp2p/host/ping.py
+++ b/libp2p/host/ping.py
@@ -25,18 +25,15 @@ async def _handle_ping(stream: INetStream, peer_id: PeerID) -> bool:
         logger.debug("Other side closed while waiting for ping from %s", peer_id)
         return False
     except StreamReset as error:
-        print("peer", peer_id, "ping reset")
         logger.debug(
             "Other side reset while waiting for ping from %s: %s", peer_id, error
         )
         raise
     except Exception as error:
-        print("peer", peer_id, "ping", type(error))
         logger.debug("Error while waiting to read ping for %s: %s", peer_id, error)
         raise
 
     logger.debug("Received ping from %s with data: 0x%s", peer_id, payload.hex())
-    print("receive ping from", peer_id)
 
     try:
         await stream.write(payload)
@@ -51,13 +48,11 @@ async def handle_ping(stream: INetStream) -> None:
     or closes the ``stream``."""
     peer_id = stream.muxed_conn.peer_id
 
-    print("handling ping from", peer_id)
     while True:
         try:
             should_continue = await _handle_ping(stream, peer_id)
             if not should_continue:
                 return
         except Exception:
-            print("error finish ping")
             await stream.reset()
             return

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -518,7 +518,10 @@ class GossipSub(IPubsubRouter):
         peer_stream = self.pubsub.peers[sender_peer_id]
 
         # 4) And write the packet to the stream
-        await peer_stream.write(encode_varint_prefixed(rpc_msg))
+        try:
+            await peer_stream.write(encode_varint_prefixed(rpc_msg))
+        except StreamClosed:
+            logger.debug("Fail to responed to iwant request from %s: stream closed", sender_peer_id)
 
     async def handle_graft(
         self, graft_msg: rpc_pb2.ControlGraft, sender_peer_id: ID
@@ -602,4 +605,7 @@ class GossipSub(IPubsubRouter):
         peer_stream = self.pubsub.peers[to_peer]
 
         # Write rpc to stream
-        await peer_stream.write(encode_varint_prefixed(rpc_msg))
+        try:
+            await peer_stream.write(encode_varint_prefixed(rpc_msg))
+        except StreamClosed:
+            logger.debug("Fail to emit control message to %s: stream closed", to_peer)

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -440,8 +440,7 @@ class Pubsub:
             except StreamClosed:
                 peer_id = stream.muxed_conn.peer_id
                 logger.debug("Fail to message peer %s: stream closed", peer_id)
-                del self.peers[peer_id]
-                self.router.remove_peer(peer_id)
+                self._handle_dead_peer(peer_id)
 
     async def publish(self, topic_id: str, data: bytes) -> None:
         """

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -20,7 +20,7 @@ from libp2p.exceptions import ParseError, ValidationError
 from libp2p.host.host_interface import IHost
 from libp2p.io.exceptions import IncompleteReadError
 from libp2p.network.exceptions import SwarmException
-from libp2p.network.stream.exceptions import StreamEOF, StreamReset
+from libp2p.network.stream.exceptions import StreamClosed, StreamEOF, StreamReset
 from libp2p.network.stream.net_stream_interface import INetStream
 from libp2p.peer.id import ID
 from libp2p.typing import TProtocol
@@ -279,13 +279,19 @@ class Pubsub:
 
         # Send hello packet
         hello = self.get_hello_packet()
-        await stream.write(encode_varint_prefixed(hello.SerializeToString()))
+        try:
+            await stream.write(encode_varint_prefixed(hello.SerializeToString()))
+        except StreamClosed:
+            logger.debug("Fail to add new peer %s: stream closed", peer_id)
+            del self.peers[peer_id]
+            return
         # TODO: Check EOF of this stream.
         # TODO: Check if the peer in black list.
         try:
             self.router.add_peer(peer_id, stream.get_protocol())
         except Exception as error:
             logger.debug("fail to add new peer %s, error %s", peer_id, error)
+            del self.peers[peer_id]
             return
 
         logger.debug("added new peer %s", peer_id)
@@ -429,7 +435,13 @@ class Pubsub:
         # Broadcast message
         for stream in self.peers.values():
             # Write message to stream
-            await stream.write(encode_varint_prefixed(raw_msg))
+            try:
+                await stream.write(encode_varint_prefixed(raw_msg))
+            except StreamClosed:
+                peer_id = stream.muxed_conn.peer_id
+                logger.debug("Fail to message peer %s: stream closed", peer_id)
+                del self.peers[peer_id]
+                self.router.remove_peer(peer_id)
 
     async def publish(self, topic_id: str, data: bytes) -> None:
         """

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     platforms=["unix", "linux", "osx"],
     classifiers=classifiers,
     install_requires=[
-        "pycryptodome>=3.8.2,<4.0.0",
+        "pycryptodome>=3.9.2,<4.0.0",
         "base58>=1.0.3,<2.0.0",
         "pymultihash>=0.8.2",
         "multiaddr>=0.0.8,<0.1.0",


### PR DESCRIPTION
Fix #350 
For `stream.read`, except for two examples `chat.py` and `echo.py`, it's actually handled in `_handle_ping`.
For `stream.write`, except for two examples `chat.py` and `echo.py`, it's handled in
- ping protocol handler
- identify protocol handler
- `publish` in floodsub and gossipsub
- `_handle_new_peer` and `message_all_peers` in pubsub