### PR TITLE
Add signing and verification to pubsub

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -543,7 +543,10 @@ class Pubsub:
             # i.e., check if `msg.key` matches `msg.from_id`
             msg_pubkey = deserialize_public_key(msg.key)
             if ID.from_pubkey(msg_pubkey) != msg.from_id:
-                logger.debug("Reject because signing key does not match sender ID for msg: %s", msg)
+                logger.debug(
+                    "Reject because signing key does not match sender ID for msg: %s",
+                    msg,
+                )
                 return
             # Validate the signature of the message
             # First, construct the original payload that's signed by 'msg.key'
@@ -556,9 +559,7 @@ class Pubsub:
             payload = (
                 PUBSUB_SIGNING_PREFIX.encode() + msg_without_key_sig.SerializeToString()
             )
-            if not signature_validator(
-                msg_pubkey, payload, msg.signature
-            ):
+            if not signature_validator(msg_pubkey, payload, msg.signature):
                 logger.debug("Signature validation failed for msg: %s", msg)
                 return
 

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -532,7 +532,7 @@ class Pubsub:
 
         # Check if signing is required and if so signature should be attached.
         if self.strict_signing:
-            if msg.signature == b'':
+            if msg.signature == b"":
                 logger.debug("Reject because no signature attached for msg: %s", msg)
                 return
             # Validate the signature of the message

--- a/libp2p/pubsub/validators.py
+++ b/libp2p/pubsub/validators.py
@@ -1,14 +1,41 @@
-from libp2p.crypto.keys import PublicKey
+import logging
+
+from libp2p.crypto.serialization import deserialize_public_key
+from libp2p.peer.id import ID
+
+from .pb import rpc_pb2
+
+logger = logging.getLogger("libp2p.pubsub")
+
+PUBSUB_SIGNING_PREFIX = "libp2p-pubsub:"
 
 
-def signature_validator(pubkey: PublicKey, payload: bytes, signature: bytes) -> bool:
+def signature_validator(msg: rpc_pb2.Message) -> bool:
     """
     Verify the message against the given public key.
 
     :param pubkey: the public key which signs the message.
     :param msg: the message signed.
     """
+    # Check if signature is attached
+    if msg.signature == b"":
+        logger.debug("Reject because no signature attached for msg: %s", msg)
+        return False
+
+    # Validate if message sender matches message signer,
+    # i.e., check if `msg.key` matches `msg.from_id`
+    msg_pubkey = deserialize_public_key(msg.key)
+    if ID.from_pubkey(msg_pubkey) != msg.from_id:
+        logger.debug(
+            "Reject because signing key does not match sender ID for msg: %s", msg
+        )
+        return False
+    # First, construct the original payload that's signed by 'msg.key'
+    msg_without_key_sig = rpc_pb2.Message(
+        data=msg.data, topicIDs=msg.topicIDs, from_id=msg.from_id, seqno=msg.seqno
+    )
+    payload = PUBSUB_SIGNING_PREFIX.encode() + msg_without_key_sig.SerializeToString()
     try:
-        return pubkey.verify(payload, signature)
+        return msg_pubkey.verify(payload, msg.signature)
     except Exception:
         return False

--- a/libp2p/pubsub/validators.py
+++ b/libp2p/pubsub/validators.py
@@ -1,10 +1,17 @@
-# FIXME: Replace the type of `pubkey` with a custom type `Pubkey`
-def signature_validator(pubkey: bytes, msg: bytes) -> bool:
+from libp2p.crypto.keys import PublicKey
+
+from .pb import rpc_pb2
+
+
+def signature_validator(pubkey: PublicKey, msg: rpc_pb2.Message) -> bool:
     """
     Verify the message against the given public key.
 
     :param pubkey: the public key which signs the message.
     :param msg: the message signed.
     """
-    # TODO: Implement the signature validation
+    try:
+        pubkey.verify(msg.SerializeToString(), msg.signature)
+    except Exception:
+        return False
     return True

--- a/libp2p/pubsub/validators.py
+++ b/libp2p/pubsub/validators.py
@@ -1,9 +1,7 @@
 from libp2p.crypto.keys import PublicKey
 
-from .pb import rpc_pb2
 
-
-def signature_validator(pubkey: PublicKey, msg: rpc_pb2.Message) -> bool:
+def signature_validator(pubkey: PublicKey, payload: bytes, signature: bytes) -> bool:
     """
     Verify the message against the given public key.
 
@@ -11,7 +9,6 @@ def signature_validator(pubkey: PublicKey, msg: rpc_pb2.Message) -> bool:
     :param msg: the message signed.
     """
     try:
