### PR TITLE
Refactor and cleanup gossipsub

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -396,13 +396,12 @@ class GossipSub(IPubsubRouter):
                 if topic in self.pubsub.peer_topics:
                     # Select D peers from peers.gossipsub[topic]
                     peers_to_emit_ihave_to = self._get_in_topic_gossipsub_peers_from_minus(
-                        topic, self.degree, []
+                        topic, self.degree, self.mesh[topic]
                     )
 
+                    msg_id_strs = [str(msg_id) for msg_id in msg_ids]
                     for peer in peers_to_emit_ihave_to:
-                        if peer not in self.mesh[topic]:
-                            msg_id_strs = [str(msg_id) for msg_id in msg_ids]
-                            await self.emit_ihave(topic, msg_id_strs, peer)
+                        await self.emit_ihave(topic, msg_id_strs, peer)
 
         # TODO: Refactor and Dedup. This section is the roughly the same as the above.
         # Do the same for fanout, for all topics not already hit in mesh
@@ -414,12 +413,11 @@ class GossipSub(IPubsubRouter):
                     if topic in self.pubsub.peer_topics:
                         # Select D peers from peers.gossipsub[topic]
                         peers_to_emit_ihave_to = self._get_in_topic_gossipsub_peers_from_minus(
-                            topic, self.degree, []
+                            topic, self.degree, self.fanout[topic]
                         )
+                        msg_id_strs = [str(msg) for msg in msg_ids]
                         for peer in peers_to_emit_ihave_to:
-                            if peer not in self.fanout[topic]:
-                                msg_id_strs = [str(msg) for msg in msg_ids]
-                                await self.emit_ihave(topic, msg_id_strs, peer)
+                            await self.emit_ihave(topic, msg_id_strs, peer)
 
         self.mcache.shift()
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -314,9 +314,11 @@ class GossipSub(IPubsubRouter):
         peers_to_prune: Dict[ID, List[str]],
         peers_to_gossip: Dict[ID, Dict[str, List[str]]],
     ) -> None:
+        graft_msgs: List[rpc_pb2.ControlGraft] = []
+        prune_msgs: List[rpc_pb2.ControlPrune] = []
+        ihave_msgs: List[rpc_pb2.ControlIHave] = []
         # Starting with GRAFT messages
         for peer, topics in peers_to_graft.items():
-            graft_msgs: List[rpc_pb2.ControlGraft] = []
             for topic in topics:
                 graft_msg: rpc_pb2.ControlGraft = rpc_pb2.ControlGraft()
                 graft_msg.topicID = topic
@@ -324,7 +326,6 @@ class GossipSub(IPubsubRouter):
 
             # If there are also PRUNE messages to send to this peer
             if peer in peers_to_prune:
-                prune_msgs: List[rpc_pb2.ControlPrune] = []
                 for topic in peers_to_prune[peer]:
                     prune_msg: rpc_pb2.ControlPrune = rpc_pb2.ControlPrune()
                     prune_msg.topicID = topic
@@ -333,7 +334,6 @@ class GossipSub(IPubsubRouter):
 
             # If there are also IHAVE messages to send to this peer
             if peer in peers_to_gossip:
-                ihave_msgs: List[rpc_pb2.ControlIHave] = []
                 for topic in peers_to_gossip[peer]:
                     ihave_msg: rpc_pb2.ControlIHave = rpc_pb2.ControlIHave()
                     ihave_msg.messageIDs.extend(peers_to_gossip[peer][topic])

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -320,10 +320,7 @@ class GossipSub(IPubsubRouter):
                     topic, self.degree - num_mesh_peers_in_topic, self.mesh[topic]
                 )
 
-                fanout_peers_not_in_mesh: List[ID] = [
-                    peer for peer in selected_peers if peer not in self.mesh[topic]
-                ]
-                for peer in fanout_peers_not_in_mesh:
+                for peer in selected_peers:
                     # Add peer to mesh[topic]
                     self.mesh[topic].append(peer)
 
@@ -377,12 +374,7 @@ class GossipSub(IPubsubRouter):
                     )
 
                     for peer in peers_to_emit_ihave_to:
