### PR TITLE
[minor] Prevent extras_require overlap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
         "sphinx_rtd_theme>=0.4.3,<=1",
         "towncrier>=19.2.0, <20",
     ],
-    "dev": [
+    "dev_core": [
         "bumpversion>=0.5.3,<1",
         "pytest-watch>=4.1.0,<5",
         "wheel",
@@ -37,7 +37,7 @@ extras_require = {
 }
 
 extras_require["dev"] = (
-    extras_require["dev"]
+    extras_require["dev_core"]
     + extras_require["test"]
     + extras_require["lint"]
     + extras_require["doc"]


### PR DESCRIPTION
## What was wrong?

`extras_require` in `setup.py` was defining `"dev"` as a list of requirements, but then redefinining and squashing it with all other extra requirements later on, with the *same key*.

## How was it fixed?

Rename `"dev"` from the list to `"dev_core"` (while keeping the squashed extras as `"dev"`), keeping everything bug-free.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/a1/77/ec/a177ecedcabae1ebcb103b3cba2bd7fb.jpg)

(a small cat for a small PR)
