### PR TITLE
Removed explicit 'Nursery' from Listener

### DIFF
--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -40,7 +40,6 @@ def create_default_stream_handler(network: INetworkService) -> StreamHandlerFn:
 
 
 class Swarm(Service, INetworkService):
-
     self_id: ID
     peerstore: IPeerStore
     upgrader: TransportUpgrader
@@ -276,7 +275,9 @@ class Swarm(Service, INetworkService):
                 #   I/O agnostic, we should change the API.
                 if self.listener_nursery is None:
                     raise SwarmException("swarm instance hasn't been run")
-                await listener.listen(maddr, self.listener_nursery)
+                await self.listener_nursery.start(
+                    listener.listen, maddr  # type: ignore
+                )
 
                 # Call notifiers since event occurred
                 await self.notify_listen(maddr)

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -391,7 +391,7 @@ class GossipSub(IPubsubRouter, Service):
             await trio.sleep(self.heartbeat_interval)
 
     def mesh_heartbeat(
-        self
+        self,
     ) -> Tuple[DefaultDict[ID, List[str]], DefaultDict[ID, List[str]]]:
         peers_to_graft: DefaultDict[ID, List[str]] = defaultdict(list)
         peers_to_prune: DefaultDict[ID, List[str]] = defaultdict(list)

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -67,7 +67,7 @@ def security_transport_factory(
 
 @asynccontextmanager
 async def raw_conn_factory(
-    nursery: trio.Nursery
+    nursery: trio.Nursery,
 ) -> AsyncIterator[Tuple[IRawConnection, IRawConnection]]:
     conn_0 = None
     conn_1 = None
@@ -81,7 +81,7 @@ async def raw_conn_factory(
 
     tcp_transport = TCP()
     listener = tcp_transport.create_listener(tcp_stream_handler)
-    await listener.listen(LISTEN_MADDR, nursery)
+    await nursery.start(listener.listen, LISTEN_MADDR)
     listening_maddr = listener.get_addrs()[0]
     conn_0 = await tcp_transport.dial(listening_maddr)
     await event.wait()
@@ -351,7 +351,7 @@ async def swarm_pair_factory(
 
 @asynccontextmanager
 async def host_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[BasicHost, BasicHost]]:
     async with HostFactory.create_batch_and_listen(is_secure, 2) as hosts:
         await connect(hosts[0], hosts[1])
@@ -370,7 +370,7 @@ async def swarm_conn_pair_factory(
 
 @asynccontextmanager
 async def mplex_conn_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[Mplex, Mplex]]:
     muxer_opt = {MPLEX_PROTOCOL_ID: Mplex}
     async with swarm_conn_pair_factory(is_secure, muxer_opt=muxer_opt) as swarm_pair:
@@ -382,7 +382,7 @@ async def mplex_conn_pair_factory(
 
 @asynccontextmanager
 async def mplex_stream_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[MplexStream, MplexStream]]:
     async with mplex_conn_pair_factory(is_secure) as mplex_conn_pair_info:
         mplex_conn_0, mplex_conn_1 = mplex_conn_pair_info
@@ -398,7 +398,7 @@ async def mplex_stream_pair_factory(
 
 @asynccontextmanager
 async def net_stream_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[INetStream, INetStream]]:
     protocol_id = TProtocol("/example/id/1")
 

--- a/libp2p/tools/utils.py
+++ b/libp2p/tools/utils.py
@@ -30,7 +30,7 @@ async def connect(node1: IHost, node2: IHost) -> None:
 
 
 def create_echo_stream_handler(
-    ack_prefix: str
+    ack_prefix: str,
 ) -> Callable[[INetStream], Awaitable[None]]:
     async def echo_stream_handler(stream: INetStream) -> None:
         while True:

--- a/libp2p/transport/listener_interface.py
+++ b/libp2p/transport/listener_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import Any, Tuple
 
 from multiaddr import Multiaddr
 import trio
@@ -7,7 +7,9 @@ import trio
 
 class IListener(ABC):
     @abstractmethod
-    async def listen(self, maddr: Multiaddr, nursery: trio.Nursery) -> bool:
+    async def listen(
+        self, maddr: Multiaddr, task_status: Any = trio.TASK_STATUS_IGNORED
+    ) -> bool:
         """
         put listener in listening mode and wait for incoming connections.
 

--- a/libp2p/transport/listener_interface.py
+++ b/libp2p/transport/listener_interface.py
@@ -11,7 +11,8 @@ class IListener(ABC):
         self, maddr: Multiaddr, task_status: Any = trio.TASK_STATUS_IGNORED
     ) -> bool:
         """
-        put listener in listening mode and wait for incoming connections.
+        put listener in listening mode and wait for incoming connections. It
+        blocks until it stops to listen.
 
         :param maddr: multiaddr of peer
         :return: return True if successful

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -27,7 +27,8 @@ class TCPListener(IListener):
         self, maddr: Multiaddr, task_status: TaskStatus[Any] = trio.TASK_STATUS_IGNORED
     ) -> None:
         """
-        put listener in listening mode and wait for incoming connections.
+        put listener in listening mode and wait for incoming connections. It
+        blocks until it stops to listen.
 
         :param maddr: maddr of peer
         :return: return True if successful

--- a/tests/transport/test_tcp.py
+++ b/tests/transport/test_tcp.py
@@ -17,9 +17,9 @@ async def test_tcp_listener(nursery):
 
     listener = transport.create_listener(handler)
     assert len(listener.get_addrs()) == 0
-    await listener.listen(LISTEN_MADDR, nursery)
+    await nursery.start(listener.listen, LISTEN_MADDR)
     assert len(listener.get_addrs()) == 1
-    await listener.listen(LISTEN_MADDR, nursery)
+    await nursery.start(listener.listen, LISTEN_MADDR)
     assert len(listener.get_addrs()) == 2
 
 
@@ -41,7 +41,7 @@ async def test_tcp_dial(nursery):
         await transport.dial(Multiaddr("/ip4/127.0.0.1/tcp/1"))
 
     listener = transport.create_listener(handler)
-    await listener.listen(LISTEN_MADDR, nursery)
+    await nursery.start(listener.listen, LISTEN_MADDR)
     addrs = listener.get_addrs()
     assert len(addrs) == 1
     listen_addr = addrs[0]


### PR DESCRIPTION
## What was wrong?
The [IListener](https://github.com/libp2p/py-libp2p/blob/99f505d6d782b363cfcaf9ebc18acd3ca462a506/libp2p/transport/listener_interface.py#L10) interface is tightly coupled to the I/O implementation (Trio). This makes the application not to be agnostic to the I/O implementation.

Even if it goes quite against Trio's Nursery philosophy, we must decide whether we prioritize the abstractions and I/O agnostic implementations, or to the contrary, Trio's structured concurrent philosophy.
In order to understand better trio's Philosophy you can check: [Trio's philosphy]( https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/ )

## How was it fixed?

Created a static class [TrioGlobalNursery](https://github.com/aratz-lasa/py-libp2p/blob/795d53f19f399f563015ee29326eab9cdf1bf3e6/libp2p/io/trio.py#L45) with two methods:
1.  **set_global_nursery_and_run**: which sets the specified `nursery` as 'Global' and runs an asynchronous function, so that if you later before the function returns `get_global_nursery`, it returns the 'Global Nursery'
2.  **get_global_nursery**: returns the current 'Global Nursery'

This way, for running the IListener `listen` you should do it by using:

`await  TrioGlobalNursery.set_global_nursery_and_run(nursery, listener.listen, maddr)`

Instead of: 

`await listener.listen(maddr, nursery)`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Check why py37-interop fails

