### PR TITLE
Use trio.lowlevel instead of trio.hazmat

### DIFF
--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -64,7 +64,7 @@ class FloodSub(IPubsubRouter):
         :param rpc: rpc message
         """
         # Checkpoint
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async def publish(self, msg_forwarder: ID, pubsub_msg: rpc_pb2.Message) -> None:
         """
@@ -112,7 +112,7 @@ class FloodSub(IPubsubRouter):
         :param topic: topic to join
         """
         # Checkpoint
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async def leave(self, topic: str) -> None:
         """
@@ -122,7 +122,7 @@ class FloodSub(IPubsubRouter):
         :param topic: topic to leave
         """
         # Checkpoint
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     def _get_peers_to_send(
         self, topic_ids: Iterable[str], msg_forwarder: ID, origin: ID

--- a/libp2p/pubsub/pubsub_notifee.py
+++ b/libp2p/pubsub/pubsub_notifee.py
@@ -32,10 +32,10 @@ class PubsubNotifee(INotifee):
         self.dead_peers_queue = dead_peers_queue
 
     async def opened_stream(self, network: INetwork, stream: INetStream) -> None:
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async def closed_stream(self, network: INetwork, stream: INetStream) -> None:
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async def connected(self, network: INetwork, conn: INetConn) -> None:
         """
@@ -67,7 +67,7 @@ class PubsubNotifee(INotifee):
             pass
 
     async def listen(self, network: INetwork, multiaddr: Multiaddr) -> None:
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async def listen_close(self, network: INetwork, multiaddr: Multiaddr) -> None:
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()

