### PR TITLE
turn mypy checks on & fix errors, remove `async_generator` dep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,13 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: v1.5.1
-#     hooks:
-#     -   id: mypy
-#         additional_dependencies:
-#         -   mypy-protobuf
-#         exclude: 'tests/|tests_interop/|crypto/|identity/|pubsub/|insecure/|noise/|security/'
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+    -   id: mypy
+        additional_dependencies:
+        -   mypy-protobuf
+        # exclude: 'tests/|crypto/|identity/|pubsub/|insecure/|noise/|security/'
+        exclude: 'tests/'
 -   repo: local
     hooks:
     -   id: check-rst-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,6 @@ repos:
     -   id: mypy
         additional_dependencies:
         -   mypy-protobuf
-        # exclude: 'tests/|crypto/|identity/|pubsub/|insecure/|noise/|security/'
         exclude: 'tests/'
 -   repo: local
     hooks:

--- a/examples/echo/echo.py
+++ b/examples/echo/echo.py
@@ -78,8 +78,8 @@ async def run(port: int, destination: str, seed: int = None) -> None:
             await stream.close()
             response = await stream.read()
 
-            print(f"Sent: {msg}")
-            print(f"Got: {response}")
+            print(f"Sent: {msg.decode('utf-8')}")
+            print(f"Got: {response.decode('utf-8')}")
 
 
 def main() -> None:

--- a/libp2p/crypto/keys.py
+++ b/libp2p/crypto/keys.py
@@ -56,7 +56,8 @@ class PublicKey(Key):
         """Return the protobuf representation of this ``Key``."""
         key_type = self.get_type().value
         data = self.to_bytes()
-        protobuf_key = protobuf.PublicKey(key_type=key_type, data=data)
+        # type ignored - TODO add ECD_P256 to KeyType
+        protobuf_key = protobuf.PublicKey(key_type=key_type, data=data)  # type: ignore
         return protobuf_key
 
     def serialize(self) -> bytes:
@@ -83,7 +84,8 @@ class PrivateKey(Key):
         """Return the protobuf representation of this ``Key``."""
         key_type = self.get_type().value
         data = self.to_bytes()
-        protobuf_key = protobuf.PrivateKey(key_type=key_type, data=data)
+        # type ignored - TODO add ECD_P256 to KeyType
+        protobuf_key = protobuf.PrivateKey(key_type=key_type, data=data)  # type: ignore
         return protobuf_key
 
     def serialize(self) -> bytes:

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -1,3 +1,6 @@
+from contextlib import (
+    asynccontextmanager,
+)
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -6,9 +9,6 @@ from typing import (
     Sequence,
 )
 
-from async_generator import (
-    asynccontextmanager,
-)
 from async_service import (
     background_trio_service,
 )
@@ -145,8 +145,7 @@ class BasicHost(IHost):
                 addrs.append(addr.encapsulate(p2p_part))
         return addrs
 
-    # type ignored because asynccontextmanager decorator is untyped
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def run(
         self, listen_addrs: Sequence[multiaddr.Multiaddr]
     ) -> AsyncIterator[None]:

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -145,7 +145,8 @@ class BasicHost(IHost):
                 addrs.append(addr.encapsulate(p2p_part))
         return addrs
 
-    @asynccontextmanager
+    # type ignored because asynccontextmanager decorator is untyped
+    @asynccontextmanager  # type: ignore
     async def run(
         self, listen_addrs: Sequence[multiaddr.Multiaddr]
     ) -> AsyncIterator[None]:

--- a/libp2p/io/msgio.py
+++ b/libp2p/io/msgio.py
@@ -8,6 +8,9 @@ NOTE: currently missing the capability to indicate lengths by "varint" method.
 from abc import (
     abstractmethod,
 )
