### PR TITLE
remove async-exit-stack dep, set `pynacl` dep to bottom pin only

### DIFF
--- a/libp2p/tools/factories.py
+++ b/libp2p/tools/factories.py
@@ -1,4 +1,5 @@
 from contextlib import (
+    AsyncExitStack,
     asynccontextmanager,
 )
 from typing import (
@@ -12,9 +13,6 @@ from typing import (
     cast,
 )
 
-from async_exit_stack import (
-    AsyncExitStack,
-)
 import factory
 from multiaddr import (
     Multiaddr,

--- a/libp2p/tools/pubsub/dummy_account_node.py
+++ b/libp2p/tools/pubsub/dummy_account_node.py
@@ -1,14 +1,11 @@
 from contextlib import (
+    AsyncExitStack,
     asynccontextmanager,
 )
 from typing import (
     AsyncIterator,
     Dict,
     Tuple,
-)
-
-from async_exit_stack import (
-    AsyncExitStack,
 )
 
 from libp2p.host.host_interface import (

--- a/newsfragments/468.removal.rst
+++ b/newsfragments/468.removal.rst
@@ -1,1 +1,1 @@
-Drop ``async-exit-stack`` dep, as of py37 can import ``AsyncExitStack`` from contextlib
+Drop ``async-exit-stack`` dep, as of py37 can import ``AsyncExitStack`` from contextlib, also open ``pynacl`` dep to bottom pin only

--- a/newsfragments/468.removal.rst
+++ b/newsfragments/468.removal.rst
@@ -1,0 +1,1 @@
+Drop ``async-exit-stack`` dep, as of py37 can import ``AsyncExitStack`` from contextlib

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ install_requires = [
     "coincurve>=10.0.0",
     "pynacl==1.3.0",
     "trio>=0.15.0",
-    "async-exit-stack==1.0.1",
     "noiseprotocol>=0.3.0",
     "trio-typing>=0.0.4",
     "exceptiongroup>=1.2.0; python_version < '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -60,14 +60,11 @@ install_requires = [
     "lru-dict>=1.1.6",
     "protobuf>=3.10.0",
     "coincurve>=10.0.0",
-    "pynacl==1.3.0",
+    "pynacl>=1.3.0",
     "trio>=0.15.0",
     "noiseprotocol>=0.3.0",
     "trio-typing>=0.0.4",
     "exceptiongroup>=1.2.0; python_version < '3.11'",
-    # added during debugging
-    "anyio",
-    "p2pclient",
 ]
 
 

--- a/tests/interop/conftest.py
+++ b/tests/interop/conftest.py
@@ -1,7 +1,8 @@
-import anyio
-from async_exit_stack import (
+from contextlib import (
     AsyncExitStack,
 )
+
+import anyio
 from p2pclient.datastructures import (
     StreamInfo,
 )


### PR DESCRIPTION
## What was wrong?

We previously imported `AsyncExitStack` from `async-exit-stack`, but that's not needed as of py37.

Removed `async-exit-stack` dep

`pynacl` was set to `==1.3.0`, opened to bottom pin only.

### To-Do

- [x] Clean up commit history

* [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/24258a66-a7a2-47ca-a320-d2be690d210e)
