### PR TITLE
Remove all asyncio.sleep statements from tests

### DIFF
--- a/tests/examples/test_chat.py
+++ b/tests/examples/test_chat.py
@@ -47,7 +47,7 @@ async def connect_write(host_a, host_b):
         await stream.write(message.encode())
 
     # Reader needs time due to async reads
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     await stream.close()
     assert received == messages

--- a/tests/host/test_ping.py
+++ b/tests/host/test_ping.py
@@ -33,5 +33,5 @@ async def test_ping_several():
             # NOTE: simulate some time to sleep to mirror a real
             # world usage where a peer sends pings on some periodic interval
             # NOTE: this interval can be `0` for this test.
-            await asyncio.sleep(0)
+            await asyncio.sleep(0)  # todo: remove sleep or justify existence
         await stream.close()

--- a/tests/network/test_net_stream.py
+++ b/tests/network/test_net_stream.py
@@ -34,17 +34,17 @@ async def test_net_stream_read_until_eof(net_stream_pair):
     # Test: `read` doesn't return before `close` is called.
     await stream_0.write(DATA)
     expected_data.extend(DATA)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(read_bytes) == 0
     # Test: `read` doesn't return before `close` is called.
     await stream_0.write(DATA)
     expected_data.extend(DATA)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(read_bytes) == 0
 
     # Test: Close the stream, `read` returns, and receive previous sent data.
     await stream_0.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert read_bytes == expected_data
 
     task.cancel()
@@ -55,7 +55,7 @@ async def test_net_stream_read_after_remote_closed(net_stream_pair):
     stream_0, stream_1 = net_stream_pair
     await stream_0.write(DATA)
     await stream_0.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert (await stream_1.read(MAX_READ_LEN)) == DATA
     with pytest.raises(StreamEOF):
         await stream_1.read(MAX_READ_LEN)
@@ -75,7 +75,7 @@ async def test_net_stream_read_after_remote_reset(net_stream_pair):
     await stream_0.write(DATA)
     await stream_0.reset()
     # Sleep to let `stream_1` receive the message.
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     with pytest.raises(StreamReset):
         await stream_1.read(MAX_READ_LEN)
 
@@ -87,7 +87,7 @@ async def test_net_stream_read_after_remote_closed_and_reset(net_stream_pair):
     await stream_0.close()
     await stream_0.reset()
     # Sleep to let `stream_1` receive the message.
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert (await stream_1.read(MAX_READ_LEN)) == DATA
 
 
@@ -112,6 +112,6 @@ async def test_net_stream_write_after_local_reset(net_stream_pair):
 async def test_net_stream_write_after_remote_reset(net_stream_pair):
     stream_0, stream_1 = net_stream_pair
     await stream_1.reset()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     with pytest.raises(StreamClosed):
         await stream_0.write(DATA)

--- a/tests/network/test_notify.py
+++ b/tests/network/test_notify.py
@@ -77,21 +77,21 @@ async def test_notify(is_host_secure):
     # OpenedStream: third, but different direction.
     await swarms[1].new_stream(swarms[0].get_peer_id())
 
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     # TODO: Check `ClosedStream` and `ListenClose` events after they are ready.
 
     # Disconnected
     await swarms[0].close_peer(swarms[1].get_peer_id())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     # Connected again, but different direction.
     await connect_swarm(swarms[1], swarms[0])
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     # Disconnected again, but different direction.
     await swarms[1].close_peer(swarms[0].get_peer_id())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     expected_events_without_listen = [
         Event.Connected,

--- a/tests/network/test_swarm.py
+++ b/tests/network/test_swarm.py
@@ -49,7 +49,7 @@ async def test_swarm_close_peer(is_host_secure):
 
     # peer 1 closes peer 0
     await swarms[1].close_peer(swarms[0].get_peer_id())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     # 0  1 <> 2
     assert len(swarms[0].connections) == 0
     assert (
@@ -59,7 +59,7 @@ async def test_swarm_close_peer(is_host_secure):
 
     # peer 1 is closed by peer 2
     await swarms[2].close_peer(swarms[1].get_peer_id())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     # 0  1  2
     assert len(swarms[1].connections) == 0 and len(swarms[2].connections) == 0
 
@@ -75,7 +75,7 @@ async def test_swarm_close_peer(is_host_secure):
     )
     # peer 0 closes peer 1
     await swarms[0].close_peer(swarms[1].get_peer_id())
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     # 0  1  2
     assert len(swarms[1].connections) == 0 and len(swarms[2].connections) == 0
 

--- a/tests/network/test_swarm_conn.py
+++ b/tests/network/test_swarm_conn.py
@@ -12,7 +12,7 @@ async def test_swarm_conn_close(swarm_conn_pair):
 
     await conn_0.close()
 
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     assert conn_0.event_closed.is_set()
     assert conn_1.event_closed.is_set()
@@ -28,12 +28,12 @@ async def test_swarm_conn_streams(swarm_conn_pair):
     assert len(await conn_1.get_streams()) == 0
 
     stream_0_0 = await conn_0.new_stream()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(await conn_0.get_streams()) == 1
     assert len(await conn_1.get_streams()) == 1
 
     stream_0_1 = await conn_0.new_stream()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(await conn_0.get_streams()) == 2
     assert len(await conn_1.get_streams()) == 2
 

--- a/tests/pubsub/test_dummyaccount_demo.py
+++ b/tests/pubsub/test_dummyaccount_demo.py
@@ -40,7 +40,7 @@ async def perform_test(num_nodes, adjacency_map, action_func, assertion_func):
             )
 
     # Allow time for network creation to take place
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     # Start a thread for each node so that each node can listen and respond
     # to messages on its own thread, which will avoid waiting indefinitely
