### PR TITLE
Add docs test to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
       env: TOXENV=lint
     - python: 3.7-dev
       dist: xenial
+      env: TOXENV=docs
+    - python: 3.7-dev
+      dist: xenial
       env: TOXENV=py37-interop
       sudo: true
       before_install:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-all:
 	tox
 
 build-docs:
-	sphinx-apidoc -o docs/ . setup.py "*conftest*"
+	sphinx-apidoc -o docs/ . setup.py "*conftest*" "libp2p/tools/interop*"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ DIR = os.path.dirname('__file__')
 with open (os.path.join(DIR, '../setup.py'), 'r') as f:
     for line in f:
         if 'version=' in line:
-            setup_version = line.split('\'')[1]
+            setup_version = line.split('"')[1]
             break
 
 # -- General configuration ------------------------------------------------

--- a/docs/examples.chat.rst
+++ b/docs/examples.chat.rst
@@ -1,0 +1,22 @@
+examples.chat package
+=====================
+
+Submodules
+----------
+
+examples.chat.chat module
+-------------------------
+
+.. automodule:: examples.chat.chat
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: examples.chat
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,17 @@
+examples package
+================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    examples.chat
+
+Module contents
+---------------
+
+.. automodule:: examples
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents
 
     libp2p
     release_notes
+    examples
 
 
 Indices and tables

