### PR TITLE
Allow `Pubsub` creator to supply a custom msg_id

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -1,4 +1,6 @@
+import base64
 import functools
+import hashlib
 import logging
 import time
 from typing import (
@@ -50,6 +52,10 @@ logger = logging.getLogger("libp2p.pubsub")
 def get_peer_and_seqno_msg_id(msg: rpc_pb2.Message) -> bytes:
     # NOTE: `string(from, seqno)` in Go
     return msg.seqno + msg.from_id
+
+
+def get_content_addressed_msg_id(msg: rpc_pb2.Message) -> bytes:
+    return base64.b64encode(hashlib.sha256(msg.data).digest())
 
 
 class TopicValidator(NamedTuple):


### PR DESCRIPTION
## What was wrong?

Fixes #408.

## How was it fixed?

Allow message id logic to be passed in as a parameter.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/8d/75/6d/8d756d9cae0888a160fd706a43510560--koala-bears-baby-koala.jpg)