@@ -51,13 +51,13 @@ async def perform_test(num_nodes, adjacency_map, action_func, assertion_func):
         thread.run()
 
     # Allow time for nodes to subscribe to CRYPTO_TOPIC topic
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     # Perform action function
     await action_func(dummy_nodes)
 
     # Allow time for action function to be performed (i.e. messages to propogate)
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
 
     # Perform assertion function
     for dummy_node in dummy_nodes:
@@ -129,7 +129,7 @@ async def test_set_then_send_from_root_seven_nodes_tree_topography():
 
     async def action_func(dummy_nodes):
         await dummy_nodes[0].publish_set_crypto("aspyn", 20)
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
         await dummy_nodes[0].publish_send_crypto("aspyn", "alex", 5)
 
     def assertion_func(dummy_node):
@@ -146,7 +146,7 @@ async def test_set_then_send_from_different_leafs_seven_nodes_tree_topography():
 
     async def action_func(dummy_nodes):
         await dummy_nodes[6].publish_set_crypto("aspyn", 20)
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
         await dummy_nodes[4].publish_send_crypto("aspyn", "alex", 5)
 
     def assertion_func(dummy_node):
@@ -177,7 +177,7 @@ async def test_set_then_send_from_diff_nodes_five_nodes_ring_topography():
 
     async def action_func(dummy_nodes):
         await dummy_nodes[0].publish_set_crypto("alex", 20)
-        await asyncio.sleep(0.25)
+        await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
         await dummy_nodes[3].publish_send_crypto("alex", "rob", 12)
 
     def assertion_func(dummy_node):
@@ -195,13 +195,13 @@ async def test_set_then_send_from_five_diff_nodes_five_nodes_ring_topography():
 
     async def action_func(dummy_nodes):
         await dummy_nodes[0].publish_set_crypto("alex", 20)
-        await asyncio.sleep(1)
+        await asyncio.sleep(1)  # todo: remove sleep or justify existence
         await dummy_nodes[1].publish_send_crypto("alex", "rob", 3)
-        await asyncio.sleep(1)
+        await asyncio.sleep(1)  # todo: remove sleep or justify existence
         await dummy_nodes[2].publish_send_crypto("rob", "aspyn", 2)
-        await asyncio.sleep(1)
+        await asyncio.sleep(1)  # todo: remove sleep or justify existence
         await dummy_nodes[3].publish_send_crypto("aspyn", "zx", 1)
-        await asyncio.sleep(1)
+        await asyncio.sleep(1)  # todo: remove sleep or justify existence
         await dummy_nodes[4].publish_send_crypto("zx", "raul", 1)
 
     def assertion_func(dummy_node):

--- a/tests/pubsub/test_floodsub.py
+++ b/tests/pubsub/test_floodsub.py
@@ -18,11 +18,11 @@ async def test_simple_two_nodes(pubsubs_fsub):
     data = b"some data"
 
     await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     sub_b = await pubsubs_fsub[1].subscribe(topic)
     # Sleep to let a know of b's subscription
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     await pubsubs_fsub[0].publish(topic, data)
 
