### PR TITLE
Disable incremental mode of mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_subclassing_any = False
 ignore_missing_imports = True
+incremental = False
 strict_optional = False
 warn_unused_ignores = True
 strict_equality = True


### PR DESCRIPTION
Quoting the section for `warn_unused_configs` mypy setting from https://mypy.readthedocs.io/en/stable/config_file.html#miscellaneous:
> This requires turning off incremental mode using `incremental = False`.)