### PR TITLE
add pypy to ci checks

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -89,23 +89,23 @@ jobs:
           python -m pip install tox
           python -m pip install --no-binary :all: cffi
 
-      # - run: |
-      #     python -m tox run -r
       - run: |
-          # Write sitecustomize.py that patches _cffi_backend
-          mkdir -p .ci-pypy-patch
-          cat <<EOF > .ci-pypy-patch/sitecustomize.py
-          import sys
-          try:
-              import _cffi_backend
-              if not hasattr(_cffi_backend, '__file__'):
-                  _cffi_backend.__file__ = "/usr/lib/libcffi.so"  # dummy fallback path
-          except (ImportError, AttributeError):
-              pass
-          EOF
-
-          # Set PYTHONPATH to load the patch
-          export PYTHONPATH="$PWD/.ci-pypy-patch"
-
-          # Run tox
           python -m tox run -r
+      # - run: |
+      #     # Write sitecustomize.py that patches _cffi_backend
+      #     mkdir -p .ci-pypy-patch
+      #     cat <<EOF > .ci-pypy-patch/sitecustomize.py
+      #     import sys
+      #     try:
+      #         import _cffi_backend
+      #         if not hasattr(_cffi_backend, '__file__'):
+      #             _cffi_backend.__file__ = "/usr/lib/libcffi.so"  # dummy fallback path
+      #     except (ImportError, AttributeError):
+      #         pass
+      #     EOF
+
+      #     # Set PYTHONPATH to load the patch
+      #     export PYTHONPATH="$PWD/.ci-pypy-patch"
+
+      #     # Run tox
+      #     python -m tox run -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.9', 'pypy3.10']
         toxenv: [core, interop, lint, wheel, demos]
         include:
           - python: '3.10'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -67,3 +67,27 @@ jobs:
           else
             python -m tox run -e py311-${{ matrix.toxenv }}
           fi
+  tox-pypy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['pypy3.9', 'pypy3.10']
+        toxenv: [core, wheel]
+      fail-fast: false
+    steps:
+      - env:
+          python: ${{ matrix.python }}
+          toxenv: ${{ matrix.toxenv }}
+        run: |
+          echo "TOXENV=${python}-${toxenv}" | tr -d '.' | tee -a $GITHUB_ENV
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+          python -m pip install --no-binary :all: cffi
+
+      - run: |
+          python -m tox run -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -85,10 +85,27 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          sudo apt-get install libffi-dev
           python -m pip install --upgrade pip
           python -m pip install tox
           python -m pip install --no-binary :all: cffi
 
+      # - run: |
+      #     python -m tox run -r
       - run: |
+          # Write sitecustomize.py that patches _cffi_backend
+          mkdir -p .ci-pypy-patch
+          cat <<EOF > .ci-pypy-patch/sitecustomize.py
+          import sys
+          try:
+              import _cffi_backend
+              if not hasattr(_cffi_backend, '__file__'):
+                  _cffi_backend.__file__ = "/usr/lib/libcffi.so"  # dummy fallback path
+          except (ImportError, AttributeError):
+              pass
+          EOF
+
+          # Set PYTHONPATH to load the patch
+          export PYTHONPATH="$PWD/.ci-pypy-patch"
+
+          # Run tox
           python -m tox run -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -87,25 +87,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           python -m pip install tox
-          python -m pip install --no-binary :all: cffi
+          python -m pip install cffi
 
       - run: |
           python -m tox run -r
-      # - run: |
-      #     # Write sitecustomize.py that patches _cffi_backend
-      #     mkdir -p .ci-pypy-patch
-      #     cat <<EOF > .ci-pypy-patch/sitecustomize.py
-      #     import sys
-      #     try:
-      #         import _cffi_backend
-      #         if not hasattr(_cffi_backend, '__file__'):
-      #             _cffi_backend.__file__ = "/usr/lib/libcffi.so"  # dummy fallback path
-      #     except (ImportError, AttributeError):
-      #         pass
-      #     EOF
-
-      #     # Set PYTHONPATH to load the patch
-      #     export PYTHONPATH="$PWD/.ci-pypy-patch"
-
-      #     # Run tox
-      #     python -m tox run -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
+          sudo apt-get install libffi-dev
           python -m pip install --upgrade pip
           python -m pip install tox
           python -m pip install --no-binary :all: cffi

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.9', 'pypy3.10']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         toxenv: [core, interop, lint, wheel, demos]
         include:
           - python: '3.10'
@@ -88,6 +88,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox
           python -m pip install cffi
+          python -m pip install _cffi_backend
 
       - run: |
           python -m tox run -r

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -87,8 +87,6 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           python -m pip install tox
-          python -m pip install cffi
-          python -m pip install _cffi_backend
 
       - run: |
           python -m tox run -r

--- a/newsfragments/505.internal.rst
+++ b/newsfragments/505.internal.rst
@@ -1,0 +1,1 @@
+Adds ``pypy3.9`` and ``pypy3.10`` to CI checks.

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,9 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Programming Language :: Python :: Implementation :: PyPy :: 3.9",
+        "Programming Language :: Python :: Implementation :: PyPy :: 3.10",
     ],
     platforms=["unix", "linux", "osx", "win32"],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
-    py{39,310,311,312,313}-core
-    py{39,310,311,312,313}-lint
-    py{39,310,311,312,313}-wheel
-    py{39,310,311,312,313}-interop
+    py{39,310,311,312,313,py39,py310}-core
+    py{39,310,311,312,313,py39,py310}-lint
+    py{39,310,311,312,313,py39,py310}-wheel
+    py{39,310,311,312,313,py39,py310}-interop
     windows-wheel
     docs
 
@@ -31,6 +31,8 @@ basepython=
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    pypypy39: pypy3.9
+    pypypy310: pypy3.10
 extras=
     test
     docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist=
-    py{39,310,311,312,313,py39,py310}-core
-    py{39,310,311,312,313,py39,py310}-lint
-    py{39,310,311,312,313,py39,py310}-wheel
-    py{39,310,311,312,313,py39,py310}-interop
+    py{39,310,311,312,313}-core
+    pypy{39,310}-core
+    py{39,310,311,312,313}-lint
+    py{39,310,311,312,313}-wheel
+    pypy{39,310}-wheel
+    py{39,310,311,312,313}-interop
     windows-wheel
     docs
 
@@ -31,8 +33,8 @@ basepython=
     py311: python3.11
     py312: python3.12
     py313: python3.13
-    pypypy39: pypy3.9
-    pypypy310: pypy3.10
+    pypy39: pypy3.9
+    pypy310: pypy3.10
 extras=
     test
     docs
@@ -46,7 +48,7 @@ commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{39,310,311,312,313}-wheel]
+[testenv:py{39,310,311,312,313,py39,py310}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
## What was wrong?

Checking for `pypy` compatibility was requested in a recent call.

## How was it fixed?

Added checks for `pypy3.9` and `pypy3.10` to CI. `pypy3.11` does not build correctly, due to what appears to be a dependency on `pyo3` via the `cryptography` library.

```
--- stderr
error: the configured PyPy interpreter version (3.11) is newer than PyO3's maximum supported version (3.10)
```
### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/c847b194-f2c0-4f2b-a872-b57111347f99)
