### PR TITLE
fixes #384

### DIFF
--- a/libp2p/exceptions.py
+++ b/libp2p/exceptions.py
@@ -8,3 +8,9 @@ class ValidationError(BaseLibp2pError):
 
 class ParseError(BaseLibp2pError):
     pass
+
+
+class MultiError(BaseLibp2pError):
+    """Raised with multiple exceptions."""
+
+    # todo: find some way for this to fancy-print all encapsulated errors

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -91,6 +91,9 @@ class Swarm(INetwork):
         except PeerStoreError as error:
             raise SwarmException(f"No known addresses to peer {peer_id}") from error
 
+        if not addrs:
+            raise SwarmException(f"No known addresses to peer {peer_id}")
+
         exceptions: List[SwarmException] = []
 
         # Try all known addresses
@@ -107,19 +110,10 @@ class Swarm(INetwork):
                 )
 
         # Tried all addresses, raising exception.
-        if len(exceptions) > 0:
-            raise SwarmException(
-                "unable to connect to %s, no addresses established a successful connection "
-                "(with exceptions)",
-                peer_id,
-            ) from MultiError(exceptions)
-        else:
-            raise SwarmException(
-                "unable to connect to %s, no addresses established a successful connection "
-                "(tried %d addresses)",
-                peer_id,
-                len(addrs),
-            )
+        raise SwarmException(
+            f"unable to connect to {peer_id}, no addresses established a successful connection "
+            "(with exceptions)",
+        ) from MultiError(exceptions)
 
     async def dial_addr(self, addr: Multiaddr, peer_id: ID) -> INetConn:
         """
@@ -138,7 +132,7 @@ class Swarm(INetwork):
         except OpenConnectionError as error:
             logger.debug("fail to dial peer %s over base transport", peer_id)
             raise SwarmException(
-                "fail to open connection to peer %s", peer_id
+                f"fail to open connection to peer {peer_id}"
             ) from error
 
         logger.debug("dialed peer %s over base transport", peer_id)

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -128,7 +128,7 @@ class Swarm(INetwork):
         :param addr: the address we want to connect with
         :param peer_id: the peer we want to connect to
         :raises SwarmException: raised when an error occurs
-        :return: muxed connection
+        :return: network connection
         """
 
         # Dial peer (connection to peer does not yet exist)

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -112,7 +112,7 @@ class Swarm(INetwork):
         # Tried all addresses, raising exception.
         raise SwarmException(
             f"unable to connect to {peer_id}, no addresses established a successful connection "
-            "(with exceptions)",
+            "(with exceptions)"
         ) from MultiError(exceptions)
 
     async def dial_addr(self, addr: Multiaddr, peer_id: ID) -> INetConn:

--- a/tests/network/test_swarm.py
+++ b/tests/network/test_swarm.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from multiaddr import Multiaddr
 import pytest
 
 from libp2p.network.exceptions import SwarmException
@@ -91,3 +92,59 @@ async def test_swarm_remove_conn(swarm_pair):
     # Test: Remove twice. There should not be errors.
     swarm_0.remove_conn(conn_0)
     assert swarm_1.get_peer_id() not in swarm_0.connections
+
+
+@pytest.mark.asyncio
+async def test_swarm_multiaddr(is_host_secure):
+    swarms = await SwarmFactory.create_batch_and_listen(is_host_secure, 3)
+
+    def clear():
+        swarms[0].peerstore.clear_addrs(swarms[1].get_peer_id())
+
+    clear()
+    # No addresses
+    with pytest.raises(SwarmException):
+        await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    clear()
+    # Wrong addresses
+    swarms[0].peerstore.add_addrs(
+        swarms[1].get_peer_id(), [Multiaddr("/ip4/0.0.0.0/tcp/9999")], 10000
+    )
+
+    with pytest.raises(SwarmException):
+        await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    clear()
+    # Multiple wrong addresses
+    swarms[0].peerstore.add_addrs(
+        swarms[1].get_peer_id(),
+        [Multiaddr("/ip4/0.0.0.0/tcp/9999"), Multiaddr("/ip4/0.0.0.0/tcp/9998")],
+        10000,
+    )
+
+    with pytest.raises(SwarmException):
+        await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    # Test one address
+    addrs = tuple(
+        addr
+        for transport in swarms[1].listeners.values()
+        for addr in transport.get_addrs()
+    )
+
+    swarms[0].peerstore.add_addrs(swarms[1].get_peer_id(), addrs[:1], 10000)
+    await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    # Test multiple addresses
+    addrs = tuple(
+        addr
+        for transport in swarms[1].listeners.values()
+        for addr in transport.get_addrs()
+    )
+
+    swarms[0].peerstore.add_addrs(swarms[1].get_peer_id(), addrs + addrs, 10000)
+    await swarms[0].dial_peer(swarms[1].get_peer_id())
+
+    for swarm in swarms:
+        await swarm.close()


### PR DESCRIPTION
    also adds MultiError to libp2p/exceptions.py

    and an additional fixme I have noticed

## What was wrong?

Issue #384

## How was it fixed?

Adding an `for .. in` iteration to the multiaddresses, also splitting the function into `dial_peer` and `dial_addr` for convenience and clarity.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://images-origin.wallwiz.link/589213fe35e2fb00012d3f81_1)
