### PR TITLE
Fix `close` an already reset connection

### DIFF
--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -58,5 +58,5 @@ class RawConnection(IRawConnection):
         try:
             await self.writer.wait_closed()
         # In case the connection is already reset.
-        except (ConnectionResetError, RawConnError):
+        except ConnectionResetError:
             return

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -55,4 +55,8 @@ class RawConnection(IRawConnection):
         self.writer.close()
         if sys.version_info < (3, 7):
             return
-        await self.writer.wait_closed()
+        try:
+            await self.writer.wait_closed()
+        # In case the connection is already reset.
+        except (ConnectionResetError, RawConnError):
+            return

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -29,7 +29,7 @@ class RawConnection(IRawConnection):
         # Detect if underlying transport is closing before write data to it
         # ref: https://github.com/ethereum/trinity/pull/614
         if self.writer.transport.is_closing():
-            raise ConnectionResetError("Transport is closing")
+            raise RawConnError("Transport is closing")
         self.writer.write(data)
         # Reference: https://github.com/ethereum/lahja/blob/93610b2eb46969ff1797e0748c7ac2595e130aef/lahja/asyncio/endpoint.py#L99-L102  # noqa: E501
         # Use a lock to serialize drain() calls. Circumvents this bug:

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -26,10 +26,11 @@ class RawConnection(IRawConnection):
 
     async def write(self, data: bytes) -> None:
         """Raise `RawConnError` if the underlying connection breaks."""
-        try:
-            self.writer.write(data)
-        except ConnectionResetError as error:
-            raise RawConnError(error)
+        # Detect if underlying transport is closing before write data to it
+        # ref: https://github.com/ethereum/trinity/pull/614
+        if self.writer.transport.is_closing():
+            raise ConnectionResetError("Transport is closing")
+        self.writer.write(data)
         # Reference: https://github.com/ethereum/lahja/blob/93610b2eb46969ff1797e0748c7ac2595e130aef/lahja/asyncio/endpoint.py#L99-L102  # noqa: E501
         # Use a lock to serialize drain() calls. Circumvents this bug:
         # https://bugs.python.org/issue29930
@@ -52,6 +53,8 @@ class RawConnection(IRawConnection):
             raise RawConnError(error)
 
     async def close(self) -> None:
+        if self.writer.transport.is_closing():
+            return
         self.writer.close()
         if sys.version_info < (3, 7):
             return


### PR DESCRIPTION
## What was wrong?

https://github.com/ethereum/trinity/issues/1422
## How was it fixed?


Catch `ConnectionResetError` error when trying to close a connection.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://p0.pxfuel.com/preview/332/940/865/meerkat-animal-vigilant-small.jpg)
