### PR TITLE
fix(readme): fix broken link to standard libp2p implementation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently maintained by [@pacrob](https://github.com/pacrob) and [@dhuseby](http
 
 ## Feature Breakdown
 
-py-libp2p aims for conformity with [the standard libp2p modules](https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md#libp2p-modules-implementations). Below is a breakdown of the modules we have developed, are developing, and may develop in the future.
+py-libp2p aims for conformity with [the standard libp2p modules](https://libp2p.io/implementations/). Below is a breakdown of the modules we have developed, are developing, and may develop in the future.
 
 > Legend: :green_apple: Done   :lemon: In Progress   :tomato: Missing   :chestnut: Not planned
 


### PR DESCRIPTION
## What was wrong?

The link to the standard libp2p modules in `Feature Breakdown` section is broken: https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md#libp2p-modules-implementations.
The linked resource is non-existent, see [here](https://github.com/libp2p/libp2p/pull/97) for more details

## How was it fixed?

replaced the broken link with https://libp2p.io/implementations/

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1526660690293-bcd32dc3b123?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)