### PR TITLE
Remove unbuildable dependencies from docs extra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,3 +286,19 @@ doctest_default_flags = (0
     | doctest.IGNORE_EXCEPTION_DETAIL
     | doctest.NORMALIZE_WHITESPACE
 )
+
+# -- Mocked dependencies ----------------------------------------
+
+# Mock out dependencies that are unbuildable on readthedocs, as recommended here:
+# https://docs.readthedocs.io/en/rel/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+
+import sys
+from unittest.mock import MagicMock
+
+# Add new modules to mock here (it should be the same list as those excluded in setup.py)
+MOCK_MODULES = [
+    "fastecdsa",
+    "fastecdsa.encoding",
+    "fastecdsa.encoding.sec1",
+]
+sys.modules.update((mod_name, MagicMock()) for mod_name in MOCK_MODULES)

--- a/libp2p/crypto/key_exchange.py
+++ b/libp2p/crypto/key_exchange.py
@@ -1,11 +1,13 @@
 from typing import Callable, Tuple, cast
 
-from fastecdsa.encoding.util import int_bytelen
+from fastecdsa.encoding import util
 
 from libp2p.crypto.ecc import ECCPrivateKey, ECCPublicKey, create_new_key_pair
 from libp2p.crypto.keys import PublicKey
 
 SharedKeyGenerator = Callable[[bytes], bytes]
+
+int_bytelen = util.int_bytelen
 
 
 def create_ephemeral_key_pair(curve_type: str) -> Tuple[PublicKey, SharedKeyGenerator]:

--- a/newsfragments/318.doc.rst
+++ b/newsfragments/318.doc.rst
@@ -1,0 +1,1 @@
+Use Sphinx & autodoc to generate docs, now available on py-libp2p.readthedocs.io

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-libp2p[doc]
+.[doc]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
+
 from setuptools import find_packages, setup
 
 extras_require = {
@@ -46,6 +48,26 @@ with open("./README.md") as readme:
     long_description = readme.read()
 
 
+install_requires = [
+    "pycryptodome>=3.9.2,<4.0.0",
+    "base58>=1.0.3,<2.0.0",
+    "pymultihash>=0.8.2",
+    "multiaddr>=0.0.8,<0.1.0",
+    "rpcudp>=3.0.0,<4.0.0",
+    "lru-dict>=1.1.6",
+    "protobuf>=3.10.0,<4.0.0",
+    "coincurve>=10.0.0,<11.0.0",
+    "pynacl==1.3.0",
+]
+
+
+# NOTE: Some dependencies break RTD builds. We can not install system dependencies on the
+# RTD system so we have to exclude these dependencies when we are in an RTD environment.
+readthedocs_is_building = os.environ.get("READTHEDOCS", False)
+if not readthedocs_is_building:
+    install_requires.append("fastecdsa==1.7.4")
+
+
 setup(
     name="libp2p",
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
@@ -57,18 +79,7 @@ setup(
     maintainer_email="snakecharmers@ethereum.org",
     url="https://github.com/libp2p/py-libp2p",
     include_package_data=True,
-    install_requires=[
-        "pycryptodome>=3.9.2,<4.0.0",
-        "base58>=1.0.3,<2.0.0",
-        "pymultihash>=0.8.2",
-        "multiaddr>=0.0.8,<0.1.0",
-        "rpcudp>=3.0.0,<4.0.0",
-        "lru-dict>=1.1.6",
-        "protobuf>=3.10.0,<4.0.0",
-        "coincurve>=10.0.0,<11.0.0",
-        "fastecdsa==1.7.4",
-        "pynacl==1.3.0",
-    ],
+    install_requires=install_requires,
     python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["libp2p"],


### PR DESCRIPTION
## What was wrong?

The autodoc feature was failing in readthedocs because `fastecdsa` could not be imported.

More generally:
Fixes #318 

## How was it fixed?

- Don't attempt to install fastecdsa in a readthedocs context
- Mock out the module when `docs/conf.py` is loaded, so that modules that import fastecdsa can still be autodoc'd
- Fiddled with only importing the top-level module, but due to some weirdness about the package, it breaks when doing `from fastecdsa import encoding; encoding.sec1.SEC1Encoder`. So I just mocked out the submodules, also.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.aspca.org/sites/default/files/blog_reading-program_090619_main_0.jpg)