### PR TITLE
Fix dependency issues (and fastecdsa windows depencency)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ extras_require = {
         "ipython",
         "setuptools>=36.2.0",
         "tox>=3.13.2,<4.0.0",
-        "eth_utils",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ extras_require = {
         "ipython",
         "setuptools>=36.2.0",
         "tox>=3.13.2,<4.0.0",
+        "eth_utils",
     ],
 }
 
@@ -42,6 +43,20 @@ extras_require["dev"] = (
     + extras_require["lint"]
     + extras_require["doc"]
 )
+
+fastecdsa = [
+    # No official fastecdsa==1.7.4,1.7.5 wheels for Windows, using a pypi package that includes
+    # the original library, but also windows-built wheels (32+64-bit) on those versions.
+    # Fixme: Remove section when fastecdsa has released a windows-compatible wheel
+    #  (specifically: both win32 and win_amd64 targets)
+    #  See the following issues for more information;
+    #  https://github.com/libp2p/py-libp2p/issues/363
+    #  https://github.com/AntonKueltz/fastecdsa/issues/11
+    "fastecdsa-any==1.7.5;sys_platform=='win32'",
+    # Wheels are provided for these platforms, or compiling one is minimally frustrating in a
+    # default python installation.
+    "fastecdsa==1.7.5;sys_platform!='win32'",
+]
 
 
 with open("./README.md") as readme:
@@ -67,7 +82,7 @@ install_requires = [
 # RTD system so we have to exclude these dependencies when we are in an RTD environment.
 readthedocs_is_building = os.environ.get("READTHEDOCS", False)
 if not readthedocs_is_building:
-    install_requires.append("fastecdsa==1.7.4")
+    install_requires.extend(fastecdsa)
 
 
 setup(


### PR DESCRIPTION
+add: `p2pclient, pexpect, eth_utils` to `setup.py`
+add: **custom `fastecdsa` strategy in regards to windows**
+bump: `fastecdsa` from `1.7.4` to `1.7.5`
(only changes are 2 lines over [here](https://github.com/AntonKueltz/fastecdsa/blob/73b9a9e0da38e544b3e643b9c99ed5badc8ada3b/fastecdsa/point.py#L70-L71), in `point.py`)

## What was wrong?

Default `pip install -e .[dev]` did not result in complete installation of all dependencies needed for normal development.

#363, windows installations and development fails because `fastecdsa` does not have a wheel, nor a easily-installable library by default.

## How was it fixed?

Adding 3 extra dependencies in `test` and `dev`, correspondent with:

    adding p2pclient, pexpect from tox.ini

    adding eth_utils from github issue template

Furthermore, adding a **modded version of `fastecdsa`** from https://github.com/shadowjonathan/fastecdsa-any when a windows platform is detected.

`fastecdsa` does currently not support nor build a windows wheel, but I have found a (probable) way to make installation succeed with the right libraries.

**Warning: this implementation is not tested, I am adding that modded version to this library exactly to test and find problems with a build, and if fastecdsa is viable for libp2p in the end.**
(see https://github.com/AntonKueltz/fastecdsa/issues/11)

Lastly, `fastecdsa` is bumped to `1.7.5` for uniformity with the modded windows version, a `diff` between the two versions revealed to me that [these two lines](https://github.com/AntonKueltz/fastecdsa/blob/73b9a9e0da38e544b3e643b9c99ed5badc8ada3b/fastecdsa/point.py#L70-L71) are the only things that changed between the versions. *Please test and verify if this does not break things.*

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history
- [ ] Extensive testing on windows platforms to justify inclusion of modded version
- [ ] Testing of `fastecdsa==1.7.5` on all platforms to assure nothing is broken

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/cZFoV6K.png)
