### PR TITLE
Cherry-pick changes mentioned from #389 into transport/tcp.py

### DIFF
--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -1,9 +1,11 @@
 import asyncio
-from socket import socket
+import socket
 import sys
-from typing import List
+from typing import List, Optional
 
 from multiaddr import Multiaddr
+from multiaddr.protocols import P_IP4, P_IP6, P_TCP, P_UDP
+from multiaddr.protocols import protocol_with_code as p_code
 
 from libp2p.network.connection.raw_connection import RawConnection
 from libp2p.network.connection.raw_connection_interface import IRawConnection
@@ -29,10 +31,14 @@ class TCPListener(IListener):
         :param maddr: maddr of peer
         :return: return True if successful
         """
+        listen_addr = _ip4_or_6_from_multiaddr(maddr)
+        if listen_addr is None:
+            raise NotImplementedError(
+                "Can only start TCP Listener with a IPv4 or IPv6 address"
+            )
+
         self.server = await asyncio.start_server(
-            self.handler,
-            maddr.value_for_protocol("ip4"),
-            maddr.value_for_protocol("tcp"),
+            self.handler, listen_addr, maddr.value_for_protocol("tcp")
         )
         socket = self.server.sockets[0]
         self.multiaddrs.append(_multiaddr_from_socket(socket))
@@ -70,7 +76,10 @@ class TCP(ITransport):
         :return: `RawConnection` if successful
         :raise OpenConnectionError: raised when failed to open connection
         """
-        self.host = maddr.value_for_protocol("ip4")
+        self.host = _ip4_or_6_from_multiaddr(maddr)
+        if self.host is None:
+            raise ValueError("Cannot find ipv4 or ipv6 host in multiaddress")
+
         self.port = int(maddr.value_for_protocol("tcp"))
 
         try:
@@ -91,5 +100,52 @@ class TCP(ITransport):
         return TCPListener(handler_function)
 
 
-def _multiaddr_from_socket(socket: socket) -> Multiaddr:
-    return Multiaddr("/ip4/%s/tcp/%s" % socket.getsockname())
+def _ip4_or_6_from_multiaddr(maddr: Multiaddr) -> Optional[str]:
+    if P_IP4 in maddr.protocols():
+        return maddr.value_for_protocol(P_IP4)
+    elif P_IP6 in maddr.protocols():
+        return maddr.value_for_protocol(P_IP6)
+    else:
+        return None
+
+
+def _multiaddr_from_socket(sock: socket.socket) -> Multiaddr:
+    # Reference: http://man7.org/linux/man-pages/man2/socket.2.html#DESCRIPTION
+    # todo: move this to more generic libp2p.transport helper function
+
+    # Reference: https://stackoverflow.com/questions/5815675/what-is-sock-dgram-and-sock-stream
+    # Selects first protocol in sequence if bitwise AND matches, else None
+    t_proto = next(
+        (
+            v
+            for k, v in {
+                socket.SOCK_STREAM: p_code(P_TCP).name,
+                socket.SOCK_DGRAM: p_code(P_UDP).name,
+            }.items()
+            if k & sock.type != 0
+        ),
+        None,
+    )
+
+    if t_proto is None:
+        raise NotImplementedError(
+            f"Cannot convert socket to multiaddr, socket type is of {sock.type}"
+        )
+
+    # Reference: https://docs.python.org/3/library/socket.html#socket-families
+    if sock.family == socket.AF_INET:
+        # ipv4: (host, port)
+        addr, port = sock.getsockname()
+        ip = p_code(P_IP4).name
+
+    elif sock.family == socket.AF_INET6:
+        # ipv6: (host, port, flowinfo, scopeid)
+        addr, port = sock.getsockname()[:2]
+        ip = p_code(P_IP6).name
+
+    else:
+        raise NotImplementedError(
+            f"Cannot convert socket to multiaddr, socket family is of {sock.family}"
+        )
+
+    return Multiaddr(f"/{ip}/{addr}/{t_proto}/{port}")

--- a/tests/transport/test_tcp.py
+++ b/tests/transport/test_tcp.py
@@ -48,9 +48,22 @@ async def test_ipv6_multiaddr_from_socket():
     def handler(r, w):
         pass
 
+    # Test if socket.has_ipv6 isn't lying
+    try:
+        server = await asyncio.start_server(handler, "::1", 0)
+    except OSError as e:
+        # OSError [99]: cannot assign requested address
+        if e.errno == 99:
+            # The reason we skip this test instead of passing it is because we are testing if
+            # _multiaddr_from_socket returns a correct value from low-level socket objects,
+            # not if the host supports ipv6. If it doesn't, this test cannot run.
+            pytest.skip("Binding to random ipv6 address failed.")
+    else:
+        server.close()
+
     # Test with IPv6
