### PR TITLE
fixes #197

### DIFF
--- a/libp2p/peer/id.py
+++ b/libp2p/peer/id.py
@@ -44,7 +44,7 @@ class ID:
     @property
     def xor_id(self) -> int:
         if not self._xor_id:
-            self._xor_id = int(digest(self._bytes).hex(), 16)
+            self._xor_id = int(sha256_digest(self._bytes).hex(), 16)
         return self._xor_id
 
     def to_bytes(self) -> bytes:
@@ -89,7 +89,7 @@ class ID:
         return cls(mh_digest.encode())
 
 
-def digest(data: Union[str, bytes]) -> bytes:
+def sha256_digest(data: Union[str, bytes]) -> bytes:
     if isinstance(data, str):
         data = data.encode("utf8")
-    return hashlib.sha1(data).digest()
+    return hashlib.sha256(data).digest()


### PR DESCRIPTION
## What was wrong?

Issue #197

## How was it fixed?

Change peerID digest algorithm to sha256 and clarify function language.

Note: This function should probably be moved to a general-use package like `tools` or something.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history
[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://mothership.sg/wp-content/uploads/2019/07/64730917_146623809844329_5045316776521807181_n.jpg)
