### PR TITLE
pubsub fixes and improvements

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -116,7 +116,7 @@ class Pubsub(Service, IPubsub):
     peer_receive_channel: trio.MemoryReceiveChannel[ID]
     dead_peer_receive_channel: trio.MemoryReceiveChannel[ID]
 
-    seen_messages: LRU[bytes, int]
+    seen_messages: LRU[bytes, bool]
 
     subscribed_topics_send: dict[str, trio.MemorySendChannel[rpc_pb2.Message]]
     subscribed_topics_receive: dict[str, TrioSubscriptionAPI]
@@ -670,9 +670,7 @@ class Pubsub(Service, IPubsub):
 
     def _mark_msg_seen(self, msg: rpc_pb2.Message) -> None:
         msg_id = self._msg_id_constructor(msg)
-        # FIXME: Mapping `msg_id` to `1` is quite awkward. Should investigate if there
-        # is a more appropriate way.
-        self.seen_messages[msg_id] = 1
+        self.seen_messages[msg_id] = True
 
     def _is_subscribed_to_msg(self, msg: rpc_pb2.Message) -> bool:
         return any(topic in self.topic_ids for topic in msg.topicIDs)


### PR DESCRIPTION
## What was wrong?
I am currently working on upgrading Gossipsub to v1.1 but before that I wanted to go through the pubsub implementation in detail and close any issues, TODOs and FIXMEs.

## How was it fixed?

I have resolved a [FIXME](https://github.com/libp2p/py-libp2p/blob/33332d71060d11c1db3f99200582e19e8f42f573/libp2p/pubsub/pubsub.py#L673) comment which required to use something better than `integer`, so I suggest using `boolean` as it will be more memory efficient compared to `integer`.

This PR is still a work in progess....

### To-Do

- [ ] add `newsfragment`
- [ ] attempt to fix open issues concerning pubsub

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://www.shutterstock.com/image-vector/cute-bison-shorts-swimming-trunks-600nw-2425467739.jpg>)
