### PR TITLE
Store peer ids in set instead of list and check if peer id exist before access

### DIFF
--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -89,6 +89,8 @@ class FloodSub(IPubsubRouter):
         logger.debug("publishing message %s", pubsub_msg)
 
         for peer_id in peers_gen:
+            if peer_id not in self.pubsub.peers:
+                continue
             stream = self.pubsub.peers[peer_id]
             # FIXME: We should add a `WriteMsg` similar to write delimited messages.
             #   Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/master/comm.go#L107

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -98,6 +98,7 @@ class FloodSub(IPubsubRouter):
                 await stream.write(encode_varint_prefixed(rpc_msg.SerializeToString()))
             except StreamClosed:
                 logger.debug("Fail to publish message to %s: stream closed", peer_id)
+                self.pubsub._handle_dead_peer(peer_id)
 
     async def join(self, topic: str) -> None:
         """

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -77,10 +77,12 @@ class FloodSub(IPubsubRouter):
         :param pubsub_msg: pubsub message in protobuf.
         """
 
-        peers_gen = self._get_peers_to_send(
-            pubsub_msg.topicIDs,
-            msg_forwarder=msg_forwarder,
-            origin=ID(pubsub_msg.from_id),
+        peers_gen = set(
+            self._get_peers_to_send(
+                pubsub_msg.topicIDs,
+                msg_forwarder=msg_forwarder,
+                origin=ID(pubsub_msg.from_id),
+            )
         )
         rpc_msg = rpc_pb2.RPC(publish=[pubsub_msg])
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -148,11 +148,9 @@ class GossipSub(IPubsubRouter):
 
         for topic in self.mesh:
             if peer_id in self.mesh[topic]:
-                # Delete the entry if no other peers left
                 self.mesh[topic].remove(peer_id)
         for topic in self.fanout:
             if peer_id in self.fanout[topic]:
-                # Delete the entry if no other peers left
                 self.fanout[topic].remove(peer_id)
 
         self.peers_to_protocol.pop(peer_id, None)

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -121,7 +121,7 @@ class GossipSub(IPubsubRouter):
             #   instance in multistream-select, but it is not the protocol that gossipsub supports.
             #   In this case, probably we registered gossipsub to a wrong `protocol_id`
             #   in multistream-select, or wrong versions.
-             raise ValueError(f"Protocol={protocol_id} is not supported.")
+            raise ValueError(f"Protocol={protocol_id} is not supported.")
         self.peer_protocol[peer_id] = protocol_id
 
     def remove_peer(self, peer_id: ID) -> None:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -719,7 +719,9 @@ class GossipSub(IPubsubRouter):
 
         # Get stream for peer from pubsub
         if to_peer not in self.pubsub.peers:
-            logger.debug("Fail to emit control message to %s: peer disconnected", to_peer)
+            logger.debug(
+                "Fail to emit control message to %s: peer disconnected", to_peer
+            )
             return
         peer_stream = self.pubsub.peers[to_peer]
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -121,7 +121,7 @@ class GossipSub(IPubsubRouter):
             #   instance in multistream-select, but it is not the protocol that gossipsub supports.
             #   In this case, probably we registered gossipsub to a wrong `protocol_id`
             #   in multistream-select, or wrong versions.
-            raise Exception(f"Unreachable: Protocol={protocol_id} is not supported.")
+             raise ValueError(f"Protocol={protocol_id} is not supported.")
         self.peer_protocol[peer_id] = protocol_id
 
     def remove_peer(self, peer_id: ID) -> None:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -588,7 +588,7 @@ class GossipSub(IPubsubRouter):
         # 3) Get the stream to this peer
         if sender_peer_id not in self.pubsub.peers:
             logger.debug(
-                "Fail to responed to iwant request from %s: peer disconnected",
+                "Fail to responed to iwant request from %s: peer record not exist",
                 sender_peer_id,
             )
             return
@@ -700,7 +700,7 @@ class GossipSub(IPubsubRouter):
         # Get stream for peer from pubsub
         if to_peer not in self.pubsub.peers:
             logger.debug(
-                "Fail to emit control message to %s: peer disconnected", to_peer
+                "Fail to emit control message to %s: peer record not exist", to_peer
             )
             return
         peer_stream = self.pubsub.peers[to_peer]

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -611,6 +611,7 @@ class GossipSub(IPubsubRouter):
                 "Fail to responed to iwant request from %s: peer disconnected",
                 sender_peer_id,
             )
