### PR TITLE
Implemented PING fully-featured

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -391,7 +391,7 @@ class GossipSub(IPubsubRouter, Service):
             await trio.sleep(self.heartbeat_interval)
 
     def mesh_heartbeat(
-        self
+        self,
     ) -> Tuple[DefaultDict[ID, List[str]], DefaultDict[ID, List[str]]]:
         peers_to_graft: DefaultDict[ID, List[str]] = defaultdict(list)
         peers_to_prune: DefaultDict[ID, List[str]] = defaultdict(list)

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -67,7 +67,7 @@ def security_transport_factory(
 
 @asynccontextmanager
 async def raw_conn_factory(
-    nursery: trio.Nursery
+    nursery: trio.Nursery,
 ) -> AsyncIterator[Tuple[IRawConnection, IRawConnection]]:
     conn_0 = None
     conn_1 = None
@@ -351,7 +351,7 @@ async def swarm_pair_factory(
 
 @asynccontextmanager
 async def host_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[BasicHost, BasicHost]]:
     async with HostFactory.create_batch_and_listen(is_secure, 2) as hosts:
         await connect(hosts[0], hosts[1])
@@ -370,7 +370,7 @@ async def swarm_conn_pair_factory(
 
 @asynccontextmanager
 async def mplex_conn_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[Mplex, Mplex]]:
     muxer_opt = {MPLEX_PROTOCOL_ID: Mplex}
     async with swarm_conn_pair_factory(is_secure, muxer_opt=muxer_opt) as swarm_pair:
@@ -382,7 +382,7 @@ async def mplex_conn_pair_factory(
 
 @asynccontextmanager
 async def mplex_stream_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[MplexStream, MplexStream]]:
     async with mplex_conn_pair_factory(is_secure) as mplex_conn_pair_info:
         mplex_conn_0, mplex_conn_1 = mplex_conn_pair_info
@@ -398,7 +398,7 @@ async def mplex_stream_pair_factory(
 
 @asynccontextmanager
 async def net_stream_pair_factory(
-    is_secure: bool
+    is_secure: bool,
 ) -> AsyncIterator[Tuple[INetStream, INetStream]]:
     protocol_id = TProtocol("/example/id/1")
 

--- a/libp2p/tools/utils.py
+++ b/libp2p/tools/utils.py
@@ -30,7 +30,7 @@ async def connect(node1: IHost, node2: IHost) -> None:
 
 
 def create_echo_stream_handler(
-    ack_prefix: str
+    ack_prefix: str,
 ) -> Callable[[INetStream], Awaitable[None]]:
     async def echo_stream_handler(stream: INetStream) -> None:
         while True:

--- a/tests/host/test_ping.py
+++ b/tests/host/test_ping.py
@@ -42,8 +42,19 @@ async def test_ping_several(is_host_secure):
 async def test_ping_service_once(is_host_secure):
     async with host_pair_factory(is_host_secure) as (host_a, host_b):
         ping_service = PingService(host_b)
-        rtt = await ping_service.ping(host_a.get_id())
-        assert rtt < 10 ** 6  # rtt is in miliseconds
+        rtts = await ping_service.ping(host_a.get_id())
+        assert len(rtts) == 1
+        assert rtts[0] < 10 ** 6  # rtt is in miliseconds
+
+
+@pytest.mark.trio
+async def test_ping_service_several(is_host_secure):
+    async with host_pair_factory(is_host_secure) as (host_a, host_b):
+        ping_service = PingService(host_b)
+        rtts = await ping_service.ping(host_a.get_id(), ping_amount=SOME_PING_COUNT)
+        assert len(rtts) == SOME_PING_COUNT
+        for rtt in rtts:
+            assert rtt < 10 ** 6  # rtt is in miliseconds
 
 
 @pytest.mark.trio
@@ -51,7 +62,7 @@ async def test_ping_service_loop(is_host_secure):
     async with host_pair_factory(is_host_secure) as (host_a, host_b):
         ping_service = PingService(host_b)
         ping_loop = await ping_service.ping_loop(
-            host_a.get_id(), ping_amount=SOME_PING_COUNT
+            host_a.get_id(), ping_limit=SOME_PING_COUNT
         )
         async for rtt in ping_loop:
             assert rtt < 10 ** 6


### PR DESCRIPTION
First draft of PingService, which executes pings and implements RTT calculation feature.

## What was wrong?
There was no PingService that implemented the RTT feature, nor an easy way for creating a Ping requests Loop.

Issue #344 

## How was it fixed?

Created a class Called [PingService](https://github.com/aratz-lasa/py-libp2p/blob/ef2e2487af9ccc8260bfcb8a8ecf51120a482847/libp2p/host/ping.py#L69), which implements two methods:
1. `ping(peer_id)`: method for executing a ping. It opens a stream, pings it, closes the stream, and returns the RTT.
2. `ping_loop(peer_id, ping_amount)`: method that returns a Ping iterator. If no `ping_amount` is passed as argument, it creates an infinite iterator. Every iteration returns the RTT.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Decide whether it is an intuitive design, and if it should be coupled to `handle_ping`
- [ ] Decide where to place the service. Maybe as an attribute of the `Host`?
- [ ] Check if the RTT calculation is accurate and if its format should be in miliseconds
- [ ] Document it well enough
