### PR TITLE
replace display_version with two other options

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,5 +17,6 @@ python:
         - docs
         - test
 
-# Build all formats for RTD Downloads - htmlzip, pdf, epub
-formats: all
+formats:
+  - epub
+  - htmlzip

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ build-docs:
 check-docs-ci: build-docs build-docs-ci validate-newsfragments
 
 build-docs-ci:
-	$(MAKE) -C docs latexpdf
 	$(MAKE) -C docs epub
 
 # release commands

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,8 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 html_theme_options = {
     "logo_only": True,
-    "display_version": False,
+    "version_selector": False,
+    "language_selector": False,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/newsfragments/481.internal.rst
+++ b/newsfragments/481.internal.rst
@@ -1,0 +1,1 @@
+Update ``sphinx_rtd_theme`` options and drop pdf build of docs


### PR DESCRIPTION
## What was wrong?

html build uses a deprecated sphinx_rtd_theme option: `display_version`
```
$ make html
preparing documents... WARNING: unsupported theme option 'display_version' given
```

## How was it fixed?

Replace `display_version` in conf.py with `language_selector` and `version_selector`, both set to false.

https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html

### To-Do

- [ ] Clean up commit history

* [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)