@@ -59,10 +59,10 @@ async def test_lru_cache_two_nodes(pubsubs_fsub, monkeypatch):
     monkeypatch.setattr(libp2p.pubsub.pubsub, "get_msg_id", get_msg_id)
 
     await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     sub_b = await pubsubs_fsub[1].subscribe(topic)
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     def _make_testing_data(i: int) -> bytes:
         num_int_bytes = 4
@@ -72,7 +72,7 @@ async def test_lru_cache_two_nodes(pubsubs_fsub, monkeypatch):
 
     for index in message_indices:
         await pubsubs_fsub[0].publish(topic, _make_testing_data(index))
-    await asyncio.sleep(0.25)
+    await asyncio.sleep(0.25)  # todo: remove sleep or justify existence
 
     for index in expected_received_indices:
         res_b = await sub_b.get()

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -34,7 +34,7 @@ async def test_join(num_hosts, hosts, pubsubs_gsub):
     await one_to_all_connect(hosts, central_node_index)
 
     # Wait 2 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # Central node publish to the topic so that this topic
     # is added to central node's fanout
@@ -49,7 +49,7 @@ async def test_join(num_hosts, hosts, pubsubs_gsub):
     # Central node subscribes the topic
     await pubsubs_gsub[central_node_index].subscribe(topic)
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # Check that the gossipsub of central node no longer has fanout for the topic
     assert topic not in gossipsubs[central_node_index].fanout
@@ -93,7 +93,7 @@ async def test_handle_graft(pubsubs_gsub, hosts, event_loop, monkeypatch):
     await connect(hosts[index_alice], hosts[index_bob])
 
     # Wait 2 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     topic = "test_handle_graft"
     # Only lice subscribe to the topic
@@ -125,7 +125,7 @@ async def test_handle_graft(pubsubs_gsub, hosts, event_loop, monkeypatch):
 
     await gossipsubs[index_bob].emit_graft(topic, id_alice)
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
 
     # Check that bob is now alice's mesh peer
     assert id_bob in gossipsubs[index_alice].mesh[topic]
@@ -150,7 +150,7 @@ async def test_handle_prune(pubsubs_gsub, hosts):
     await connect(hosts[index_alice], hosts[index_bob])
 
     # Wait for heartbeat to allow mesh to connect
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
 
     # Check that they are each other's mesh peer
     assert id_alice in gossipsubs[index_bob].mesh[topic]
@@ -165,7 +165,7 @@ async def test_handle_prune(pubsubs_gsub, hosts):
     # NOTE: We increase `heartbeat_interval` to 3 seconds so that bob will not
     # add alice back to his mesh after heartbeat.
     # Wait for bob to `handle_prune`
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)  # todo: remove sleep or justify existence
 
     # Check that alice is no longer bob's mesh peer
     assert id_alice not in gossipsubs[index_bob].mesh[topic]
@@ -188,7 +188,7 @@ async def test_dense(num_hosts, pubsubs_gsub, hosts):
     await dense_connect(hosts)
 
     # Wait 2 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     for i in range(num_msgs):
         msg_content = b"foo " + i.to_bytes(1, "big")
@@ -199,7 +199,7 @@ async def test_dense(num_hosts, pubsubs_gsub, hosts):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish("foobar", msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)  # todo: remove sleep or justify existence
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()
@@ -223,7 +223,7 @@ async def test_fanout(hosts, pubsubs_gsub):
     await dense_connect(hosts)
 
     # Wait 2 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     topic = "foobar"
     # Send messages with origin not subscribed
@@ -236,7 +236,7 @@ async def test_fanout(hosts, pubsubs_gsub):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)  # todo: remove sleep or justify existence
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()
@@ -255,7 +255,7 @@ async def test_fanout(hosts, pubsubs_gsub):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)  # todo: remove sleep or justify existence
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()
@@ -281,7 +281,7 @@ async def test_fanout_maintenance(hosts, pubsubs_gsub):
     await dense_connect(hosts)
 
     # Wait 2 seconds for heartbeat to allow mesh to connect
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # Send messages with origin not subscribed
     for i in range(num_msgs):
@@ -293,7 +293,7 @@ async def test_fanout_maintenance(hosts, pubsubs_gsub):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)  # todo: remove sleep or justify existence
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()
@@ -304,7 +304,7 @@ async def test_fanout_maintenance(hosts, pubsubs_gsub):
 
     queues = []
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # Resub and repeat
     for i in range(1, len(pubsubs_gsub)):