-        pubkey.verify(msg.SerializeToString(), msg.signature)
+        return pubkey.verify(payload, signature)
     except Exception:
         return False
-    return True

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -153,6 +153,7 @@ class PubsubFactory(factory.Factory):
     router = None
     my_id = factory.LazyAttribute(lambda obj: obj.host.get_id())
     cache_size = None
+    strict_signing = False
 
 
 async def swarm_pair_factory(

--- a/tests/pubsub/conftest.py
+++ b/tests/pubsub/conftest.py
@@ -4,14 +4,24 @@ from libp2p.tools.constants import GOSSIPSUB_PARAMS
 from libp2p.tools.factories import FloodsubFactory, GossipsubFactory, PubsubFactory
 
 
-def _make_pubsubs(hosts, pubsub_routers, cache_size):
+@pytest.fixture
+def is_strict_signing():
+    return False
+
+
+def _make_pubsubs(hosts, pubsub_routers, cache_size, is_strict_signing):
     if len(pubsub_routers) != len(hosts):
         raise ValueError(
             f"lenght of pubsub_routers={pubsub_routers} should be equaled to the "
             f"length of hosts={len(hosts)}"
         )
     return tuple(
-        PubsubFactory(host=host, router=router, cache_size=cache_size)
+        PubsubFactory(
+            host=host,
+            router=router,
+            cache_size=cache_size,
+            strict_signing=is_strict_signing,
+        )
         for host, router in zip(hosts, pubsub_routers)
     )
 
@@ -27,16 +37,22 @@ def gossipsub_params():
 
 
 @pytest.fixture
-def pubsubs_fsub(num_hosts, hosts, pubsub_cache_size):
+def pubsubs_fsub(num_hosts, hosts, pubsub_cache_size, is_strict_signing):
     floodsubs = FloodsubFactory.create_batch(num_hosts)
-    _pubsubs_fsub = _make_pubsubs(hosts, floodsubs, pubsub_cache_size)
+    _pubsubs_fsub = _make_pubsubs(
+        hosts, floodsubs, pubsub_cache_size, is_strict_signing
+    )
     yield _pubsubs_fsub
     # TODO: Clean up
 
 
 @pytest.fixture
-def pubsubs_gsub(num_hosts, hosts, pubsub_cache_size, gossipsub_params):
+def pubsubs_gsub(
+    num_hosts, hosts, pubsub_cache_size, gossipsub_params, is_strict_signing
+):
     gossipsubs = GossipsubFactory.create_batch(num_hosts, **gossipsub_params._asdict())
-    _pubsubs_gsub = _make_pubsubs(hosts, gossipsubs, pubsub_cache_size)
+    _pubsubs_gsub = _make_pubsubs(
+        hosts, gossipsubs, pubsub_cache_size, is_strict_signing
+    )
     yield _pubsubs_gsub
     # TODO: Clean up

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -5,6 +5,7 @@ import pytest
 
 from libp2p.exceptions import ValidationError
 from libp2p.peer.id import ID
+from libp2p.pubsub.pubsub import PUBSUB_SIGNING_PREFIX
 from libp2p.pubsub.pb import rpc_pb2
 from libp2p.tools.pubsub.utils import make_pubsub_msg
 from libp2p.tools.utils import connect
@@ -514,7 +515,7 @@ async def test_push_msg(pubsubs_fsub, monkeypatch):
 
 @pytest.mark.parametrize("num_hosts, is_strict_signing", ((2, True),))
 @pytest.mark.asyncio
-async def test_strict_signing(pubsubs_fsub, hosts, monkeypatch):
+async def test_strict_signing(pubsubs_fsub, hosts):
     await connect(hosts[0], hosts[1])
     await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
     await pubsubs_fsub[1].subscribe(TESTING_TOPIC)
@@ -525,3 +526,57 @@ async def test_strict_signing(pubsubs_fsub, hosts, monkeypatch):
 
     assert len(pubsubs_fsub[0].seen_messages) == 1
     assert len(pubsubs_fsub[1].seen_messages) == 1
+
+
+@pytest.mark.parametrize("num_hosts, is_strict_signing", ((2, True),))
+@pytest.mark.asyncio
+async def test_strict_signing_failed_validation(pubsubs_fsub, hosts, monkeypatch):
+    msg = make_pubsub_msg(
+        origin_id=pubsubs_fsub[0].my_id,
+        topic_ids=[TESTING_TOPIC],
+        data=TESTING_DATA,
+        seqno=b"\x00" * 8,
+    )
+    priv_key = pubsubs_fsub[0].sign_key
+    signature = priv_key.sign(
+        PUBSUB_SIGNING_PREFIX.encode() + msg.SerializeToString()
+    )
+
+    event = asyncio.Event()
+
+    def _is_msg_seen(msg):
+        return False
+
+    # Use router publish to check if `push_msg` succeed.
+    async def router_publish(*args, **kwargs):
+        # The event will only be set if `push_msg` succeed.
+        event.set()
+
+    monkeypatch.setattr(pubsubs_fsub[0], "_is_msg_seen", _is_msg_seen)
+    monkeypatch.setattr(pubsubs_fsub[0].router, "publish", router_publish)
+
+    # Test: no signature attached in `msg`
+    await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
+    await asyncio.sleep(0.01)
+    assert not event.is_set()
+
+    # Test: `msg.key` does not match `msg.from_id`
+    msg.key = hosts[1].get_public_key().serialize()
+    msg.signature = signature
+    await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
+    await asyncio.sleep(0.01)
+    assert not event.is_set()
+
+    # Test: invalid signature
+    msg.key = hosts[0].get_public_key().serialize()
+    msg.signature = b"\x12" * 100
+    await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
+    await asyncio.sleep(0.01)
+    assert not event.is_set()
+
+    # Finally, assert the signature indeed will pass validation
+    msg.key = hosts[0].get_public_key().serialize()
+    msg.signature = signature
+    await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
+    await asyncio.sleep(0.01)
+    assert event.is_set()

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -5,8 +5,8 @@ import pytest
 
 from libp2p.exceptions import ValidationError
 from libp2p.peer.id import ID
-from libp2p.pubsub.pubsub import PUBSUB_SIGNING_PREFIX
 from libp2p.pubsub.pb import rpc_pb2
+from libp2p.pubsub.pubsub import PUBSUB_SIGNING_PREFIX
 from libp2p.tools.pubsub.utils import make_pubsub_msg
 from libp2p.tools.utils import connect
 from libp2p.utils import encode_varint_prefixed
@@ -538,9 +538,7 @@ async def test_strict_signing_failed_validation(pubsubs_fsub, hosts, monkeypatch
         seqno=b"\x00" * 8,
     )
     priv_key = pubsubs_fsub[0].sign_key
-    signature = priv_key.sign(
-        PUBSUB_SIGNING_PREFIX.encode() + msg.SerializeToString()
-    )
+    signature = priv_key.sign(PUBSUB_SIGNING_PREFIX.encode() + msg.SerializeToString())
 
     event = asyncio.Event()
 

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -510,3 +510,18 @@ async def test_push_msg(pubsubs_fsub, monkeypatch):
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg_2)
     await asyncio.sleep(0.01)
     assert not event.is_set()
