### PR TITLE
Release notes fix: v0.1.15 -> v0.1.5

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 
 .. towncrier release notes start
 
-libp2p v0.1.15 (2020-03-23)
+libp2p v0.1.5 (2020-03-25)
 ---------------------------
 
 Features


### PR DESCRIPTION
## What was wrong?

Looks like a typo in the release notes. Previous version was 0.1.4, so the next release is 0.1.5.

## How was it fixed?

Updated the release notes. (Also, reflect the actual release date)