### PR TITLE
No Duplicate Peers in Peerdata

### DIFF
--- a/libp2p/peer/peerdata.py
+++ b/libp2p/peer/peerdata.py
@@ -55,7 +55,9 @@ class PeerData(IPeerData):
         """
         :param addrs: multiaddresses to add
         """
-        self.addrs.extend(addrs)
+        for addr in addrs:
+            if addr not in self.addrs:
+                self.addrs.append(addr)
 
     def get_addrs(self) -> List[Multiaddr]:
         """

--- a/newsfragments/485.bugfix.rst
+++ b/newsfragments/485.bugfix.rst
@@ -1,0 +1,1 @@
+Added missing check in ``add_addrs`` function for duplicate addresses in ``peerdata``

--- a/tests/core/peer/test_peerdata.py
+++ b/tests/core/peer/test_peerdata.py
@@ -1,94 +1,106 @@
-import unittest
-from unittest.mock import (
-    MagicMock,
-)
+import pytest
 
-from multiaddr import (
-    Multiaddr,
-)
-
-from libp2p.crypto.keys import (
-    PrivateKey,
-    PublicKey,
+from libp2p.crypto.secp256k1 import (
+    create_new_key_pair,
 )
 from libp2p.peer.peerdata import (
     PeerData,
     PeerDataError,
 )
 
+MOCK_ADDR = "/peer"
+MOCK_KEYPAIR = create_new_key_pair()
+MOCK_PUBKEY = MOCK_KEYPAIR.public_key
+MOCK_PRIVKEY = MOCK_KEYPAIR.private_key
 
-class TestPeerData(unittest.TestCase):
-    def setUp(self):
-        # This will run before each test method
-        self.peer_data = PeerData()
-        self.mock_pubkey = MagicMock(PublicKey)
-        self.mock_privkey = MagicMock(PrivateKey)
-        self.mock_addr = MagicMock(Multiaddr)
 
-    def test_get_protocols_empty(self):
-        # Test case when no protocols have been added
-        self.assertEqual(self.peer_data.get_protocols(), [])
+# Test case when no protocols have been added
+def test_get_protocols_empty():
+    peer_data = PeerData()
+    assert peer_data.get_protocols() == []
 
-    def test_add_protocols(self):
-        # Test case when adding protocols
-        protocols = ["protocol1", "protocol2"]
-        self.peer_data.add_protocols(protocols)
-        self.assertEqual(self.peer_data.get_protocols(), protocols)
 
-    def test_set_protocols(self):
-        # Test case when setting protocols
-        protocols = ["protocolA", "protocolB"]
-        self.peer_data.set_protocols(protocols)
-        self.assertEqual(self.peer_data.get_protocols(), protocols)
+# Test case when adding protocols
+def test_add_protocols():
+    peer_data = PeerData()
+    protocols = ["protocol1", "protocol2"]
+    peer_data.add_protocols(protocols)
+    assert peer_data.get_protocols() == protocols
 
-    def test_add_addrs(self):
-        # Test case when adding addresses
-        addresses = [self.mock_addr]
-        self.peer_data.add_addrs(addresses)
-        self.assertEqual(self.peer_data.get_addrs(), addresses)
 
-    def test_add_dup_addrs(self):
-        # Test case when adding same address more than once
-        addresses = [self.mock_addr, self.mock_addr]
-        self.peer_data.add_addrs(addresses)
-        self.peer_data.add_addrs(addresses)
-        self.assertEqual(self.peer_data.get_addrs(), [self.mock_addr])
+# Test case when setting protocols
+def test_set_protocols():
+    peer_data = PeerData()
+    protocols = ["protocolA", "protocolB"]
+    peer_data.set_protocols(protocols)
+    assert peer_data.get_protocols() == protocols
 
-    def test_clear_addrs(self):
-        # Test case for clearing addresses
-        addresses = [self.mock_addr]
-        self.peer_data.add_addrs(addresses)
-        self.peer_data.clear_addrs()
-        self.assertEqual(self.peer_data.get_addrs(), [])
 
-    def test_put_metadata(self):
-        # Test case for adding metadata
-        key = "key1"
-        value = "value1"
-        self.peer_data.put_metadata(key, value)
-        self.assertEqual(self.peer_data.get_metadata(key), value)
+# Test case when adding addresses
+def test_add_addrs():
+    peer_data = PeerData()
+    addresses = [MOCK_ADDR]
+    peer_data.add_addrs(addresses)
+    assert peer_data.get_addrs() == addresses
 
-    def test_get_metadata_key_not_found(self):
-        # Test case for key not found in metadata
-        with self.assertRaises(PeerDataError):
-            self.peer_data.get_metadata("nonexistent_key")
 
-    def test_add_pubkey(self):
-        # Test case for adding public key
-        self.peer_data.add_pubkey(self.mock_pubkey)
-        self.assertEqual(self.peer_data.get_pubkey(), self.mock_pubkey)
+# Test case when adding same address more than once
+def test_add_dup_addrs():
+    peer_data = PeerData()
+    addresses = [MOCK_ADDR, MOCK_ADDR]
+    peer_data.add_addrs(addresses)
+    peer_data.add_addrs(addresses)
+    assert peer_data.get_addrs() == [MOCK_ADDR]
 
-    def test_get_pubkey_not_found(self):
-        # Test case when public key is not set
-        with self.assertRaises(PeerDataError):
-            self.peer_data.get_pubkey()
 
-    def test_add_privkey(self):
-        # Test case for adding private key
-        self.peer_data.add_privkey(self.mock_privkey)
-        self.assertEqual(self.peer_data.get_privkey(), self.mock_privkey)
+# Test case for clearing addresses
+def test_clear_addrs():
+    peer_data = PeerData()
+    addresses = [MOCK_ADDR]
+    peer_data.add_addrs(addresses)
+    peer_data.clear_addrs()
+    assert peer_data.get_addrs() == []
 
-    def test_get_privkey_not_found(self):
-        # Test case when private key is not set
-        with self.assertRaises(PeerDataError):
-            self.peer_data.get_privkey()
+
+# Test case for adding metadata
+def test_put_metadata():
+    peer_data = PeerData()
+    key = "key1"
+    value = "value1"
+    peer_data.put_metadata(key, value)
+    assert peer_data.get_metadata(key) == value
+
+
+# Test case for key not found in metadata
+def test_get_metadata_key_not_found():
+    peer_data = PeerData()
+    with pytest.raises(PeerDataError):
+        peer_data.get_metadata("nonexistent_key")
+
+
+# Test case for adding public key
+def test_add_pubkey():
+    peer_data = PeerData()
+    peer_data.add_pubkey(MOCK_PUBKEY)
+    assert peer_data.get_pubkey() == MOCK_PUBKEY
+
+
+# Test case when public key is not set
+def test_get_pubkey_not_found():
+    peer_data = PeerData()
+    with pytest.raises(PeerDataError):
+        peer_data.get_pubkey()
+
+
+# Test case for adding private key
+def test_add_privkey():
+    peer_data = PeerData()
+    peer_data.add_privkey(MOCK_PRIVKEY)
+    assert peer_data.get_privkey() == MOCK_PRIVKEY
+
+
+# Test case when private key is not set
+def test_get_privkey_not_found():
+    peer_data = PeerData()
+    with pytest.raises(PeerDataError):
+        peer_data.get_privkey()

--- a/tests/core/peer/test_peerdata.py
+++ b/tests/core/peer/test_peerdata.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import (
+    MagicMock,
+)
+
+from multiaddr import (
+    Multiaddr,
+)
+
+from libp2p.crypto.keys import (
+    PrivateKey,
+    PublicKey,
+)
+from libp2p.peer.peerdata import (
+    PeerData,
+    PeerDataError,
+)
+
+
+class TestPeerData(unittest.TestCase):
+    def setUp(self):
+        # This will run before each test method
+        self.peer_data = PeerData()
+        self.mock_pubkey = MagicMock(PublicKey)
+        self.mock_privkey = MagicMock(PrivateKey)
+        self.mock_addr = MagicMock(Multiaddr)
+
+    def test_get_protocols_empty(self):
+        # Test case when no protocols have been added
+        self.assertEqual(self.peer_data.get_protocols(), [])
+
+    def test_add_protocols(self):
+        # Test case when adding protocols
+        protocols = ["protocol1", "protocol2"]
+        self.peer_data.add_protocols(protocols)
+        self.assertEqual(self.peer_data.get_protocols(), protocols)
+
+    def test_set_protocols(self):
+        # Test case when setting protocols
+        protocols = ["protocolA", "protocolB"]
+        self.peer_data.set_protocols(protocols)
+        self.assertEqual(self.peer_data.get_protocols(), protocols)
+
+    def test_add_addrs(self):
+        # Test case when adding addresses
+        addresses = [self.mock_addr]
+        self.peer_data.add_addrs(addresses)
+        self.assertEqual(self.peer_data.get_addrs(), addresses)
+
+    def test_add_dup_addrs(self):
+        # Test case when adding same address more than once
+        addresses = [self.mock_addr, self.mock_addr]
+        self.peer_data.add_addrs(addresses)
+        self.peer_data.add_addrs(addresses)
+        self.assertEqual(self.peer_data.get_addrs(), [self.mock_addr])
+
+    def test_clear_addrs(self):
+        # Test case for clearing addresses
+        addresses = [self.mock_addr]
+        self.peer_data.add_addrs(addresses)
+        self.peer_data.clear_addrs()
+        self.assertEqual(self.peer_data.get_addrs(), [])
+
+    def test_put_metadata(self):
+        # Test case for adding metadata
+        key = "key1"
+        value = "value1"
+        self.peer_data.put_metadata(key, value)
+        self.assertEqual(self.peer_data.get_metadata(key), value)
+
+    def test_get_metadata_key_not_found(self):
+        # Test case for key not found in metadata
+        with self.assertRaises(PeerDataError):
+            self.peer_data.get_metadata("nonexistent_key")
+
+    def test_add_pubkey(self):
+        # Test case for adding public key
+        self.peer_data.add_pubkey(self.mock_pubkey)
+        self.assertEqual(self.peer_data.get_pubkey(), self.mock_pubkey)
+
+    def test_get_pubkey_not_found(self):
+        # Test case when public key is not set
+        with self.assertRaises(PeerDataError):
+            self.peer_data.get_pubkey()
+
+    def test_add_privkey(self):
+        # Test case for adding private key
+        self.peer_data.add_privkey(self.mock_privkey)
+        self.assertEqual(self.peer_data.get_privkey(), self.mock_privkey)
+
+    def test_get_privkey_not_found(self):
+        # Test case when private key is not set
+        with self.assertRaises(PeerDataError):
+            self.peer_data.get_privkey()


### PR DESCRIPTION
## What was wrong?

The `add_addrs` function lacked checking if the address already exists in the peerdata, necessary tests have been added.

updated from #325 & #479 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://static.vecteezy.com/system/resources/thumbnails/032/875/501/small_2x/of-heart-melting-two-bears-with-an-emphasis-on-expression-of-love-generative-ai-photo.jpg>)
