### PR TITLE
Fixed Failing Tests due to RaisesGroup of Trio Package

### DIFF
--- a/newsfragments/482.internal.rst
+++ b/newsfragments/482.internal.rst
@@ -1,0 +1,1 @@
+Update ``trio`` package version dependency

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     "pynacl>=1.3.0",
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",
-    "trio>=0.15.0",
+    "trio>=0.26.0",
 ]
 
 

--- a/tests/core/protocol_muxer/test_protocol_muxer.py
+++ b/tests/core/protocol_muxer/test_protocol_muxer.py
@@ -67,7 +67,7 @@ async def test_single_protocol_fails(security_protocol):
 
     # the StreamFailure is within 2 nested ExceptionGroups, so we use strict=False
     # to unwrap down to the core Exception
-    with RaisesGroup(StreamFailure, strict=False):
+    with RaisesGroup(StreamFailure, allow_unwrapped=True, flatten_subgroups=True):
         await perform_simple_test(
             "", [PROTOCOL_ECHO], [PROTOCOL_POTATO], security_protocol
         )
@@ -112,7 +112,7 @@ async def test_multiple_protocol_fails(security_protocol):
 
     # the StreamFailure is within 2 nested ExceptionGroups, so we use strict=False
     # to unwrap down to the core Exception
-    with RaisesGroup(StreamFailure, strict=False):
+    with RaisesGroup(StreamFailure, allow_unwrapped=True, flatten_subgroups=True):
         await perform_simple_test(
             "", protocols_for_client, protocols_for_listener, security_protocol
         )

--- a/tests/core/tools/async_service/test_trio_based_service.py
+++ b/tests/core/tools/async_service/test_trio_based_service.py
@@ -135,7 +135,9 @@ async def test_trio_service_lifecycle_run_and_exception():
 
     async def do_service_run():
         with RaisesGroup(
-            Matcher(RuntimeError, match="Service throwing error"), strict=False
+            Matcher(RuntimeError, match="Service throwing error"),
+            allow_unwrapped=True,
+            flatten_subgroups=True,
         ):
             await manager.run()
 
@@ -164,7 +166,9 @@ async def test_trio_service_lifecycle_run_and_task_exception():
 
     async def do_service_run():
         with RaisesGroup(
-            Matcher(RuntimeError, match="Service throwing error"), strict=False
+            Matcher(RuntimeError, match="Service throwing error"),
+            allow_unwrapped=True,
+            flatten_subgroups=True,
         ):
             await manager.run()
 
@@ -226,7 +230,11 @@ async def test_trio_service_lifecycle_run_and_daemon_task_exit():
     manager = TrioManager(service)
 
     async def do_service_run():
-        with RaisesGroup(Matcher(DaemonTaskExit, match="Daemon task"), strict=False):
+        with RaisesGroup(
+            Matcher(DaemonTaskExit, match="Daemon task"),
+            allow_unwrapped=True,
+            flatten_subgroups=True,
+        ):
             await manager.run()
 
     await do_service_lifecycle_check(
@@ -388,7 +396,9 @@ async def test_trio_service_manager_run_task_reraises_exceptions():
             await trio.sleep_forever()
 
     with RaisesGroup(
-        Matcher(Exception, match="task exception in run_task"), strict=False
+        Matcher(Exception, match="task exception in run_task"),
+        allow_unwrapped=True,
+        flatten_subgroups=True,
     ):
         async with background_trio_service(RunTaskService()):
             task_event.set()
@@ -413,7 +423,8 @@ async def test_trio_service_manager_run_daemon_task_cancels_if_exits():
         Matcher(
             DaemonTaskExit, match=r"Daemon task daemon_task_fn\[daemon=True\] exited"
         ),
-        strict=False,
+        allow_unwrapped=True,
+        flatten_subgroups=True,
     ):
         async with background_trio_service(RunTaskService()):
             task_event.set()
@@ -432,7 +443,11 @@ async def test_trio_service_manager_propogates_and_records_exceptions():
 
     assert manager.did_error is False
 
-    with RaisesGroup(Matcher(RuntimeError, match="this is the error"), strict=False):
+    with RaisesGroup(
+        Matcher(RuntimeError, match="this is the error"),
+        allow_unwrapped=True,
+        flatten_subgroups=True,
+    ):
         await manager.run()
 
     assert manager.did_error is True
@@ -645,7 +660,7 @@ async def test_error_in_service_run():
             self.manager.run_daemon_task(self.manager.wait_finished)
             raise ValueError("Exception inside run()")
 
-    with RaisesGroup(ValueError, strict=False):
+    with RaisesGroup(ValueError, allow_unwrapped=True, flatten_subgroups=True):
         await TrioManager.run_service(ServiceTest())
 
 
@@ -664,5 +679,5 @@ async def test_daemon_task_finishes_leaving_children():
         async def run(self):
             self.manager.run_daemon_task(self.buggy_daemon)
 
-    with RaisesGroup(DaemonTaskExit, strict=False):
+    with RaisesGroup(DaemonTaskExit, allow_unwrapped=True, flatten_subgroups=True):
         await TrioManager.run_service(ServiceTest())

--- a/tests/core/tools/async_service/test_trio_external_api.py
+++ b/tests/core/tools/async_service/test_trio_external_api.py
@@ -50,7 +50,7 @@ async def test_trio_service_external_api_raises_when_cancelled():
     service = ExternalAPIService()
 
     async with background_trio_service(service) as manager:
-        with RaisesGroup(LifecycleError, strict=False):
+        with RaisesGroup(LifecycleError, allow_unwrapped=True, flatten_subgroups=True):
             async with trio.open_nursery() as nursery:
                 # an event to ensure that we are indeed within the body of the
                 is_within_fn = trio.Event()


### PR DESCRIPTION
## Issue with `RaisesGroup`

The failed tests were a result of deprecated keyword `strict` for `trio.testing.RaisesGroup`.

## How was it fixed?

I updated the keywords from `strict` to `allow_unwrapped` and `flatten_subgroups`, and assigning value `True` to both, this fixed the failing tests but `protobuf` warnings still remain but it doesn't break the tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://img.freepik.com/premium-photo/close-up-cute-honey-badger-grass-created-using-generative-ai-technology_772924-2681.jpg>)
