### PR TITLE
run mypy locally, bump mypy to 1.10.0, fix new errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,14 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        additional_dependencies:
-        -   mypy-protobuf
-        -   trio-typing
-        exclude: 'tests/'
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p libp2p
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: local
     hooks:
     -   id: check-rst-files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ release = __version__
 exclude_patterns = [
     "_build",
     "modules.rst",
+    "libp2p.crypto.pb.rst",
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/libp2p.crypto.rst
+++ b/docs/libp2p.crypto.rst
@@ -7,8 +7,6 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
-   libp2p.crypto.pb
-
 Submodules
 ----------
 

--- a/libp2p/crypto/ed25519.py
+++ b/libp2p/crypto/ed25519.py
@@ -69,7 +69,7 @@ class Ed25519PrivateKey(PrivateKey):
     def sign(self, data: bytes) -> bytes:
         h = SHA256.new(data)
         signing_key = SigningKey(self.to_bytes())
-        return signing_key.sign(h)
+        return signing_key.sign(h.digest())
 
     def get_public_key(self) -> PublicKey:
         return Ed25519PublicKey(self.impl.public_key)

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -1,3 +1,7 @@
+from __future__ import (
+    annotations,
+)
+
 import base64
 import functools
 import hashlib
@@ -6,12 +10,8 @@ import time
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     KeysView,
-    List,
     NamedTuple,
-    Set,
-    Tuple,
     cast,
 )
 
@@ -111,20 +111,20 @@ class TopicValidator(NamedTuple):
 class Pubsub(Service, IPubsub):
     host: IHost
 
-    router: "IPubsubRouter"
+    router: IPubsubRouter
 
-    peer_receive_channel: "trio.MemoryReceiveChannel[ID]"
-    dead_peer_receive_channel: "trio.MemoryReceiveChannel[ID]"
+    peer_receive_channel: trio.MemoryReceiveChannel[ID]
+    dead_peer_receive_channel: trio.MemoryReceiveChannel[ID]
 
-    seen_messages: LRU
+    seen_messages: LRU[bytes, int]
 
-    subscribed_topics_send: Dict[str, "trio.MemorySendChannel[rpc_pb2.Message]"]
-    subscribed_topics_receive: Dict[str, "TrioSubscriptionAPI"]
+    subscribed_topics_send: dict[str, trio.MemorySendChannel[rpc_pb2.Message]]
+    subscribed_topics_receive: dict[str, TrioSubscriptionAPI]
 
-    peer_topics: Dict[str, Set[ID]]
-    peers: Dict[ID, INetStream]
+    peer_topics: dict[str, set[ID]]
+    peers: dict[ID, INetStream]
 
-    topic_validators: Dict[str, TopicValidator]
+    topic_validators: dict[str, TopicValidator]
 
     counter: int  # uint64
 
@@ -138,7 +138,7 @@ class Pubsub(Service, IPubsub):
     def __init__(
         self,
         host: IHost,
-        router: "IPubsubRouter",
+        router: IPubsubRouter,
         cache_size: int = None,
         strict_signing: bool = True,
         msg_id_constructor: Callable[
@@ -222,7 +222,7 @@ class Pubsub(Service, IPubsub):
         return self.host.get_id()
 
     @property
-    def protocols(self) -> Tuple[TProtocol, ...]:
+    def protocols(self) -> tuple[TProtocol, ...]:
         return tuple(self.router.get_protocols())
 
     @property
@@ -311,7 +311,7 @@ class Pubsub(Service, IPubsub):
         """
         self.topic_validators.pop(topic, None)
 
-    def get_msg_validators(self, msg: rpc_pb2.Message) -> Tuple[TopicValidator, ...]:
+    def get_msg_validators(self, msg: rpc_pb2.Message) -> tuple[TopicValidator, ...]:
         """
         Get all validators corresponding to the topics in the message.
 
@@ -569,8 +569,8 @@ class Pubsub(Service, IPubsub):
         :param msg_forwarder: the peer who forward us the message.
         :param msg: the message.
         """
-        sync_topic_validators: List[SyncValidatorFn] = []
-        async_topic_validators: List[AsyncValidatorFn] = []
+        sync_topic_validators: list[SyncValidatorFn] = []
+        async_topic_validators: list[AsyncValidatorFn] = []
         for topic_validator in self.get_msg_validators(msg):
             if topic_validator.is_async:
                 async_topic_validators.append(

--- a/newsfragments/472.internal.rst
+++ b/newsfragments/472.internal.rst
@@ -1,0 +1,1 @@
+Bump to ``mypy==1.10.0``, run ``pre-commit`` local hook instead of ``mirrors-mypy``

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "build>=0.9.0",
         "bump-my-version>=0.5.3",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",
@@ -52,19 +53,20 @@ with open("./README.md") as readme:
 
 
 install_requires = [
-    "pycryptodome>=3.9.2",
     "base58>=1.0.3",
-    "pymultihash>=0.8.2",
-    "multiaddr>=0.0.9",
-    "rpcudp>=3.0.0",
-    "lru-dict>=1.1.6",
-    "protobuf>=3.10.0",
     "coincurve>=10.0.0",
-    "pynacl>=1.3.0",
-    "trio>=0.15.0",
-    "noiseprotocol>=0.3.0",
-    "trio-typing>=0.0.4",
     "exceptiongroup>=1.2.0; python_version < '3.11'",
+    "lru-dict>=1.1.6",
+    "multiaddr>=0.0.9",
+    "mypy-protobuf>=3.0.0",
+    "noiseprotocol>=0.3.0",
+    "protobuf>=3.10.0",
+    "pycryptodome>=3.9.2",
+    "pymultihash>=0.8.2",
+    "pynacl>=1.3.0",
+    "rpcudp>=3.0.0",
+    "trio-typing>=0.0.4",
+    "trio>=0.15.0",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=
+    dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## What was wrong?

Running mypy via the pre-commit mirrors-mypy hook misses context of other libs installed as part of py-libp2p.

## How was it fixed?

Created a hook to run mypy locally. 
Bumped mypy dep to 1.10.0
Fixed new errors
sorted the list of `install_requires` deps

### To-Do

- [ ] Clean up commit history

* [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/libp2p/py-libp2p/assets/5199899/bbdad8d5-30eb-4dd1-9222-bd1966f3a5ca)