+from typing import (
+    Literal,
+)
 
 from libp2p.io.abc import (
     MsgReadWriteCloser,
@@ -26,7 +29,7 @@ from .exceptions import (
     MessageTooLarge,
 )
 
-BYTE_ORDER = "big"
+BYTE_ORDER: Literal["big", "little"] = "big"
 
 
 async def read_length(reader: Reader, size_len_bytes: int) -> int:

--- a/libp2p/network/connection/swarm_connection.py
+++ b/libp2p/network/connection/swarm_connection.py
@@ -83,9 +83,7 @@ class SwarmConn(INetConn):
     async def _handle_muxed_stream(self, muxed_stream: IMuxedStream) -> None:
         net_stream = await self._add_stream(muxed_stream)
         try:
-            # Ignore type here since mypy complains:
-            # https://github.com/python/mypy/issues/2427
-            await self.swarm.common_stream_handler(net_stream)  # type: ignore
+            await self.swarm.common_stream_handler(net_stream)
         finally:
             # As long as `common_stream_handler`, remove the stream.
             self.remove_stream(net_stream)

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -113,9 +113,7 @@ class Swarm(Service, INetworkService):
         # Create Notifee array
         self.notifees = []
 
-        # Ignore type here since mypy complains:
-        # https://github.com/python/mypy/issues/2427
-        self.common_stream_handler = create_default_stream_handler(self)  # type: ignore
+        self.common_stream_handler = create_default_stream_handler(self)
 
         self.listener_nursery = None
         self.event_listener_nursery_created = trio.Event()
@@ -137,9 +135,7 @@ class Swarm(Service, INetworkService):
         return self.self_id
 
     def set_stream_handler(self, stream_handler: StreamHandlerFn) -> None:
-        # Ignore type here since mypy complains:
-        # https://github.com/python/mypy/issues/2427
-        self.common_stream_handler = stream_handler  # type: ignore
+        self.common_stream_handler = stream_handler
 
     async def dial_peer(self, peer_id: ID) -> INetConn:
         """
@@ -273,7 +269,7 @@ class Swarm(Service, INetworkService):
                 return True
 
             async def conn_handler(
-                read_write_closer: ReadWriteCloser, maddr=maddr
+                read_write_closer: ReadWriteCloser, maddr: Multiaddr = maddr
             ) -> None:
                 raw_conn = RawConnection(read_write_closer, False)
 

--- a/libp2p/pubsub/subscription.py
+++ b/libp2p/pubsub/subscription.py
@@ -44,12 +44,10 @@ class TrioSubscriptionAPI(BaseSubscriptionAPI):
         unsubscribe_fn: UnsubscribeFn,
     ) -> None:
         self.receive_channel = receive_channel
-        # Ignore type here since mypy complains: https://github.com/python/mypy/issues/2427  # noqa: E501
-        self.unsubscribe_fn = unsubscribe_fn  # type: ignore
+        self.unsubscribe_fn = unsubscribe_fn
 
     async def unsubscribe(self) -> None:
-        # Ignore type here since mypy complains: https://github.com/python/mypy/issues/2427  # noqa: E501
-        await self.unsubscribe_fn()  # type: ignore
+        await self.unsubscribe_fn()
 
     def __aiter__(self) -> AsyncIterator[rpc_pb2.Message]:
         return self.receive_channel.__aiter__()

--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -182,7 +182,9 @@ class InsecureTransport(BaseSecureTransport):
 
 def make_exchange_message(pubkey: PublicKey) -> plaintext_pb2.Exchange:
     pubkey_pb = crypto_pb2.PublicKey(
-        key_type=pubkey.get_type().value, data=pubkey.to_bytes()
+        # type ignored - TODO add ECD_P256 to KeyType
+        key_type=pubkey.get_type().value,  # type: ignore
+        data=pubkey.to_bytes(),
     )
     id_bytes = ID.from_pubkey(pubkey).to_bytes()
     return plaintext_pb2.Exchange(id=id_bytes, pubkey=pubkey_pb)

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -189,7 +189,8 @@ class Mplex(IMuxedConn):
 
         _bytes = header + encode_varint_prefixed(data)
 
-        return await self.write_to_stream(_bytes)
+        # type ignored TODO figure out return for this and write_to_stream
+        return await self.write_to_stream(_bytes)  # type: ignore
 
     async def write_to_stream(self, _bytes: bytes) -> None:
         """

--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -1,3 +1,6 @@
+from contextlib import (
+    asynccontextmanager,
+)
 from typing import (
     Any,
     AsyncIterator,
@@ -11,9 +14,6 @@ from typing import (
 
 from async_exit_stack import (
     AsyncExitStack,
-)
-from async_generator import (
-    asynccontextmanager,
 )
 from async_service import (
     background_trio_service,

--- a/libp2p/tools/interop/daemon.py
+++ b/libp2p/tools/interop/daemon.py
@@ -1,10 +1,10 @@
+from contextlib import (
+    asynccontextmanager,
+)
 from typing import (
     AsyncIterator,
 )
 
-from async_generator import (
-    asynccontextmanager,
-)
 import multiaddr
 from multiaddr import (
     Multiaddr,

--- a/libp2p/tools/interop/process.py
+++ b/libp2p/tools/interop/process.py
@@ -56,8 +56,7 @@ class BaseInteractiveProcess(AbstractInterativeProcess):
     async def start(self) -> None:
         if self.proc is not None:
             return
-        # NOTE: Ignore type checks here since mypy complains about bufsize=0
-        self.proc = await trio.open_process(  # type: ignore
+        self.proc = await trio.open_process(
             [self.cmd] + self.args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,  # Redirect stderr to stdout, which makes parsing easier  # noqa: E501

--- a/libp2p/tools/pubsub/dummy_account_node.py
+++ b/libp2p/tools/pubsub/dummy_account_node.py
@@ -1,3 +1,6 @@
+from contextlib import (
+    asynccontextmanager,
+)
 from typing import (
     AsyncIterator,
     Dict,
@@ -6,9 +9,6 @@ from typing import (
 
 from async_exit_stack import (
     AsyncExitStack,
-)
-from async_generator import (
-    asynccontextmanager,
 )
 from async_service import (
     Service,

--- a/newsfragments/464.internal.rst
+++ b/newsfragments/464.internal.rst
@@ -1,0 +1,1 @@
+Turn ``mypy`` checks on and remove ``async_generator`` dependency

--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -5,10 +5,13 @@ import subprocess
 from tempfile import (
     TemporaryDirectory,
 )
+from typing import (
+    Tuple,
+)
 import venv
 
 
-def create_venv(parent_path):
+def create_venv(parent_path: Path) -> Path:
     venv_path = parent_path / "package-smoke-test"
     venv.create(venv_path, with_pip=True)
     subprocess.run(
@@ -17,7 +20,7 @@ def create_venv(parent_path):
     return venv_path
 
 
-def find_wheel(project_path):
+def find_wheel(project_path: Path) -> Path:
     wheels = list(project_path.glob("dist/*.whl"))
 
     if len(wheels) != 1:
@@ -29,7 +32,9 @@ def find_wheel(project_path):
     return wheels[0]
 
 
-def install_wheel(venv_path, wheel_path, extras=()):
+def install_wheel(
+    venv_path: Path, wheel_path: Path, extras: Tuple[str, ...] = ()
+) -> None:
     if extras:
         extra_suffix = f"[{','.join(extras)}]"
     else:
@@ -41,7 +46,7 @@ def install_wheel(venv_path, wheel_path, extras=()):
     )
 
 
-def test_install_local_wheel():
+def test_install_local_wheel() -> None:
     with TemporaryDirectory() as tmpdir:
         venv_path = create_venv(Path(tmpdir))
         wheel_path = find_wheel(Path("."))

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ install_requires = [
     "protobuf>=3.10.0",
     "coincurve>=10.0.0",
     "pynacl==1.3.0",
-    "async_generator==1.10",
     "trio>=0.15.0",
     "async-service>=0.1.0a6",
     "async-exit-stack==1.0.1",


### PR DESCRIPTION
## What was wrong?

`mypy` checks were turned off in the recent linting upgrade. Turning back on and fixing errors.

The `asynccontextmanager` decorator was imported from the `async_generator` lib, but that was just porting the decorator back to py35 and py36. It can now be imported directly from `contextlib`.

### To-Do

- [x] Clean up commit history

* [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/3ca36a61-db88-494c-bd87-b0029077dd10)