@@ -313,7 +313,7 @@ async def test_fanout_maintenance(hosts, pubsubs_gsub):
         # Add each blocking queue to an array of blocking queues
         queues.append(q)
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # Check messages can still be sent
     for i in range(num_msgs):
@@ -325,7 +325,7 @@ async def test_fanout_maintenance(hosts, pubsubs_gsub):
         # publish from the randomly chosen host
         await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.5)  # todo: remove sleep or justify existence
         # Assert that all blocking queues receive the message
         for queue in queues:
             msg = await queue.get()
@@ -364,7 +364,7 @@ async def test_gossip_propagation(hosts, pubsubs_gsub):
     await connect(hosts[0], hosts[1])
 
     # wait for gossip heartbeat
-    await asyncio.sleep(2)
+    await asyncio.sleep(2)  # todo: remove sleep or justify existence
 
     # should be able to read message
     msg = await queue_1.get()

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -58,11 +58,11 @@ async def test_peers_subscribe(pubsubs_fsub):
     await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
     await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
     # Yield to let 0 notify 1
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
     assert pubsubs_fsub[0].my_id in pubsubs_fsub[1].peer_topics[TESTING_TOPIC]
     await pubsubs_fsub[0].unsubscribe(TESTING_TOPIC)
     # Yield to let 0 notify 1
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
     assert pubsubs_fsub[0].my_id not in pubsubs_fsub[1].peer_topics[TESTING_TOPIC]
 
 
@@ -474,7 +474,7 @@ async def test_push_msg(pubsubs_fsub, monkeypatch):
     #   `router_publish` is not called then.
     event.clear()
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg_0)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert not event.is_set()
 
     sub = await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
@@ -509,7 +509,7 @@ async def test_push_msg(pubsubs_fsub, monkeypatch):
 
     event.clear()
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg_2)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert not event.is_set()
 
 
@@ -519,10 +519,10 @@ async def test_strict_signing(pubsubs_fsub, hosts):
     await connect(hosts[0], hosts[1])
     await pubsubs_fsub[0].subscribe(TESTING_TOPIC)
     await pubsubs_fsub[1].subscribe(TESTING_TOPIC)
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
 
     await pubsubs_fsub[0].publish(TESTING_TOPIC, TESTING_DATA)
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # todo: remove sleep or justify existence
 
     assert len(pubsubs_fsub[0].seen_messages) == 1
     assert len(pubsubs_fsub[1].seen_messages) == 1