+            return
         peer_stream = self.pubsub.peers[sender_peer_id]
 
         # 4) And write the packet to the stream
@@ -719,6 +720,7 @@ class GossipSub(IPubsubRouter):
         # Get stream for peer from pubsub
         if to_peer not in self.pubsub.peers:
             logger.debug("Fail to emit control message to %s: peer disconnected", to_peer)
+            return
         peer_stream = self.pubsub.peers[to_peer]
 
         # Write rpc to stream

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -193,6 +193,8 @@ class GossipSub(IPubsubRouter):
         logger.debug("publishing message %s", pubsub_msg)
 
         for peer_id in peers_gen:
+            if peer_id not in self.pubsub.peers:
+                continue
             stream = self.pubsub.peers[peer_id]
             # FIXME: We should add a `WriteMsg` similar to write delimited messages.
             #   Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/master/comm.go#L107
@@ -604,6 +606,11 @@ class GossipSub(IPubsubRouter):
         rpc_msg: bytes = packet.SerializeToString()
 
         # 3) Get the stream to this peer
+        if sender_peer_id not in self.pubsub.peers:
+            logger.debug(
+                "Fail to responed to iwant request from %s: peer disconnected",
+                sender_peer_id,
+            )
         peer_stream = self.pubsub.peers[sender_peer_id]
 
         # 4) And write the packet to the stream
@@ -710,6 +717,8 @@ class GossipSub(IPubsubRouter):
         rpc_msg: bytes = packet.SerializeToString()
 
         # Get stream for peer from pubsub