-    server = await asyncio.start_server(handler, "::1", 8000)
-    assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip6/::1/tcp/8000"
+    server = await asyncio.start_server(handler, "::1", 8081)
+    assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip6/::1/tcp/8081"
     server.close()
 
     # Additional test with raw sockets

--- a/tests/transport/test_tcp.py
+++ b/tests/transport/test_tcp.py
@@ -1,8 +1,17 @@
 import asyncio
+import socket
 
 import pytest
 
 from libp2p.transport.tcp.tcp import _multiaddr_from_socket
+
+
+def create_socket(
+    addr, family: socket.AddressFamily, type: socket.SocketKind
+) -> socket.socket:
+    sock = socket.socket(family, type)
+    sock.bind(addr)
+    return sock
 
 
 @pytest.mark.asyncio
@@ -10,11 +19,37 @@ async def test_multiaddr_from_socket():
     def handler(r, w):
         pass
 
+    # Test with IPv4
     server = await asyncio.start_server(handler, "127.0.0.1", 8000)
     assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip4/127.0.0.1/tcp/8000"
+    server.close()
 
+    # Test with IPv6
+    server = await asyncio.start_server(handler, "::1", 8000)
+    assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip6/::1/tcp/8000"
+    server.close()
+
+    # Additional test with raw sockets
+    sock = create_socket(("127.0.0.1", 8089), socket.AF_INET, socket.SOCK_STREAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip4/127.0.0.1/tcp/8089"
+    sock.close()
+
+    sock = create_socket(("::", 8090), socket.AF_INET6, socket.SOCK_STREAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/tcp/8090"
+    sock.close()
+
+    sock = create_socket(("127.0.0.1", 8091), socket.AF_INET, socket.SOCK_DGRAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip4/127.0.0.1/udp/8091"
+    sock.close()
+
+    sock = create_socket(("::", 8092), socket.AF_INET6, socket.SOCK_DGRAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/udp/8092"
+    sock.close()
+
+    # Test if ipv4 address stays the same with random-port socket
     server = await asyncio.start_server(handler, "127.0.0.1", 0)
     addr = _multiaddr_from_socket(server.sockets[0])
     assert addr.value_for_protocol("ip4") == "127.0.0.1"
     port = addr.value_for_protocol("tcp")
     assert int(port) > 0
+    server.close()

--- a/tests/transport/test_tcp.py
+++ b/tests/transport/test_tcp.py
@@ -24,26 +24,13 @@ async def test_multiaddr_from_socket():
     assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip4/127.0.0.1/tcp/8000"
     server.close()
 
-    # Test with IPv6
-    server = await asyncio.start_server(handler, "::1", 8000)
-    assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip6/::1/tcp/8000"
-    server.close()
-
     # Additional test with raw sockets
     sock = create_socket(("127.0.0.1", 8089), socket.AF_INET, socket.SOCK_STREAM)
     assert str(_multiaddr_from_socket(sock)) == "/ip4/127.0.0.1/tcp/8089"
     sock.close()
 
-    sock = create_socket(("::", 8090), socket.AF_INET6, socket.SOCK_STREAM)
-    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/tcp/8090"
-    sock.close()
-
     sock = create_socket(("127.0.0.1", 8091), socket.AF_INET, socket.SOCK_DGRAM)
     assert str(_multiaddr_from_socket(sock)) == "/ip4/127.0.0.1/udp/8091"
-    sock.close()
-
-    sock = create_socket(("::", 8092), socket.AF_INET6, socket.SOCK_DGRAM)
-    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/udp/8092"
     sock.close()
 
     # Test if ipv4 address stays the same with random-port socket
@@ -53,3 +40,24 @@ async def test_multiaddr_from_socket():
     port = addr.value_for_protocol("tcp")
     assert int(port) > 0
     server.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 not supported on test host")
+async def test_ipv6_multiaddr_from_socket():
+    def handler(r, w):
+        pass
+
+    # Test with IPv6
+    server = await asyncio.start_server(handler, "::1", 8000)
+    assert str(_multiaddr_from_socket(server.sockets[0])) == "/ip6/::1/tcp/8000"
+    server.close()
+
+    # Additional test with raw sockets
+    sock = create_socket(("::", 8090), socket.AF_INET6, socket.SOCK_STREAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/tcp/8090"
+    sock.close()
+
+    sock = create_socket(("::", 8092), socket.AF_INET6, socket.SOCK_DGRAM)
+    assert str(_multiaddr_from_socket(sock)) == "/ip6/::/udp/8092"
+    sock.close()


### PR DESCRIPTION
## Describe the fix.

`transport/tcp.py::_multiaddr_from_socket()` assumes that the socket uses `AF_INET` as family and `SOCK_STREAM` as a socket type, everything is also hardcoded to ipv4.

This fix should make this function more smarter in handling ipv4+6, and allows it to detect if the socket is UDP or TCP.

Also in general it's recommended to move this to something like `transport/utils.py` or similar.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://data.whicdn.com/images/29074721/original.jpg)