--- a/docs/libp2p.crypto.pb.rst
+++ b/docs/libp2p.crypto.pb.rst
@@ -1,0 +1,22 @@
+libp2p.crypto.pb package
+========================
+
+Submodules
+----------
+
+libp2p.crypto.pb.crypto\_pb2 module
+-----------------------------------
+
+.. automodule:: libp2p.crypto.pb.crypto_pb2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.crypto.pb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.crypto.rst
+++ b/docs/libp2p.crypto.rst
@@ -1,0 +1,93 @@
+libp2p.crypto package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.crypto.pb
+
+Submodules
+----------
+
+libp2p.crypto.authenticated\_encryption module
+----------------------------------------------
+
+.. automodule:: libp2p.crypto.authenticated_encryption
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.ecc module
+------------------------
+
+.. automodule:: libp2p.crypto.ecc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.ed25519 module
+----------------------------
+
+.. automodule:: libp2p.crypto.ed25519
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.exceptions module
+-------------------------------
+
+.. automodule:: libp2p.crypto.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.key\_exchange module
+----------------------------------
+
+.. automodule:: libp2p.crypto.key_exchange
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.keys module
+-------------------------
+
+.. automodule:: libp2p.crypto.keys
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.rsa module
+------------------------
+
+.. automodule:: libp2p.crypto.rsa
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.secp256k1 module
+------------------------------
+
+.. automodule:: libp2p.crypto.secp256k1
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.crypto.serialization module
+----------------------------------
+
+.. automodule:: libp2p.crypto.serialization
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.crypto
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.host.rst
+++ b/docs/libp2p.host.rst
@@ -1,0 +1,62 @@
+libp2p.host package
+===================
+
+Submodules
+----------
+
+libp2p.host.basic\_host module
+------------------------------
+
+.. automodule:: libp2p.host.basic_host
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.host.defaults module
+---------------------------
+
+.. automodule:: libp2p.host.defaults
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.host.exceptions module
+-----------------------------
+
+.. automodule:: libp2p.host.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.host.host\_interface module
+----------------------------------
+
+.. automodule:: libp2p.host.host_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.host.ping module
+-----------------------
+
+.. automodule:: libp2p.host.ping
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.host.routed\_host module
+-------------------------------
+
+.. automodule:: libp2p.host.routed_host
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.host
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.identity.identify.pb.rst
+++ b/docs/libp2p.identity.identify.pb.rst
@@ -1,0 +1,22 @@
+libp2p.identity.identify.pb package
+===================================
+
+Submodules
+----------
+
+libp2p.identity.identify.pb.identify\_pb2 module
+------------------------------------------------
+
+.. automodule:: libp2p.identity.identify.pb.identify_pb2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.identity.identify.pb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.identity.identify.rst
+++ b/docs/libp2p.identity.identify.rst
@@ -1,0 +1,29 @@
+libp2p.identity.identify package
+================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.identity.identify.pb
+
+Submodules
+----------
+
+libp2p.identity.identify.protocol module
+----------------------------------------
+
+.. automodule:: libp2p.identity.identify.protocol
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.identity.identify
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.identity.rst
+++ b/docs/libp2p.identity.rst
@@ -1,0 +1,17 @@
+libp2p.identity package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.identity.identify
+
+Module contents
+---------------
+
+.. automodule:: libp2p.identity
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.io.rst
+++ b/docs/libp2p.io.rst
@@ -1,0 +1,46 @@
+libp2p.io package
+=================
+
+Submodules
+----------
+
+libp2p.io.abc module
+--------------------
+
+.. automodule:: libp2p.io.abc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.io.exceptions module
+---------------------------
+
+.. automodule:: libp2p.io.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.io.msgio module
+----------------------
+
+.. automodule:: libp2p.io.msgio
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.io.utils module
+----------------------
+
+.. automodule:: libp2p.io.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.io
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.kademlia.rst
+++ b/docs/libp2p.kademlia.rst
@@ -1,0 +1,70 @@
+libp2p.kademlia package
+=======================
+
+Submodules
+----------
+
+libp2p.kademlia.crawling module
+-------------------------------
+
+.. automodule:: libp2p.kademlia.crawling
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.kad\_peerinfo module
+------------------------------------
+
+.. automodule:: libp2p.kademlia.kad_peerinfo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.network module
+------------------------------
+
+.. automodule:: libp2p.kademlia.network
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.protocol module
+-------------------------------
+
+.. automodule:: libp2p.kademlia.protocol
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.routing module
+------------------------------
+
+.. automodule:: libp2p.kademlia.routing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.storage module
+------------------------------
+
+.. automodule:: libp2p.kademlia.storage
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.kademlia.utils module
+----------------------------
+
+.. automodule:: libp2p.kademlia.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.kademlia
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.network.connection.rst
+++ b/docs/libp2p.network.connection.rst
@@ -1,0 +1,54 @@
+libp2p.network.connection package
+=================================
+
+Submodules
+----------
+
+libp2p.network.connection.exceptions module
+-------------------------------------------
+
+.. automodule:: libp2p.network.connection.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.connection.net\_connection\_interface module
+-----------------------------------------------------------
+
+.. automodule:: libp2p.network.connection.net_connection_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.connection.raw\_connection module
+------------------------------------------------
+
+.. automodule:: libp2p.network.connection.raw_connection
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.connection.raw\_connection\_interface module
+-----------------------------------------------------------
+
+.. automodule:: libp2p.network.connection.raw_connection_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.connection.swarm\_connection module
+--------------------------------------------------
+
+.. automodule:: libp2p.network.connection.swarm_connection
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.network.connection
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.network.rst
+++ b/docs/libp2p.network.rst
@@ -1,0 +1,54 @@
+libp2p.network package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.network.connection
+    libp2p.network.stream
+
+Submodules
+----------
+
+libp2p.network.exceptions module
+--------------------------------
+
+.. automodule:: libp2p.network.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.network\_interface module
+----------------------------------------
+
+.. automodule:: libp2p.network.network_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.notifee\_interface module
+----------------------------------------
+
+.. automodule:: libp2p.network.notifee_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.swarm module
+---------------------------
+
+.. automodule:: libp2p.network.swarm
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.network
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.network.stream.rst
+++ b/docs/libp2p.network.stream.rst
@@ -1,0 +1,38 @@
+libp2p.network.stream package
+=============================
+
+Submodules
+----------
+
+libp2p.network.stream.exceptions module
+---------------------------------------
+
+.. automodule:: libp2p.network.stream.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.stream.net\_stream module
+----------------------------------------
+
+.. automodule:: libp2p.network.stream.net_stream
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.network.stream.net\_stream\_interface module
+---------------------------------------------------
+
+.. automodule:: libp2p.network.stream.net_stream_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.network.stream
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.peer.rst
+++ b/docs/libp2p.peer.rst
@@ -1,0 +1,78 @@
+libp2p.peer package
+===================
+
+Submodules
+----------
+
+libp2p.peer.addrbook\_interface module
+--------------------------------------
+
+.. automodule:: libp2p.peer.addrbook_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.id module
+---------------------
+
+.. automodule:: libp2p.peer.id
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peerdata module
+---------------------------
+
+.. automodule:: libp2p.peer.peerdata
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peerdata\_interface module
+--------------------------------------
+
+.. automodule:: libp2p.peer.peerdata_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peerinfo module
+---------------------------
+
+.. automodule:: libp2p.peer.peerinfo
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peermetadata\_interface module
+------------------------------------------
+
+.. automodule:: libp2p.peer.peermetadata_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peerstore module
+----------------------------
+
+.. automodule:: libp2p.peer.peerstore
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.peer.peerstore\_interface module
+---------------------------------------
+
+.. automodule:: libp2p.peer.peerstore_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.peer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.protocol_muxer.rst
+++ b/docs/libp2p.protocol_muxer.rst
@@ -1,0 +1,70 @@
+libp2p.protocol\_muxer package
+==============================
+
+Submodules
+----------
+
+libp2p.protocol\_muxer.exceptions module
+----------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect module
+-----------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect\_client module
+-------------------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect\_client\_interface module
+------------------------------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect_client_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect\_communicator module
+-------------------------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect_communicator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect\_communicator\_interface module
+------------------------------------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect_communicator_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.protocol\_muxer.multiselect\_muxer\_interface module
+-----------------------------------------------------------
+
+.. automodule:: libp2p.protocol_muxer.multiselect_muxer_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.protocol_muxer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.pubsub.pb.rst
+++ b/docs/libp2p.pubsub.pb.rst
@@ -1,0 +1,22 @@
+libp2p.pubsub.pb package
+========================
+
+Submodules
+----------
+
+libp2p.pubsub.pb.rpc\_pb2 module
+--------------------------------
+
+.. automodule:: libp2p.pubsub.pb.rpc_pb2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.pubsub.pb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.pubsub.rst
+++ b/docs/libp2p.pubsub.rst
@@ -1,0 +1,77 @@
+libp2p.pubsub package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.pubsub.pb
+
+Submodules
+----------
+
+libp2p.pubsub.floodsub module
+-----------------------------
+
+.. automodule:: libp2p.pubsub.floodsub
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.gossipsub module
+------------------------------
+
+.. automodule:: libp2p.pubsub.gossipsub
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.mcache module
+---------------------------
+
+.. automodule:: libp2p.pubsub.mcache
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.pubsub module
+---------------------------
+
+.. automodule:: libp2p.pubsub.pubsub
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.pubsub\_notifee module
+------------------------------------
+
+.. automodule:: libp2p.pubsub.pubsub_notifee
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.pubsub\_router\_interface module
+----------------------------------------------
+
+.. automodule:: libp2p.pubsub.pubsub_router_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.pubsub.validators module
+-------------------------------
+
+.. automodule:: libp2p.pubsub.validators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.pubsub
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.routing.kademlia.rst
+++ b/docs/libp2p.routing.kademlia.rst
@@ -1,0 +1,30 @@
+libp2p.routing.kademlia package
+===============================
+
+Submodules
+----------
+
+libp2p.routing.kademlia.kademlia\_content\_router module
+--------------------------------------------------------
+
+.. automodule:: libp2p.routing.kademlia.kademlia_content_router
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.routing.kademlia.kademlia\_peer\_router module
+-----------------------------------------------------
+
+.. automodule:: libp2p.routing.kademlia.kademlia_peer_router
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.routing.kademlia
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.routing.rst
+++ b/docs/libp2p.routing.rst
@@ -1,0 +1,29 @@
+libp2p.routing package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.routing.kademlia
+
+Submodules
+----------
+
+libp2p.routing.interfaces module
+--------------------------------
+
+.. automodule:: libp2p.routing.interfaces
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.routing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.rst
+++ b/docs/libp2p.rst
@@ -1,0 +1,58 @@
+libp2p package
+==============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.crypto
+    libp2p.host
+    libp2p.identity
+    libp2p.io
+    libp2p.kademlia
+    libp2p.network
+    libp2p.peer
+    libp2p.protocol_muxer
+    libp2p.pubsub
+    libp2p.routing
+    libp2p.security
+    libp2p.stream_muxer
+    libp2p.tools
+    libp2p.transport
+
+Submodules
+----------
+
+libp2p.exceptions module
+------------------------
+
+.. automodule:: libp2p.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.typing module
+--------------------
+
+.. automodule:: libp2p.typing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.utils module
+-------------------
+
+.. automodule:: libp2p.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.security.insecure.pb.rst
+++ b/docs/libp2p.security.insecure.pb.rst
@@ -1,0 +1,22 @@
+libp2p.security.insecure.pb package
+===================================
+
+Submodules
+----------
+
+libp2p.security.insecure.pb.plaintext\_pb2 module
+-------------------------------------------------
+
+.. automodule:: libp2p.security.insecure.pb.plaintext_pb2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.security.insecure.pb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.security.insecure.rst
+++ b/docs/libp2p.security.insecure.rst
@@ -1,0 +1,29 @@
+libp2p.security.insecure package
+================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.security.insecure.pb
+
+Submodules
+----------
+
+libp2p.security.insecure.transport module
+-----------------------------------------
+
+.. automodule:: libp2p.security.insecure.transport
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.security.insecure
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.security.rst
+++ b/docs/libp2p.security.rst
@@ -1,0 +1,70 @@
+libp2p.security package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.security.insecure
+    libp2p.security.secio
+
+Submodules
+----------
+
+libp2p.security.base\_session module
+------------------------------------
+
+.. automodule:: libp2p.security.base_session
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.base\_transport module
+--------------------------------------
+
+.. automodule:: libp2p.security.base_transport
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.exceptions module
+---------------------------------
+
+.. automodule:: libp2p.security.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.secure\_conn\_interface module
+----------------------------------------------
+
+.. automodule:: libp2p.security.secure_conn_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.secure\_transport\_interface module
+---------------------------------------------------
+
+.. automodule:: libp2p.security.secure_transport_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.security\_multistream module
+--------------------------------------------
+
+.. automodule:: libp2p.security.security_multistream
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.security
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.security.secio.pb.rst
+++ b/docs/libp2p.security.secio.pb.rst
@@ -1,0 +1,22 @@
+libp2p.security.secio.pb package
+================================
+
+Submodules
+----------
+
+libp2p.security.secio.pb.spipe\_pb2 module
+------------------------------------------
+
+.. automodule:: libp2p.security.secio.pb.spipe_pb2
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.security.secio.pb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.security.secio.rst
+++ b/docs/libp2p.security.secio.rst
@@ -1,0 +1,37 @@
+libp2p.security.secio package
+=============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.security.secio.pb
+
+Submodules
+----------
+
+libp2p.security.secio.exceptions module
+---------------------------------------
+
+.. automodule:: libp2p.security.secio.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.security.secio.transport module
+--------------------------------------
+
+.. automodule:: libp2p.security.secio.transport
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.security.secio
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.stream_muxer.mplex.rst
+++ b/docs/libp2p.stream_muxer.mplex.rst
@@ -1,0 +1,54 @@
+libp2p.stream\_muxer.mplex package
+==================================
+
+Submodules
+----------
+
+libp2p.stream\_muxer.mplex.constants module
+-------------------------------------------
+
+.. automodule:: libp2p.stream_muxer.mplex.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.mplex.datastructures module
+------------------------------------------------
+
+.. automodule:: libp2p.stream_muxer.mplex.datastructures
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.mplex.exceptions module
+--------------------------------------------
+
+.. automodule:: libp2p.stream_muxer.mplex.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.mplex.mplex module
+---------------------------------------
+
+.. automodule:: libp2p.stream_muxer.mplex.mplex
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.mplex.mplex\_stream module
+-----------------------------------------------
+
+.. automodule:: libp2p.stream_muxer.mplex.mplex_stream
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.stream_muxer.mplex
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.stream_muxer.rst
+++ b/docs/libp2p.stream_muxer.rst
@@ -1,0 +1,45 @@
+libp2p.stream\_muxer package
+============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.stream_muxer.mplex
+
+Submodules
+----------
+
+libp2p.stream\_muxer.abc module
+-------------------------------
+
+.. automodule:: libp2p.stream_muxer.abc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.exceptions module
+--------------------------------------
+
+.. automodule:: libp2p.stream_muxer.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.stream\_muxer.muxer\_multistream module
+----------------------------------------------
+
+.. automodule:: libp2p.stream_muxer.muxer_multistream
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.stream_muxer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.tools.pubsub.rst
+++ b/docs/libp2p.tools.pubsub.rst
@@ -1,0 +1,38 @@
+libp2p.tools.pubsub package
+===========================
+
+Submodules
+----------
+
+libp2p.tools.pubsub.dummy\_account\_node module
+-----------------------------------------------
+
+.. automodule:: libp2p.tools.pubsub.dummy_account_node
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.tools.pubsub.floodsub\_integration\_test\_settings module
+----------------------------------------------------------------
+
+.. automodule:: libp2p.tools.pubsub.floodsub_integration_test_settings
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.tools.pubsub.utils module
+--------------------------------
+
+.. automodule:: libp2p.tools.pubsub.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.tools.pubsub
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.tools.rst
+++ b/docs/libp2p.tools.rst
@@ -1,0 +1,47 @@
+libp2p.tools package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.tools.pubsub
+
+The interop module is left out for now, because of the extra dependencies it requires.
+
+Submodules
+----------
+
+libp2p.tools.constants module
+-----------------------------
+
+.. automodule:: libp2p.tools.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.tools.factories module
+-----------------------------
+
+.. automodule:: libp2p.tools.factories
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.tools.utils module
+-------------------------
+
+.. automodule:: libp2p.tools.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.transport.rst
+++ b/docs/libp2p.transport.rst
@@ -1,0 +1,61 @@
+libp2p.transport package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    libp2p.transport.tcp
+
+Submodules
+----------
+
+libp2p.transport.exceptions module
+----------------------------------
+
+.. automodule:: libp2p.transport.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.transport.listener\_interface module
+-------------------------------------------
+
+.. automodule:: libp2p.transport.listener_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.transport.transport\_interface module
+--------------------------------------------
+
+.. automodule:: libp2p.transport.transport_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.transport.typing module
+------------------------------
+
+.. automodule:: libp2p.transport.typing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+libp2p.transport.upgrader module
+--------------------------------
+
+.. automodule:: libp2p.transport.upgrader
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.transport
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/libp2p.transport.tcp.rst
+++ b/docs/libp2p.transport.tcp.rst
@@ -1,0 +1,22 @@
+libp2p.transport.tcp package
+============================
+
+Submodules
+----------
+
+libp2p.transport.tcp.tcp module
+-------------------------------
+
+.. automodule:: libp2p.transport.tcp.tcp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: libp2p.transport.tcp
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -55,7 +55,7 @@ def initialize_default_kademlia_router(
     :param alpha: The alpha parameter from the paper
     :param id_opt: optional id for host
     :param storage: An instance that implements
-        :interface:`~kademlia.storage.IStorage`
+        :class:`~kademlia.storage.IStorage`
     :return: return a default kademlia instance
     """
     if not id_opt:

--- a/libp2p/kademlia/network.py
+++ b/libp2p/kademlia/network.py
@@ -232,10 +232,9 @@ class KademliaServer:
         """
         Save the state of node with a given regularity to the given filename.
 
-        Args:
-            fname: File name to save retularly to
-            frequency: Frequency in seconds that the state should be saved.
-                        By default, 10 minutes.
+        :param fname: File name to save regularly to
+        :param frequency: Frequency in seconds that the state should be saved.
+            By default, 10 minutes.
         """
         self.save_state(fname)
         loop = asyncio.get_event_loop()

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -155,13 +155,15 @@ class Swarm(INetwork):
         :return: true if at least one success
 
         For each multiaddr
-            Check if a listener for multiaddr exists already
-            If listener already exists, continue
-            Otherwise:
-                Capture multiaddr in conn handler
-                Have conn handler delegate to stream handler
-                Call listener listen with the multiaddr
-                Map multiaddr to listener
+
+          - Check if a listener for multiaddr exists already
+          - If listener already exists, continue
+          - Otherwise:
+
+              - Capture multiaddr in conn handler
+              - Have conn handler delegate to stream handler
+              - Call listener listen with the multiaddr
+              - Map multiaddr to listener
         """
         for maddr in multiaddrs:
             if str(maddr) in self.listeners:

--- a/libp2p/tools/pubsub/floodsub_integration_test_settings.py
+++ b/libp2p/tools/pubsub/floodsub_integration_test_settings.py
@@ -145,31 +145,34 @@ floodsub_protocol_pytest_params = [
 
 async def perform_test_from_obj(obj, router_factory) -> None:
     """
-    Perform pubsub tests from a test obj.
-    test obj are composed as follows:
+    Perform pubsub tests from a test object, which is composed as follows:
 
-    {
-        "supported_protocols": ["supported/protocol/1.0.0",...],
-        "adj_list": {
-            "node1": ["neighbor1_of_node1", "neighbor2_of_node1", ...],
-            "node2": ["neighbor1_of_node2", "neighbor2_of_node2", ...],
-            ...
-        },
-        "topic_map": {
-            "topic1": ["node1_subscribed_to_topic1", "node2_subscribed_to_topic1", ...]
-        },
-        "messages": [
-            {
-                "topics": ["topic1_for_message", "topic2_for_message", ...],
-                "data": b"some contents of the message (newlines are not supported)",
-                "node_id": "message sender node id"
+    .. code-block:: python
+
+        {
+            "supported_protocols": ["supported/protocol/1.0.0",...],
+            "adj_list": {
+                "node1": ["neighbor1_of_node1", "neighbor2_of_node1", ...],
+                "node2": ["neighbor1_of_node2", "neighbor2_of_node2", ...],
+                ...
             },
-            ...
-        ]
-    }
-    NOTE: In adj_list, for any neighbors A and B, only list B as a neighbor of A
-    or B as a neighbor of A once. Do NOT list both A: ["B"] and B:["A"] as the behavior
-    is undefined (even if it may work)
+            "topic_map": {
+                "topic1": ["node1_subscribed_to_topic1", "node2_subscribed_to_topic1", ...]
+            },
+            "messages": [
+                {
+                    "topics": ["topic1_for_message", "topic2_for_message", ...],
+                    "data": b"some contents of the message (newlines are not supported)",
+                    "node_id": "message sender node id"
+                },
+                ...
+            ]
+        }
+
+    .. note::
+        In adj_list, for any neighbors A and B, only list B as a neighbor of A
+        or B as a neighbor of A once. Do NOT list both A: ["B"] and B:["A"] as the behavior
+        is undefined (even if it may work)
     """
 
     # Step 1) Create graph

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
         "docformatter>=1.3.1,<2",
     ],
     "doc": [
-        "Sphinx>=1.6.5,<2",
+        "Sphinx>=2.2.1,<3",
         "sphinx_rtd_theme>=0.4.3,<=1",
         "towncrier>=19.2.0, <20",
     ],


### PR DESCRIPTION
## What was wrong?

The docs build is failing.
Secondary problem: Travis was not running the new tox target for docs.

## How was it fixed?

Added the docs build to travis, made it strict, fixed existing warnings, committed the built docs.

After this is merged, some docs should be visible on readthedocs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md) (It's not necessary to put a bug report for a fix to a feature added in the same release)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images-na.ssl-images-amazon.com/images/I/51X3HyLmbAL._SX425_.jpg)