+        if to_peer not in self.pubsub.peers:
+            logger.debug("Fail to emit control message to %s: peer disconnected", to_peer)
         peer_stream = self.pubsub.peers[to_peer]
 
         # Write rpc to stream

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -351,7 +351,7 @@ class Pubsub:
         """
         if sub_message.subscribe:
             if sub_message.topicid not in self.peer_topics:
-                self.peer_topics[sub_message.topicid] = [origin_id]
+                self.peer_topics[sub_message.topicid] = set([origin_id])
             elif origin_id not in self.peer_topics[sub_message.topicid]:
                 # Add peer to topic
                 self.peer_topics[sub_message.topicid].add(origin_id)

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     List,
     NamedTuple,
+    Set,
     Tuple,
     Union,
     cast,
@@ -73,7 +74,7 @@ class Pubsub:
 
     my_topics: Dict[str, "asyncio.Queue[rpc_pb2.Message]"]
 
-    peer_topics: Dict[str, List[ID]]
+    peer_topics: Dict[str, Set[ID]]
     peers: Dict[ID, INetStream]
 
     topic_validators: Dict[str, TopicValidator]
@@ -314,7 +315,7 @@ class Pubsub:
 
         for topic in self.peer_topics:
             if peer_id in self.peer_topics[topic]:
-                self.peer_topics[topic].remove(peer_id)
+                self.peer_topics[topic].discard(peer_id)
 
         self.router.remove_peer(peer_id)
 
@@ -353,11 +354,11 @@ class Pubsub:
                 self.peer_topics[sub_message.topicid] = [origin_id]
             elif origin_id not in self.peer_topics[sub_message.topicid]:
                 # Add peer to topic
-                self.peer_topics[sub_message.topicid].append(origin_id)
+                self.peer_topics[sub_message.topicid].add(origin_id)
         else:
             if sub_message.topicid in self.peer_topics:
                 if origin_id in self.peer_topics[sub_message.topicid]:
-                    self.peer_topics[sub_message.topicid].remove(origin_id)
+                    self.peer_topics[sub_message.topicid].discard(origin_id)
 
     # FIXME(mhchia): Change the function name?
     async def handle_talk(self, publish_message: rpc_pb2.Message) -> None:

--- a/newsfragments/387.bugfix.rst
+++ b/newsfragments/387.bugfix.rst
@@ -1,0 +1,1 @@
+Store peer ids in ``set`` instead of ``list`` and check if peer id exists in ``dict`` before accessing to prevent ``KeyError``.

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -390,15 +390,15 @@ async def test_mesh_heartbeat(
     fake_peer_ids = [
         ID((i).to_bytes(2, byteorder="big")) for i in range(total_peer_count)
     ]
-    monkeypatch.setattr(pubsubs_gsub[0].router, "peers_gossipsub", fake_peer_ids)
+    monkeypatch.setattr(pubsubs_gsub[0].router, "peers_gossipsub", set(fake_peer_ids))
 
-    peer_topics = {topic: fake_peer_ids}
+    peer_topics = {topic: set(fake_peer_ids)}
     # Monkeypatch the peer subscriptions
     monkeypatch.setattr(pubsubs_gsub[0], "peer_topics", peer_topics)
 
     mesh_peer_indices = random.sample(range(total_peer_count), initial_mesh_peer_count)
     mesh_peers = [fake_peer_ids[i] for i in mesh_peer_indices]
-    router_mesh = {topic: list(mesh_peers)}
+    router_mesh = {topic: set(mesh_peers)}
     # Monkeypatch our mesh peers
     monkeypatch.setattr(pubsubs_gsub[0].router, "mesh", router_mesh)
 
@@ -437,27 +437,27 @@ async def test_gossip_heartbeat(
     fake_peer_ids = [
         ID((i).to_bytes(2, byteorder="big")) for i in range(total_peer_count)
     ]
-    monkeypatch.setattr(pubsubs_gsub[0].router, "peers_gossipsub", fake_peer_ids)
+    monkeypatch.setattr(pubsubs_gsub[0].router, "peers_gossipsub", set(fake_peer_ids))
 
     topic_mesh_peer_count = 14
     # Split into mesh peers and fanout peers
     peer_topics = {
-        topic_mesh: fake_peer_ids[:topic_mesh_peer_count],
-        topic_fanout: fake_peer_ids[topic_mesh_peer_count:],
+        topic_mesh: set(fake_peer_ids[:topic_mesh_peer_count]),
+        topic_fanout: set(fake_peer_ids[topic_mesh_peer_count:]),
     }
     # Monkeypatch the peer subscriptions
     monkeypatch.setattr(pubsubs_gsub[0], "peer_topics", peer_topics)
 
     mesh_peer_indices = random.sample(range(topic_mesh_peer_count), initial_peer_count)
     mesh_peers = [fake_peer_ids[i] for i in mesh_peer_indices]
-    router_mesh = {topic_mesh: list(mesh_peers)}
+    router_mesh = {topic_mesh: set(mesh_peers)}
     # Monkeypatch our mesh peers
     monkeypatch.setattr(pubsubs_gsub[0].router, "mesh", router_mesh)
     fanout_peer_indices = random.sample(
         range(topic_mesh_peer_count, total_peer_count), initial_peer_count
     )
     fanout_peers = [fake_peer_ids[i] for i in fanout_peer_indices]
-    router_fanout = {topic_fanout: list(fanout_peers)}
+    router_fanout = {topic_fanout: set(fanout_peers)}
     # Monkeypatch our fanout peers
     monkeypatch.setattr(pubsubs_gsub[0].router, "fanout", router_fanout)
 

--- a/tests_interop/test_pubsub.py
+++ b/tests_interop/test_pubsub.py
@@ -99,7 +99,7 @@ async def test_pubsub(pubsubs, p2pds):
     go_0_topic_1_peers = await p2pds[0].control.pubsub_list_peers(TOPIC_1)
     assert len(go_0_topic_1_peers) == 1 and py_peer_id == go_0_topic_1_peers[0]
     # py
-    py_topic_0_peers = py_pubsub.peer_topics[TOPIC_0]
+    py_topic_0_peers = list(py_pubsub.peer_topics[TOPIC_0])
     assert len(py_topic_0_peers) == 1 and p2pds[0].peer_id == py_topic_0_peers[0]
     # go_1
     go_1_topic_1_peers = await p2pds[1].control.pubsub_list_peers(TOPIC_1)


### PR DESCRIPTION
## What was wrong?

Possible issue: https://github.com/ethereum/trinity/issues/1395

## How was it fixed?

- store peer ids in set so there's no duplicated peer id due to re-adding peer.
- check if peer id exist in the dict before accessing.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://p1.pxfuel.com/preview/592/841/255/tender-cute-animal-cute-cats-cat.jpg)
