### PR TITLE
[HOLD] Add Apple Silicon install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ virtualenv -p python3.7 venv
 pip install -e .[dev]
 ```
 
+### Apple Silicon
+This method avoids some common issues with [ctypes](https://dev.to/ajkerrigan/homebrew-pyenv-ctypes-oh-my-3d9) and the [GMP Library](https://github.com/libp2p/py-libp2p/issues/432#issuecomment-962437483) on Apple Silicon.
+```sh
+pyenv install --verbose 3.10.3
+virtualenv -p python3.10 venv
+. venv/bin/activate
+CFLAGS=-I/opt/homebrew/opt/gmp/include LDFLAGS=-L/opt/homebrew/opt/gmp/lib pip install -e .[dev]
+```
+
 ### Testing Setup
 
 During development, you might like to have tests run on every file save.


### PR DESCRIPTION
## What was wrong?

Apple Silicon machines are unable to install `py-libp2p` when following the current `README.md`

Issue #432

## How was it fixed?

There are two issues when attempting to install `py-libp2p`

1. _ctypes are not available in python3.7 | [source](https://dev.to/ajkerrigan/homebrew-pyenv-ctypes-oh-my-3d9)
2. gmp.h not included | [source](https://github.com/libp2p/py-libp2p/issues/432#issuecomment-962437483) #432

Summary of approach.
After research, and local testing, I've been able to install the `py-libp2p` with python3.10. The process to do so is added in the `README.md`
### To-Do

[//]: # (See: https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
