### PR TITLE
Add release notes for v0.1.3

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 
 .. towncrier release notes start
 
-v0.1.0-alpha.1
+v0.1.2
 --------------
 
-- Launched repository, claimed names for pip, RTD, github, etc
+Welcome to the great beyond, where changes were not tracked by release...

--- a/newsfragments/350.bugfix.rst
+++ b/newsfragments/350.bugfix.rst
@@ -1,0 +1,2 @@
+Handle Stream* errors (like ``StreamClosed``) during calls to ``stream.write()`` and
+``stream.read()``

--- a/newsfragments/353.internal.rst
+++ b/newsfragments/353.internal.rst
@@ -1,0 +1,1 @@
+Added Makefile target to test a packaged version of libp2p before release.

--- a/newsfragments/354.bugfix.rst
+++ b/newsfragments/354.bugfix.rst
@@ -1,0 +1,2 @@
+Relax the protobuf dependency to play nicely with other libraries. It was pinned to 3.9.0, and now
+permits v3.10 up to (but not including) v4.

--- a/newsfragments/355.bugfix.rst
+++ b/newsfragments/355.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes KeyError when peer in a stream accidentally closes and resets the stream, because handlers
+for both will try to ``del streams[stream_id]`` without checking if the entry still exists.

--- a/newsfragments/356.internal.rst
+++ b/newsfragments/356.internal.rst
@@ -1,0 +1,1 @@
+Move helper tools from `tests/` to `libp2p/tools/`, and some mildly-related cleanups.


### PR DESCRIPTION
## What was wrong?

PRs merged since 0.1.2 haven't been using the `towncrier` style release notes.

## How was it fixed?

I did a quick pass at summarizing the changes. If you'd like a different summary, feel free to comment and I'll update it. For future PRs, please include the notes in the related PR.

- #350 @NIC619 
- #354  @ralexstokes 
- #355 @NIC619 
- #356 @ChihChengLiang 
- #357 @NIC619 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.aspca.org/sites/default/files/blog_puppy-bowl_020118_main.jpg)