@@ -555,26 +555,26 @@ async def test_strict_signing_failed_validation(pubsubs_fsub, hosts, monkeypatch
 
     # Test: no signature attached in `msg`
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert not event.is_set()
 
     # Test: `msg.key` does not match `msg.from_id`
     msg.key = hosts[1].get_public_key().serialize()
     msg.signature = signature
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert not event.is_set()
 
     # Test: invalid signature
     msg.key = hosts[0].get_public_key().serialize()
     msg.signature = b"\x12" * 100
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert not event.is_set()
 
     # Finally, assert the signature indeed will pass validation
     msg.key = hosts[0].get_public_key().serialize()
     msg.signature = signature
     await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert event.is_set()

--- a/tests/security/test_security_multistream.py
+++ b/tests/security/test_security_multistream.py
@@ -46,7 +46,7 @@ async def perform_simple_test(
     # Wait a very short period to allow conns to be stored (since the functions
     # storing the conns are async, they may happen at slightly different times
     # on each node)
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)  # todo: remove sleep or justify existence
 
     # Get conns
     node1_conn = node1.get_network().connections[peer_id_for_node(node2)]

--- a/tests/stream_muxer/test_mplex_conn.py
+++ b/tests/stream_muxer/test_mplex_conn.py
@@ -16,19 +16,19 @@ async def test_mplex_conn(mplex_conn_pair):
 
     # Test: Open a stream, and both side get 1 more stream.
     stream_0 = await conn_0.open_stream()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(conn_0.streams) == 1
     assert len(conn_1.streams) == 1
     # Test: From another side.
     stream_1 = await conn_1.open_stream()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(conn_0.streams) == 2
     assert len(conn_1.streams) == 2
 
     # Close from one side.
     await conn_0.close()
     # Sleep for a while for both side to handle `close`.
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     # Test: Both side is closed.
     assert conn_0.event_shutting_down.is_set()
     assert conn_0.event_closed.is_set()

--- a/tests/stream_muxer/test_mplex_stream.py
+++ b/tests/stream_muxer/test_mplex_stream.py
@@ -34,17 +34,17 @@ async def test_mplex_stream_pair_read_until_eof(mplex_stream_pair):
     # Test: `read` doesn't return before `close` is called.
     await stream_0.write(DATA)
     expected_data.extend(DATA)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(read_bytes) == 0
     # Test: `read` doesn't return before `close` is called.
     await stream_0.write(DATA)
     expected_data.extend(DATA)
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert len(read_bytes) == 0
 
     # Test: Close the stream, `read` returns, and receive previous sent data.
     await stream_0.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert read_bytes == expected_data
 
     task.cancel()
@@ -56,7 +56,7 @@ async def test_mplex_stream_read_after_remote_closed(mplex_stream_pair):
     assert not stream_1.event_remote_closed.is_set()
     await stream_0.write(DATA)
     await stream_0.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert stream_1.event_remote_closed.is_set()
     assert (await stream_1.read(MAX_READ_LEN)) == DATA
     with pytest.raises(MplexStreamEOF):
@@ -77,7 +77,7 @@ async def test_mplex_stream_read_after_remote_reset(mplex_stream_pair):
     await stream_0.write(DATA)
     await stream_0.reset()
     # Sleep to let `stream_1` receive the message.
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     with pytest.raises(MplexStreamReset):
         await stream_1.read(MAX_READ_LEN)
 
@@ -89,7 +89,7 @@ async def test_mplex_stream_read_after_remote_closed_and_reset(mplex_stream_pair
     await stream_0.close()
     await stream_0.reset()
     # Sleep to let `stream_1` receive the message.
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     assert (await stream_1.read(MAX_READ_LEN)) == DATA
 
 
@@ -114,7 +114,7 @@ async def test_mplex_stream_write_after_local_reset(mplex_stream_pair):
 async def test_mplex_stream_write_after_remote_reset(mplex_stream_pair):
     stream_0, stream_1 = mplex_stream_pair
     await stream_1.reset()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     with pytest.raises(MplexStreamClosed):
         await stream_0.write(DATA)
 
@@ -133,7 +133,7 @@ async def test_mplex_stream_both_close(mplex_stream_pair):
 
     # Test: Close one side.
     await stream_0.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     assert stream_0.event_local_closed.is_set()
     assert not stream_1.event_local_closed.is_set()
@@ -145,7 +145,7 @@ async def test_mplex_stream_both_close(mplex_stream_pair):
 
     # Test: Close the other side.
     await stream_1.close()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
     # Both sides are closed.
     assert stream_0.event_local_closed.is_set()
     assert stream_1.event_local_closed.is_set()
@@ -163,7 +163,7 @@ async def test_mplex_stream_both_close(mplex_stream_pair):
 async def test_mplex_stream_reset(mplex_stream_pair):
     stream_0, stream_1 = mplex_stream_pair
     await stream_0.reset()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)  # todo: remove sleep or justify existence
 
     # Both sides are closed.
     assert stream_0.event_local_closed.is_set()


### PR DESCRIPTION
## What was wrong?

Currently nearly all tests under `tests/` arbitrarily wait with `asyncio.sleep(0.01)` (or a greater number) to effectively hide the race conditions that some underlying library code are intentionally or unintentionally making for the tests, or to loop through one event loop iteration.

Talking to @mhchia while going through tests and making tests available to windows (in preparation for after #380), it's been agreed to remove these `sleep` statements and replace them with logic that cascades only when a specific requisite for that tests has been asynchronously set in place. (actual test intentions will also be written in docstring, if not clear)

## Why is this change needed?

`asyncio.sleep()` delays per wall clock, it:
1. Does not care what it's underlying system clock speed is, tests could heavily differ per machine speed.
2. Waits *arbitrarily*, it does not wait for the *specific hinted requisite/state* that that tests needs from the event loop before continuing.

### To-Do

- [ ] Work through all todo items and clear up sleep statement per test.
- [ ] Confirm testing works as intended

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://static.independent.co.uk/s3fs-public/thumbnails/image/2016/09/05/10/cubs9.jpg)
