### PR TITLE
Don't hash data passed to nacl library in Ed25519PublicKey.verify

### DIFF
--- a/libp2p/crypto/ed25519.py
+++ b/libp2p/crypto/ed25519.py
@@ -24,9 +24,8 @@ class Ed25519PublicKey(PublicKey):
 
     def verify(self, data: bytes, signature: bytes) -> bool:
         verify_key = VerifyKey(self.to_bytes())
-        h = SHA256.new(data)
         try:
-            verify_key.verify(h, signature)
+            verify_key.verify(data, signature)
         except BadSignatureError:
             return False
         return True


### PR DESCRIPTION
## What was wrong?

Issue #428 

## How was it fixed?

Don't hash the data parameter passed to nacl library, as it expects both inputs to be bytes.