-                        # TODO: this line is a monster, can hopefully be simplified
-                        if (
-                            topic not in self.mesh or (peer not in self.mesh[topic])
-                        ) and (
-                            topic not in self.fanout or (peer not in self.fanout[topic])
-                        ):
+                        if peer not in self.mesh[topic]:
                             msg_id_strs = [str(msg_id) for msg_id in msg_ids]
                             await self.emit_ihave(topic, msg_id_strs, peer)
 
@@ -399,10 +391,7 @@ class GossipSub(IPubsubRouter):
                             topic, self.degree, []
                         )
                         for peer in peers_to_emit_ihave_to:
-                            if (
-                                peer not in self.mesh[topic]
-                                and peer not in self.fanout[topic]
-                            ):
+                            if peer not in self.fanout[topic]:
                                 msg_id_strs = [str(msg) for msg in msg_ids]
                                 await self.emit_ihave(topic, msg_id_strs, peer)
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -129,9 +129,7 @@ class GossipSub(IPubsubRouter):
             #   instance in multistream-select, but it is not the protocol that gossipsub supports.
             #   In this case, probably we registered gossipsub to a wrong `protocol_id`
             #   in multistream-select, or wrong versions.
-            raise Exception(
-                f"Unreachable: Protocol={protocol_id} is not supported."
-            )
+            raise Exception(f"Unreachable: Protocol={protocol_id} is not supported.")
         self.peers_to_protocol[peer_id] = protocol_id
 
     def remove_peer(self, peer_id: ID) -> None:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -235,7 +235,7 @@ class GossipSub(IPubsubRouter):
                 gossipsub_peers = self.mesh[topic]
             else:
                 # When we publish to a topic that we have not subscribe to, we randomly pick
-                # `self.degree` number of peers who have subscribe to the topic and add them
+                # `self.degree` number of peers who have subscribed to the topic and add them
                 # as our `fanout` peers.
                 topic_in_fanout: bool = topic in self.fanout
                 fanout_peers: List[ID] = self.fanout[topic] if topic_in_fanout else []

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -43,6 +43,7 @@ class GossipSub(IPubsubRouter):
 
     mcache: MessageCache
 
+    heartbeat_initial_delay: float
     heartbeat_interval: int
 
     def __init__(
@@ -54,6 +55,7 @@ class GossipSub(IPubsubRouter):
         time_to_live: int,
         gossip_window: int = 3,
         gossip_history: int = 5,
+        heartbeat_initial_delay: int = 0.1,
         heartbeat_interval: int = 120,
     ) -> None:
         self.protocols = list(protocols)
@@ -84,6 +86,7 @@ class GossipSub(IPubsubRouter):
         self.mcache = MessageCache(gossip_window, gossip_history)
 
         # Create heartbeat timer
+        self.heartbeat_initial_delay = heartbeat_initial_delay
         self.heartbeat_interval = heartbeat_interval
 
     # Interface functions
@@ -294,7 +297,7 @@ class GossipSub(IPubsubRouter):
         state changes in the preceding heartbeat
         """
         # Start after a delay. Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/01b9825fbee1848751d90a8469e3f5f43bac8466/gossipsub.go#L410  # Noqa: E501
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(self.heartbeat_initial_delay)
         while True:
 
             await self.mesh_heartbeat()

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -150,17 +150,11 @@ class GossipSub(IPubsubRouter):
         for topic in self.mesh:
             if peer_id in self.mesh[topic]:
                 # Delete the entry if no other peers left
-                if len(self.mesh[topic]) == 1:
-                    del self.mesh[topic]
-                else:
-                    self.mesh[topic].remove(peer_id)
+                self.mesh[topic].remove(peer_id)
         for topic in self.fanout:
             if peer_id in self.fanout[topic]:
                 # Delete the entry if no other peers left
-                if len(self.fanout[topic]) == 1:
-                    del self.fanout[topic]
-                else:
-                    self.fanout[topic].remove(peer_id)
+                self.fanout[topic].remove(peer_id)
 
         self.peers_to_protocol.pop(peer_id, None)
 
@@ -647,10 +641,7 @@ class GossipSub(IPubsubRouter):
 
         # Remove peer from mesh for topic, if peer is in topic
         if topic in self.mesh and sender_peer_id in self.mesh[topic]:
-            if len(self.mesh[topic]) == 1:
-                del self.mesh[topic]
-            else:
-                self.mesh[topic].remove(sender_peer_id)
+            self.mesh[topic].remove(sender_peer_id)
 
     # RPC emitters
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -106,8 +106,6 @@ class GossipSub(IPubsubRouter):
         logger.debug("attached to pusub")
 
         # Start heartbeat now that we have a pubsub instance
-        # Start after a delay. Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/01b9825fbee1848751d90a8469e3f5f43bac8466/gossipsub.go#L410  # Noqa: E501
-        await asyncio.sleep(0.1)
         asyncio.ensure_future(self.heartbeat())
 
     def add_peer(self, peer_id: ID, protocol_id: TProtocol) -> None:
@@ -295,6 +293,8 @@ class GossipSub(IPubsubRouter):
         Note: the heartbeats are called with awaits because each heartbeat depends on the
         state changes in the preceding heartbeat
         """
