### PR TITLE
sort install_requires and sync with mypy deps in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,19 @@ repos:
     rev: v1.5.1
     hooks:
     -   id: mypy
-        additional_dependencies:
+        additional_dependencies:  # keep in sync with setup.py install_requires
+        -   base58
+        -   coincurve
+        -   lru-dict
+        -   multiaddr
         -   mypy-protobuf
+        -   noiseprotocol
+        -   protobuf
+        -   pycryptodome
+        -   pymultihash
+        -   pynacl
+        -   rpcudp
+        -   trio
         -   trio-typing
         exclude: 'tests/'
 -   repo: local

--- a/libp2p/crypto/ed25519.py
+++ b/libp2p/crypto/ed25519.py
@@ -67,7 +67,7 @@ class Ed25519PrivateKey(PrivateKey):
         return KeyType.Ed25519
 
     def sign(self, data: bytes) -> bytes:
-        h = SHA256.new(data)
+        h = SHA256.new(data).digest()
         signing_key = SigningKey(self.to_bytes())
         return signing_key.sign(h)
 

--- a/newsfragments/469.internal.rst
+++ b/newsfragments/469.internal.rst
@@ -1,0 +1,1 @@
+sync install_requires with pre-commit mypy deps

--- a/setup.py
+++ b/setup.py
@@ -50,21 +50,22 @@ fastecdsa = [
 with open("./README.md") as readme:
     long_description = readme.read()
 
-
+# keep in sync with pre-commit mypy hook
 install_requires = [
-    "pycryptodome>=3.9.2",
     "base58>=1.0.3",
-    "pymultihash>=0.8.2",
-    "multiaddr>=0.0.9",
-    "rpcudp>=3.0.0",
-    "lru-dict>=1.1.6",
-    "protobuf>=3.10.0",
     "coincurve>=10.0.0",
-    "pynacl>=1.3.0",
-    "trio>=0.15.0",
-    "noiseprotocol>=0.3.0",
-    "trio-typing>=0.0.4",
     "exceptiongroup>=1.2.0; python_version < '3.11'",
+    "lru-dict>=1.1.6",
+    "multiaddr>=0.0.9",
+    "mypy-protobuf>=3.1.0",
+    "noiseprotocol>=0.3.0",
+    "protobuf>=3.10.0",
+    "pycryptodome>=3.9.2",
+    "pymultihash>=0.8.2",
+    "pynacl>=1.3.0",
+    "rpcudp>=3.0.0",
+    "trio-typing>=0.0.4",
+    "trio>=0.15.0",
 ]
 
 


### PR DESCRIPTION
Important to have the same deps for mypy checks as install_requires so users don't get mypy errors we missed.

### To-Do

- [x] Clean up commit history

* [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/ccd63897-b44c-494e-b5cb-88d283f82401)
