### PR TITLE
Fixed Doc Comments

### DIFF
--- a/libp2p/pubsub/abc.py
+++ b/libp2p/pubsub/abc.py
@@ -83,7 +83,7 @@ class IPubsubRouter(ABC):
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
 
-        :param rpc: rpc message
+        :param rpc: RPC message
         :param sender_peer_id: id of the peer who sent the message
         """
 

--- a/libp2p/pubsub/abc.py
+++ b/libp2p/pubsub/abc.py
@@ -66,6 +66,7 @@ class IPubsubRouter(ABC):
         Notifies the router that a new peer has been connected.
 
         :param peer_id: id of peer to add
+        :param protocol_id: router protocol the peer speaks, e.g., floodsub, gossipsub
         """
 
     @abstractmethod
@@ -81,10 +82,9 @@ class IPubsubRouter(ABC):
         """
         Invoked to process control messages in the RPC envelope.
         It is invoked after subscriptions and payload messages have been processed
-        TODO: Check if this interface is ok. It's not the exact same as the go code, but
-        the go code is really confusing with the msg origin, they specify `rpc.from`
-        even when the rpc shouldn't have a from
+
         :param rpc: rpc message
+        :param sender_peer_id: id of the peer who sent the message
         """
 
     @abstractmethod

--- a/libp2p/pubsub/floodsub.py
+++ b/libp2p/pubsub/floodsub.py
@@ -75,10 +75,11 @@ class FloodSub(IPubsubRouter):
 
     async def handle_rpc(self, rpc: rpc_pb2.RPC, sender_peer_id: ID) -> None:
         """
-        Invoked to process control messages in the RPC envelope. It is invoked
-        after subscriptions and payload messages have been processed.
+        Invoked to process control messages in the RPC envelope.
+        It is invoked after subscriptions and payload messages have been processed
 
-        :param rpc: rpc message
+        :param rpc: RPC message
+        :param sender_peer_id: id of the peer who sent the message
         """
         # Checkpoint
         await trio.lowlevel.checkpoint()

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -179,8 +179,8 @@ class GossipSub(IPubsubRouter, Service):
 
     async def handle_rpc(self, rpc: rpc_pb2.RPC, sender_peer_id: ID) -> None:
         """
-        Invoked to process control messages in the RPC envelope. It is invoked
-        after subscriptions and payload messages have been processed.
+        Invoked to process control messages in the RPC envelope.
+        It is invoked after subscriptions and payload messages have been processed
 
         :param rpc: RPC message
         :param sender_peer_id: id of the peer who sent the message

--- a/newsfragments/486.docs.rst
+++ b/newsfragments/486.docs.rst
@@ -1,0 +1,1 @@
+added missing details of params in ``IPubsubRouter``


### PR DESCRIPTION
## What was wrong?

There were some missing comments for params in `abc.py` under the pubsub folder.
There was an outdated TODO which was to check whether the interface was correct or not, I reviewed the usage of `handle_rpc` function in both `py-libp2p` and `go-libp2p`, the `sender_peer_id` is a necessary param which allows us to keep context for who sent this message to us. Thus, the TODO is resolved and removed.

I have added the newsfragment for the same.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://i.pinimg.com/736x/0f/72/ab/0f72ab571b175c28621eda61ee3b29ea.jpg>)