+
+
+@pytest.mark.parametrize("num_hosts, is_strict_signing", ((2, True),))
+@pytest.mark.asyncio
+async def test_strict_signing(pubsubs_fsub, hosts, monkeypatch):
+    await connect(hosts[0], hosts[1])
+    await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
+    await pubsubs_fsub[1].subscribe(TESTING_TOPIC)
+    await asyncio.sleep(1)
+
+    await pubsubs_fsub[0].publish(TESTING_TOPIC, TESTING_DATA)
+    await asyncio.sleep(1)
+
+    assert len(pubsubs_fsub[0].seen_messages) == 1
+    assert len(pubsubs_fsub[1].seen_messages) == 1

--- a/tests_interop/test_pubsub.py
+++ b/tests_interop/test_pubsub.py
@@ -55,6 +55,9 @@ def validate_pubsub_msg(msg: rpc_pb2.Message, data: bytes, from_peer_id: ID) -> 
     assert msg.data == data and msg.from_id == from_peer_id
 
 
+@pytest.mark.parametrize(
+    "is_pubsub_signing, is_pubsub_signing_strict", ((True, True), (False, False))
+)
 @pytest.mark.parametrize("is_gossipsub", (True, False))
 @pytest.mark.parametrize("num_hosts, num_p2pds", ((1, 2),))
 @pytest.mark.asyncio


### PR DESCRIPTION
Build on #360 .
- add `strict_signing: bool` attribute to `Pubsub`, default to `True`
    - if `strict_signing` is set to `True`, we sign every message we publish and verify signature of every message we receive
- implement `signature_validator`