### PR TITLE
reject messages claiming to be from ourselves but not locally published

### DIFF
--- a/newsfragments/413.bugfix.rst
+++ b/newsfragments/413.bugfix.rst
@@ -1,0 +1,1 @@
+Added missing check to reject messages claiming to be from ourselves but not locally published in pubsub's ``push_msg`` function

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -535,7 +535,7 @@ async def test_publish_push_msg_is_called(monkeypatch):
 
 @pytest.mark.trio
 async def test_push_msg(monkeypatch):
-    async with PubsubFactory.create_batch_with_floodsub(1) as pubsubs_fsub:
+    async with PubsubFactory.create_batch_with_floodsub(2) as pubsubs_fsub:
         msg_0 = make_pubsub_msg(
             origin_id=pubsubs_fsub[0].my_id,
             topic_ids=[TESTING_TOPIC],
@@ -568,6 +568,18 @@ async def test_push_msg(monkeypatch):
             # Test: `push_msg` the message again and it will be reject.
             #   `router_publish` is not called then.
             await pubsubs_fsub[0].push_msg(pubsubs_fsub[0].my_id, msg_0)
+            await trio.sleep(0.01)
+            assert not event.is_set()
+
+            # Test: `push_msg` a new msg but forwarder as not self, it will be reject.
+            #   `router_publish` is not called then.
+            msg_0A = make_pubsub_msg(
+                origin_id=pubsubs_fsub[0].my_id,
+                topic_ids=[TESTING_TOPIC],
+                data=TESTING_DATA,
+                seqno=b"\x33" * 8,
+            )
+            await pubsubs_fsub[0].push_msg(pubsubs_fsub[1].my_id, msg_0A)
             await trio.sleep(0.01)
             assert not event.is_set()
 


### PR DESCRIPTION
## What was wrong?

There was a missing check in `push_msg` function inside the `pubsub` module wherein we weren't rejecting messages claiming to be from ourselves but not locally published

Closes #413 

## How was it fixed?

I took a reference from [`go-libp2p-pubsub`](https://github.com/libp2p/go-libp2p-pubsub/blob/c06df2f9a38e9382e644b241adf0e96e5ca00955/pubsub.go#L1154) implementation and added the missing check

### To-Do

- [X] Ran `tests`
- [X] Ran `make lint`
- [X] Added `newsfragment`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://i.ytimg.com/vi/VM2TzG5psJo/hq720.jpg?sqp=-oaymwEhCK4FEIIDSFryq4qpAxMIARUAAAAAGAElAADIQj0AgKJD&rs=AOn4CLDyJ4CAORv8RnSr6bvT-BNX37Bn6g>)
