### PR TITLE
fixed noise_state returns bytearray where we want bytes, add slow to …

### DIFF
--- a/libp2p/security/noise/io.py
+++ b/libp2p/security/noise/io.py
@@ -72,7 +72,7 @@ class NoiseHandshakeReadWriter(BaseNoiseMsgReadWriter):
         return self.noise_state.write_message(data)
 
     def decrypt(self, data: bytes) -> bytes:
-        return self.noise_state.read_message(data)
+        return bytes(self.noise_state.read_message(data))
 
 
 class NoiseTransportReadWriter(BaseNoiseMsgReadWriter):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ xfail_strict = true
 log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
 
+markers = [
+  "slow: mark test as slow",
+]
+
 [tool.towncrier]
 # Read https://github.com/ethereum/py-libp2p/blob/main/newsfragments/README.md for instructions
 package = "libp2p"


### PR DESCRIPTION
…pytest markers

## What was wrong?

Failing tests due to `bytearray` vs `bytes` typing

## How was it fixed?

Convert `noise_state.decrypt` output from `bytearray` to `bytes`.
Added `slow` to pytest markers to remove warning.

### To-Do

- [ ] Clean up commit history

* [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/631a2584-5177-44d9-9bd1-40665c3fdb51)
