### PR TITLE
drop resource class xlarge requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ docs: &docs
           - ~/.cache/pip
           - ~/.local
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  resource_class: xlarge
 
 interop: &interop
   docker:


### PR DESCRIPTION
## What was wrong?

CI started failing saying `xlarge` is no longer a valid resource class.

## How was it fixed?

Doesn't appear necessary, try dropping.

### To-Do

- [ ] Clean up commit history

* [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