+        # Start after a delay. Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/01b9825fbee1848751d90a8469e3f5f43bac8466/gossipsub.go#L410  # Noqa: E501
+        await asyncio.sleep(0.1)
         while True:
 
             await self.mesh_heartbeat()

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -130,7 +130,7 @@ class GossipSub(IPubsubRouter):
             #   In this case, probably we registered gossipsub to a wrong `protocol_id`
             #   in multistream-select, or wrong versions.
             raise Exception(
-                f"This should not happen. Protocol={protocol_id} is not supported."
+                f"Unreachable: Protocol={protocol_id} is not supported."
             )
         self.peers_to_protocol[peer_id] = protocol_id
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -460,9 +460,12 @@ class GossipSub(IPubsubRouter):
             else:
                 # Check whether our peers are still in the topic
                 # ref: https://github.com/libp2p/go-libp2p-pubsub/blob/01b9825fbee1848751d90a8469e3f5f43bac8466/gossipsub.go#L498-L504  # noqa: E501
-                for peer in self.fanout[topic]:
-                    if peer not in self.pubsub.peer_topics[topic]:
-                        self.fanout[topic].remove(peer)
+                in_topic_fanout_peers = [
+                    peer
+                    for peer in self.fanout[topic]
+                    if peer in self.pubsub.peer_topics[topic]
+                ]
+                self.fanout[topic] = in_topic_fanout_peers
                 num_fanout_peers_in_topic = len(self.fanout[topic])
 
                 # If |fanout[topic]| < D
@@ -644,7 +647,10 @@ class GossipSub(IPubsubRouter):
 
         # Remove peer from mesh for topic, if peer is in topic
         if topic in self.mesh and sender_peer_id in self.mesh[topic]:
-            self.mesh[topic].remove(sender_peer_id)
+            if len(self.mesh[topic]) == 1:
+                del self.mesh[topic]
+            else:
+                self.mesh[topic].remove(sender_peer_id)
 
     # RPC emitters
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -145,6 +145,21 @@ class GossipSub(IPubsubRouter):
         elif peer_id in self.peers_floodsub:
             self.peers_floodsub.remove(peer_id)
 
+        for topic in self.mesh:
+            if peer_id in self.mesh[topic]:
+                # Delete the entry if no other peers left
+                if len(self.mesh[topic]) == 1:
+                    del self.mesh[topic]
+                else:
+                    self.mesh[topic].remove(peer_id)
+        for topic in self.fanout:
+            if peer_id in self.fanout[topic]:
+                # Delete the entry if no other peers left
+                if len(self.fanout[topic]) == 1:
+                    del self.fanout[topic]
+                else:
+                    self.fanout[topic].remove(peer_id)
+
         self.peers_to_protocol.pop(peer_id, None)
 
     async def handle_rpc(self, rpc: rpc_pb2.RPC, sender_peer_id: ID) -> None:

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -327,11 +327,9 @@ class Pubsub:
         logger.debug("removed dead peer %s", peer_id)
 
     async def handle_peer_queue(self) -> None:
