### PR TITLE
readthedocs build is failing, looking for factoryboy and pytest - add test deps to docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require = {
 extras_require["dev"] = (
     extras_require["dev"] + extras_require["docs"] + extras_require["test"]
 )
+extras_require["docs"] = extras_require["docs"] + extras_require["test"]
 
 fastecdsa = [
     # No official fastecdsa==1.7.4,1.7.5 wheels for Windows, using a pypi package that includes


### PR DESCRIPTION
## What was wrong?

The readthedocs build is failing:

```
WARNING: autodoc: failed to import module 'factories' from module 'libp2p.tools'; the following exception was raised:
No module named 'factory'
WARNING: autodoc: failed to import module 'dummy_account_node' from module 'libp2p.tools.pubsub'; the following exception was raised:
No module named 'factory'
WARNING: autodoc: failed to import module 'floodsub_integration_test_settings' from module 'libp2p.tools.pubsub'; the following exception was raised:
No module named 'pytest'
```

## How was it fixed?
To add `pytest` and `factory-boy` easily to `docs` deps, combined docs and test deps together in `setup.py`

### To-Do

- [ ] Clean up commit history

* [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/dc1fddde-fa2b-400e-aca6-57e569ef3a65)