--- a/libp2p/pubsub/subscription.py
+++ b/libp2p/pubsub/subscription.py
@@ -10,7 +10,7 @@ from .typing import UnsubscribeFn
 
 class BaseSubscriptionAPI(ISubscriptionAPI):
     async def __aenter__(self) -> "BaseSubscriptionAPI":
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
         return self
 
     async def __aexit__(

--- a/libp2p/security/noise/patterns.py
+++ b/libp2p/security/noise/patterns.py
@@ -177,8 +177,6 @@ class PatternXX(BasePattern):
     def _get_pubkey_from_noise_keypair(key_pair: NoiseKeyPair) -> PublicKey:
         # Use `Ed25519PublicKey` since 25519 is used in our pattern.
         raw_bytes = key_pair.public.public_bytes(
-            # ignore "'Type[...]' has no attribute 'Raw'"
-            serialization.Encoding.Raw,  # type: ignore
-            serialization.PublicFormat.Raw,  # type: ignore
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
         )
         return Ed25519PublicKey.from_bytes(raw_bytes)

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -297,7 +297,7 @@ class DummyRouter(IPeerRouting):
         self._routing_table[peer_id] = PeerInfo(peer_id, addrs)
 
     async def find_peer(self, peer_id: ID) -> PeerInfo:
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
         return self._routing_table.get(peer_id, None)
 
 

--- a/libp2p/tools/pubsub/floodsub_integration_test_settings.py
+++ b/libp2p/tools/pubsub/floodsub_integration_test_settings.py
@@ -217,7 +217,7 @@ async def perform_test_from_obj(obj, pubsub_factory) -> None:
             # Avoid repeated works
             if topic in queues_map[node_id]:
                 # Checkpoint
-                await trio.hazmat.checkpoint()
+                await trio.lowlevel.checkpoint()
                 return
             sub = await pubsub_map[node_id].subscribe(topic)
             queues_map[node_id][topic] = sub

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -102,5 +102,5 @@ class TCP(ITransport):
 
 
 def _multiaddr_from_socket(socket: trio.socket.SocketType) -> Multiaddr:
-    ip, port = socket.getsockname()  # type: ignore
+    ip, port = socket.getsockname()
     return Multiaddr(f"/ip4/{ip}/tcp/{port}")

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,12 @@ extras_require = {
     "lint": [
         "flake8==3.7.9",  # flake8 is not semver: it has added new warnings at minor releases
         "isort==4.3.21",
-        "mypy==0.740",  # mypy is not semver: it has added new warnings at minor releases
+        "mypy==0.780",  # mypy is not semver: it has added new warnings at minor releases
         "mypy-protobuf==1.15",
         "black==19.3b0",
         "flake8-bugbear>=19.8.0,<20",
         "docformatter>=1.3.1,<2",
+        "trio-typing~=0.5.0",
     ],
     "doc": [
         "Sphinx>=2.2.1,<3",
@@ -74,10 +75,9 @@ install_requires = [
     "pynacl==1.3.0",
     "dataclasses>=0.7, <1;python_version<'3.7'",
     "async_generator==1.10",
-    "trio>=0.13.0",
+    "trio>=0.15.0",
     "async-service>=0.1.0a6",
     "async-exit-stack==1.0.1",
-    "trio-typing>=0.3.0,<0.4.0",
     "noiseprotocol>=0.3.0,<0.4.0",
 ]
 

--- a/tests/pubsub/test_gossipsub.py
+++ b/tests/pubsub/test_gossipsub.py
@@ -106,7 +106,7 @@ async def test_handle_graft(monkeypatch):
 
         async def emit_prune(topic, sender_peer_id):
             event_emit_prune.set()
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         monkeypatch.setattr(gossipsubs[index_bob], "emit_prune", emit_prune)
 

--- a/tests/pubsub/test_pubsub.py
+++ b/tests/pubsub/test_pubsub.py
@@ -103,7 +103,7 @@ async def test_set_and_remove_topic_validator():
         async def async_validator(peer_id, msg):
             nonlocal is_async_validator_called
             is_async_validator_called = True
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         topic = "TEST_VALIDATOR"
 
@@ -155,7 +155,7 @@ async def test_get_msg_validators():
         async def async_validator(peer_id, msg):
             nonlocal times_async_validator_called
             times_async_validator_called += 1
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         topic_1 = "TEST_VALIDATOR_1"
         topic_2 = "TEST_VALIDATOR_2"
@@ -201,11 +201,11 @@ async def test_validate_msg(is_topic_1_val_passed, is_topic_2_val_passed):
             return False
 
         async def passed_async_validator(peer_id, msg):
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
             return True
 
         async def failed_async_validator(peer_id, msg):
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
             return False
 
         topic_1 = "TEST_SYNC_VALIDATOR"
@@ -238,7 +238,7 @@ async def test_validate_msg(is_topic_1_val_passed, is_topic_2_val_passed):
 @pytest.mark.trio
 async def test_continuously_read_stream(monkeypatch, nursery, security_protocol):
     async def wait_for_event_occurring(event):
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
         with trio.fail_after(0.1):
             await event.wait()
 
@@ -255,14 +255,14 @@ async def test_continuously_read_stream(monkeypatch, nursery, security_protocol)
 
         async def mock_push_msg(msg_forwarder, msg):
             event_push_msg.set()
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         def mock_handle_subscription(origin_id, sub_message):
             event_handle_subscription.set()
 
         async def mock_handle_rpc(rpc, sender_peer_id):
             event_handle_rpc.set()
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         with monkeypatch.context() as m:
             m.setattr(pubsubs_fsub[0], "push_msg", mock_push_msg)
@@ -488,7 +488,7 @@ async def test_publish_push_msg_is_called(monkeypatch):
     async def push_msg(msg_forwarder, msg):
         msg_forwarders.append(msg_forwarder)
         msgs.append(msg)
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
     async with PubsubFactory.create_batch_with_floodsub(1) as pubsubs_fsub:
         with monkeypatch.context() as m:
@@ -525,7 +525,7 @@ async def test_push_msg(monkeypatch):
 
             async def router_publish(*args, **kwargs):
                 event.set()
-                await trio.hazmat.checkpoint()
+                await trio.lowlevel.checkpoint()
 
             with monkeypatch.context() as m:
                 m.setattr(pubsubs_fsub[0].router, "publish", router_publish)
@@ -626,7 +626,7 @@ async def test_strict_signing_failed_validation(monkeypatch):
 
         # Use router publish to check if `push_msg` succeed.
         async def router_publish(*args, **kwargs):
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
             # The event will only be set if `push_msg` succeed.
             event.set()
 

--- a/tests_interop/conftest.py
+++ b/tests_interop/conftest.py
@@ -122,7 +122,7 @@ async def py_to_daemon_stream_pair(p2pds, security_protocol, is_to_fail_daemon_s
             nonlocal stream_daemon
             stream_daemon = DaemonStream(stream_info, stream)
             event_stream_handled.set()
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
 
         await p2pd.control.stream_handler(protocol_id, daemon_stream_handler)
         # Sleep for a while to wait for the handler being registered.


### PR DESCRIPTION
Since trio 0.15.0, hazmat has been deprecated (python-trio/trio#476).  trio-typing and mypy are bumped to support newer trio and each other.

I suppose that this needs not a news fragment, but feel free to tell me to add one.

### Cute Animal Motion Picture

https://user-images.githubusercontent.com/13689192/108862799-29135d80-7623-11eb-93e4-57f0f8776886.mp4