-        """
-        Continuously read from peer queue and each time a new peer is found,
-        open a stream to the peer using a supported pubsub protocol
-        pubsub protocols we support
-        """
+        """Continuously read from peer queue and each time a new peer is found,
+        open a stream to the peer using a supported pubsub protocol pubsub
+        protocols we support."""
         while True:
             peer_id: ID = await self.peer_queue.get()
             # Add Peer

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -78,7 +78,6 @@ class Pubsub:
 
     topic_validators: Dict[str, TopicValidator]
 
-    # TODO: Be sure it is increased atomically everytime.
     counter: int  # uint64
 
     _tasks: List["asyncio.Future[Any]"]
@@ -300,7 +299,6 @@ class Pubsub:
             logger.debug("Fail to add new peer %s: stream closed", peer_id)
             del self.peers[peer_id]
             return
-        # TODO: Check EOF of this stream.
         # TODO: Check if the peer in black list.
         try:
             self.router.add_peer(peer_id, stream.get_protocol())
@@ -328,7 +326,6 @@ class Pubsub:
         """
         Continuously read from peer queue and each time a new peer is found,
         open a stream to the peer using a supported pubsub protocol
-        TODO: Handle failure for when the peer does not support any of the
         pubsub protocols we support
         """
         while True:

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -316,7 +316,11 @@ class Pubsub:
 
         for topic in self.peer_topics:
             if peer_id in self.peer_topics[topic]:
-                self.peer_topics[topic].remove(peer_id)
+                # Delete the entry if no other peers left
+                if len(self.peer_topics[topic]) == 1:
+                    del self.peer_topics[topic]
+                else:
+                    self.peer_topics[topic].remove(peer_id)
 
         self.router.remove_peer(peer_id)
 
@@ -361,7 +365,11 @@ class Pubsub:
         else:
             if sub_message.topicid in self.peer_topics:
                 if origin_id in self.peer_topics[sub_message.topicid]:
-                    self.peer_topics[sub_message.topicid].remove(origin_id)
+                    # Delete the entry if no other peers left
+                    if len(self.peer_topics[sub_message.topicid]) == 1:
+                        del self.peer_topics[sub_message.topicid]
+                    else:
+                        self.peer_topics[sub_message.topicid].remove(origin_id)
 
     # FIXME(mhchia): Change the function name?
     async def handle_talk(self, publish_message: rpc_pb2.Message) -> None:

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -317,10 +317,7 @@ class Pubsub:
         for topic in self.peer_topics:
             if peer_id in self.peer_topics[topic]:
                 # Delete the entry if no other peers left
-                if len(self.peer_topics[topic]) == 1:
-                    del self.peer_topics[topic]
-                else:
-                    self.peer_topics[topic].remove(peer_id)
+                self.peer_topics[topic].remove(peer_id)
 
         self.router.remove_peer(peer_id)
 
@@ -364,10 +361,7 @@ class Pubsub:
             if sub_message.topicid in self.peer_topics:
                 if origin_id in self.peer_topics[sub_message.topicid]:
                     # Delete the entry if no other peers left
-                    if len(self.peer_topics[sub_message.topicid]) == 1:
-                        del self.peer_topics[sub_message.topicid]
-                    else:
-                        self.peer_topics[sub_message.topicid].remove(origin_id)
+                    self.peer_topics[sub_message.topicid].remove(origin_id)
 
     # FIXME(mhchia): Change the function name?
     async def handle_talk(self, publish_message: rpc_pb2.Message) -> None:

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -24,7 +24,7 @@ class GossipsubParams(NamedTuple):
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5
-    heartbeat_initial_delay: int = 0.1
+    heartbeat_initial_delay: float = 0.1
     heartbeat_interval: float = 0.5
 
 

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -24,6 +24,7 @@ class GossipsubParams(NamedTuple):
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5
+    heartbeat_initial_delay: int = 0.1
     heartbeat_interval: float = 0.5
 
 

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -142,6 +142,7 @@ class GossipsubFactory(factory.Factory):
     time_to_live = GOSSIPSUB_PARAMS.time_to_live
     gossip_window = GOSSIPSUB_PARAMS.gossip_window
     gossip_history = GOSSIPSUB_PARAMS.gossip_history
