### PR TITLE
Add py36 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,30 +48,24 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py36-core:
+  py36-test:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-core
-  py37-core:
+          TOXENV: py36-test
+  py37-test:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-core
-  pypy3-core:
-    <<: *common
-    docker:
-      - image: pypy
-        environment:
-          TOXENV: pypy3-core
+          TOXENV: py37-test
+
 workflows:
   version: 2
   test:
     jobs:
       - docs
       - lint
-      - py36-core
-      - py37-core
-      - pypy3-core
+      - py36-test
+      - py37-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,24 +48,30 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py36-test:
+  py36-core:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-test
-  py37-test:
+          TOXENV: py36-core
+  py37-core:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-test
-
+          TOXENV: py37-core
+  pypy3-core:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-core
 workflows:
   version: 2
   test:
     jobs:
       - docs
       - lint
-      - py36-test
-      - py37-test
+      - py36-core
+      - py37-core
+      - pypy3-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 
 matrix:
   include:
+    - python: 3.6-dev
+      dist: xenial
+      env: TOXENV=py36-test
     - python: 3.7-dev
       dist: xenial
       env: TOXENV=py37-test

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -53,5 +53,6 @@ class RawConnection(IRawConnection):
 
     async def close(self) -> None:
         self.writer.close()
-        if sys.version_info[0:2] > (3, 6):
-            await self.writer.wait_closed()
+        if sys.version_info < (3, 7):
+            return
+        await self.writer.wait_closed()

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from .exceptions import RawConnError
 from .raw_connection_interface import IRawConnection
@@ -52,4 +53,5 @@ class RawConnection(IRawConnection):
 
     async def close(self) -> None:
         self.writer.close()
-        await self.writer.wait_closed()
+        if sys.version_info[0:2] > (3, 6):
+            await self.writer.wait_closed()

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -150,7 +150,7 @@ class Pubsub:
         # Map of topic to topic validator
         self.topic_validators = {}
 
-        self.counter = time.time_ns()
+        self.counter = int(time.time())
 
         self._tasks = []
         # Call handle peer to keep waiting for updates to peer queue

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -1,6 +1,8 @@
 import asyncio
 from typing import Any, AsyncIterator, Dict, Tuple, cast
 
+# NOTE: import ``asynccontextmanager`` from ``contextlib`` when support for python 3.6 is dropped.
+from async_generator import asynccontextmanager
 import factory
 
 from libp2p import generate_new_rsa_identity, generate_peer_id_from
@@ -31,12 +33,6 @@ from .constants import (
     LISTEN_MADDR,
 )
 from .utils import connect, connect_swarm
-
-try:
-    from contextlib import asynccontextmanager
-except ImportError:
-    # NOTE: mypy complains about a duplicate import without the following ``# type: ignore``
-    from async_generator import asynccontextmanager  # type: ignore
 
 
 def initialize_peerstore_with_our_keypair(self_id: ID, key_pair: KeyPair) -> PeerStore:
@@ -177,7 +173,7 @@ async def host_pair_factory(is_secure: bool) -> Tuple[BasicHost, BasicHost]:
     return hosts[0], hosts[1]
 
 
-@asynccontextmanager
+@asynccontextmanager  # type: ignore
 async def pair_of_connected_hosts(
     is_secure: bool = True
 ) -> AsyncIterator[Tuple[BasicHost, BasicHost]]:

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -1,5 +1,4 @@
 import asyncio
-from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, Tuple, cast
 
 import factory
@@ -32,6 +31,12 @@ from .constants import (
     LISTEN_MADDR,
 )
 from .utils import connect, connect_swarm
+
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    # NOTE: mypy complains about a duplicate import without the following ``# type: ignore``
+    from async_generator import asynccontextmanager  # type: ignore
 
 
 def initialize_peerstore_with_our_keypair(self_id: ID, key_pair: KeyPair) -> PeerStore:

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -1,5 +1,6 @@
 import asyncio
 from socket import socket
+import sys
 from typing import List
 
 from multiaddr import Multiaddr
@@ -53,7 +54,8 @@ class TCPListener(IListener):
         if self.server is None:
             return
         self.server.close()
-        await self.server.wait_closed()
+        if sys.version_info[0:2] > (3, 6):
+            await self.server.wait_closed()
         self.server = None
 
 

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -54,9 +54,11 @@ class TCPListener(IListener):
         if self.server is None:
             return
         self.server.close()
-        if sys.version_info[0:2] > (3, 6):
-            await self.server.wait_closed()
+        server = self.server
         self.server = None
+        if sys.version_info < (3, 7):
+            return
+        await server.wait_closed()
 
 
 class TCP(ITransport):

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     "coincurve>=10.0.0,<11.0.0",
     "pynacl==1.3.0",
     "dataclasses>=0.7, <1;python_version<'3.7'",
