### PR TITLE
fix: prevent infinite loop by adding break statement in example ping.py

### DIFF
--- a/examples/ping/ping.py
+++ b/examples/ping/ping.py
@@ -34,6 +34,7 @@ async def handle_ping(stream: INetStream) -> None:
 
         except Exception:
             await stream.reset()
+            break
 
 
 async def send_ping(stream: INetStream) -> None:

--- a/newsfragments/492.bugfix.rst
+++ b/newsfragments/492.bugfix.rst
@@ -1,0 +1,1 @@
+- This fix issue #492 adding a missing break statement that lowers GIL usage from 99% to 0%-2%.


### PR DESCRIPTION
## What was wrong?

Issue #492 Enhancement of the ```ping.py``` example to improve performance and clarity. The issue addressed high GIL contention in the handle_ping function

## How was it fixed?

Adding a missing ```break``` statement
These changes lowered the GIL usage to between 0%-2%, a significant improvement over the original implementation.

### To-Do

- [ ] Clean up commit history

* [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQQrZwbluHwVQmkXAD2uP_FgL8d5UwvTMUGpw&s)