+    heartbeat_initial_delay = GOSSIPSUB_PARAMS.heartbeat_initial_delay
     heartbeat_interval = GOSSIPSUB_PARAMS.heartbeat_interval
 
 

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -197,7 +197,7 @@ async def test_dense(num_hosts, pubsubs_gsub, hosts):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish("foobar", msg_content)
 
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.5)
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -161,9 +161,8 @@ async def test_handle_prune(pubsubs_gsub, hosts):
     # `emit_prune` does not remove bob from alice's mesh peers
     assert id_bob in gossipsubs[index_alice].mesh[topic]
 
-    # FIXME: This test currently works because the heartbeat interval
-    # is increased to 3 seconds, so alice won't get add back into
-    # bob's mesh peer during heartbeat.
+    # NOTE: We increase `heartbeat_interval` to 3 seconds so that bob will not
+    # add alice back to his mesh after heartbeat.
     # Wait for bob to `handle_prune`
     await asyncio.sleep(0.1)
 

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -197,7 +197,7 @@ async def test_dense(num_hosts, pubsubs_gsub, hosts):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish("foobar", msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1)
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -148,7 +148,7 @@ async def test_handle_prune(pubsubs_gsub, hosts):
 
     await connect(hosts[index_alice], hosts[index_bob])
 
-     # Wait for heartbeat to allow mesh to connect
+    # Wait for heartbeat to allow mesh to connect
     await asyncio.sleep(1)
 
     # Check that they are each other's mesh peer

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -149,7 +149,7 @@ async def test_handle_prune(pubsubs_gsub, hosts):
     await connect(hosts[index_alice], hosts[index_bob])
 
     # Wait 3 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(3)
+    await asyncio.sleep(1)
 
     # Check that they are each other's mesh peer
     assert id_alice in gossipsubs[index_bob].mesh[topic]
@@ -158,15 +158,17 @@ async def test_handle_prune(pubsubs_gsub, hosts):
     # alice emit prune message to bob, alice should be removed
     # from bob's mesh peer
     await gossipsubs[index_alice].emit_prune(topic, id_bob)
+    # `emit_prune` does not remove bob from alice's mesh peers
+    assert id_bob in gossipsubs[index_alice].mesh[topic]
 
     # FIXME: This test currently works because the heartbeat interval
     # is increased to 3 seconds, so alice won't get add back into
     # bob's mesh peer during heartbeat.
-    await asyncio.sleep(1)
+    # Wait for bob to `handle_prune`
+    await asyncio.sleep(0.1)
 
     # Check that alice is no longer bob's mesh peer
     assert id_alice not in gossipsubs[index_bob].mesh[topic]
-    assert id_bob in gossipsubs[index_alice].mesh[topic]
 
 
 @pytest.mark.parametrize("num_hosts", (10,))

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -148,7 +148,7 @@ async def test_handle_prune(pubsubs_gsub, hosts):
 
     await connect(hosts[index_alice], hosts[index_bob])
 
-    # Wait 3 seconds for heartbeat to allow mesh to connect
+     # Wait for heartbeat to allow mesh to connect
     await asyncio.sleep(1)
 
     # Check that they are each other's mesh peer


### PR DESCRIPTION
## How was it fixed?

Mainly refactoring the Gossipsub `heartbeat`.
- some refactors, remove unnecessary check and peer selection filter
- don't send the control messages at once but instead group the messages for the same peer and send it at the end of the heartbeat
- add tests for individual `mesh_heartbeat` and `gossip_heartbeat`

And some other bug fixes and remove outdated `TODO`s.

#### Cute Animal Picture


![](https://www.maxpixel.net/static/photo/2x/Mammals-Cute-Pet-Dog-Animal-Kingdom-Portrait-3071189.jpg)
(source: https://www.maxpixels.net/Mammals-Cute-Pet-Dog-Animal-Kingdom-Portrait-3071189)