-    "async_generator==1.10;python_version<'3.7'",
+    "async_generator==1.10",
 ]
 
 
@@ -96,6 +96,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
     platforms=["unix", "linux", "osx"],

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ install_requires = [
     "protobuf>=3.10.0,<4.0.0",
     "coincurve>=10.0.0,<11.0.0",
     "pynacl==1.3.0",
+    "dataclasses>=0.7, <1;python_version<'3.7'",
+    "async_generator==1.10;python_version<'3.7'",
 ]
 
 
@@ -80,7 +82,7 @@ setup(
     url="https://github.com/libp2p/py-libp2p",
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.7,<4",
+    python_requires=">=3.6,<4",
     extras_require=extras_require,
     py_modules=["libp2p"],
     license="MIT/APACHE2.0",

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -58,11 +58,11 @@ async def test_peers_subscribe(pubsubs_fsub):
     await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
     await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
     # Yield to let 0 notify 1
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(1)
     assert pubsubs_fsub[0].my_id in pubsubs_fsub[1].peer_topics[TESTING_TOPIC]
     await pubsubs_fsub[0].unsubscribe(TESTING_TOPIC)
     # Yield to let 0 notify 1
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(1)
     assert pubsubs_fsub[0].my_id not in pubsubs_fsub[1].peer_topics[TESTING_TOPIC]
 
 

--- a/tests/security/test_secio.py
+++ b/tests/security/test_secio.py
@@ -76,8 +76,8 @@ async def test_create_secure_session():
     local_conn = InMemoryConnection(local_peer, is_initiator=True)
     remote_conn = InMemoryConnection(remote_peer)
 
-    local_pipe_task = asyncio.create_task(create_pipe(local_conn, remote_conn))
-    remote_pipe_task = asyncio.create_task(create_pipe(remote_conn, local_conn))
+    local_pipe_task = asyncio.ensure_future(create_pipe(local_conn, remote_conn))
+    remote_pipe_task = asyncio.ensure_future(create_pipe(remote_conn, local_conn))
 
     local_session_builder = create_secure_session(
         local_nonce, local_peer, local_key_pair.private_key, local_conn, remote_peer

--- a/tests_interop/conftest.py
+++ b/tests_interop/conftest.py
@@ -151,8 +151,9 @@ class DaemonStream(ReadWriteCloser):
 
     async def close(self) -> None:
         self.writer.close()
-        if sys.version_info[0:2] > (3, 6):
-            await self.writer.wait_closed()
+        if sys.version_info < (3, 7):
+            return
+        await self.writer.wait_closed()
 
     async def read(self, n: int = -1) -> bytes:
         return await self.reader.read(n)

--- a/tests_interop/conftest.py
+++ b/tests_interop/conftest.py
@@ -151,7 +151,8 @@ class DaemonStream(ReadWriteCloser):
 
     async def close(self) -> None:
         self.writer.close()
-        await self.writer.wait_closed()
+        if sys.version_info[0:2] > (3, 6):
+            await self.writer.wait_closed()
 
     async def read(self, n: int = -1) -> bytes:
         return await self.reader.read(n)
@@ -196,7 +197,8 @@ async def py_to_daemon_stream_pair(hosts, p2pds, is_to_fail_daemon_stream):
         #   some day.
         listener = p2pds[0].control.control.listener
         listener.close()
-        await listener.wait_closed()
+        if sys.version_info[0:2] > (3, 6):
+            await listener.wait_closed()
     stream_py = await host.new_stream(p2pd.peer_id, [protocol_id])
     if not is_to_fail_daemon_stream:
         await event_stream_handled.wait()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 # Reference: https://github.com/ethereum/ethereum-python-project-template/blob/master/tox.ini
 
-# TODO: consider py36 and pypy3 support
+# TODO: consider pypy3 support
 [tox]
 envlist =
+    py36-test
     py37-test
     py37-interop
     lint
@@ -37,6 +38,7 @@ commands =
 basepython =
     docs: python
     py37: python3.7
+    py36: python3.6
 extras =
     test
     docs: doc

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@
 # TODO: consider pypy3 support
 [tox]
 envlist =
-    py36-test
-    py37-test
+    py{36,37}-test
     py37-interop
     lint
     docs


### PR DESCRIPTION
## What was wrong?

We only supported python 3.7.


## How was it fixed?

The main thing was adding backfills for APIs that changed in python 3.7 compared to earlier versions.

I had to make some changes to some tests to account for subtleties in the tests that interacted w/ differences in semantics b/t python 3.6 and 3.7.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fs-media-cache-ak0.pinimg.com%2F736x%2F3f%2F87%2Fd5%2F3f87d589777f90c9cf77eed98435776a--kangaroos-babys.jpg&f=1&nofb=1)
