### PR TITLE
feat: complete identify protocol and improved tests

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -1132,6 +1132,12 @@ class IHost(ABC):
         """
 
     @abstractmethod
+    def get_peerstore(self) -> IPeerStore:
+        """
+        :return: the peerstore of the host
+        """
+
+    @abstractmethod
     def get_connected_peers(self) -> list[ID]:
         """
         Retrieve the identifiers of peers currently connected to the host.

--- a/libp2p/identity/identify/protocol.py
+++ b/libp2p/identity/identify/protocol.py
@@ -1,4 +1,7 @@
 import logging
+from typing import (
+    Optional,
+)
 
 from multiaddr import (
     Multiaddr,
@@ -15,9 +18,6 @@ from libp2p.custom_types import (
 from libp2p.network.stream.exceptions import (
     StreamClosed,
 )
-from libp2p.network.stream.net_stream_interface import (
-    INetStream,
-)
 from libp2p.utils import (
     get_agent_version,
 )
@@ -26,7 +26,9 @@ from .pb.identify_pb2 import (
     Identify,
 )
 
-logger = logging.getLogger("libp2p.identity.identify")
+# Not sure I can do this or I break a pattern
+# logger = logging.getLogger("libp2p.identity.identify")
+logger = logging.getLogger(__name__)
 
 ID = TProtocol("/ipfs/id/1.0.0")
 PROTOCOL_VERSION = "ipfs/0.1.0"
@@ -37,28 +39,45 @@ def _multiaddr_to_bytes(maddr: Multiaddr) -> bytes:
     return maddr.to_bytes()
 
 
-def _mk_identify_protobuf(host: IHost) -> Identify:
+def _mk_identify_protobuf(
+    host: IHost, observed_multiaddr: Optional[Multiaddr]
+) -> Identify:
     public_key = host.get_public_key()
     laddrs = host.get_addrs()
     protocols = host.get_mux().get_protocols()
 
+    observed_addr = observed_multiaddr.to_bytes() if observed_multiaddr else b""
     return Identify(
         protocol_version=PROTOCOL_VERSION,
         agent_version=AGENT_VERSION,
         public_key=public_key.serialize(),
         listen_addrs=map(_multiaddr_to_bytes, laddrs),
-        # TODO send observed address from ``stream``
-        observed_addr=b"",
+        observed_addr=observed_addr,
         protocols=protocols,
     )
 
 
 def identify_handler_for(host: IHost) -> StreamHandlerFn:
     async def handle_identify(stream: INetStream) -> None:
-        peer_id = stream.muxed_conn.peer_id
+        # get observed address from ``stream``
+        # class Swarm(Service, INetworkService):
+        # TODO: Connection and `peer_id` are 1-1 mapping in our implementation,
+        # whereas in Go one `peer_id` may point to multiple connections.
+        # connections: dict[ID, INetConn]
+        # Luca: So I'm assuming that the connection is 1-1 mapping for now
+        peer_id = stream.muxed_conn.peer_id  # remote peer_id
+        peer_store = host.get_peerstore()  # get the peer store from the host
+        remote_peer_multiaddrs = peer_store.addrs(
+            peer_id
+        )  # get the Multiaddrs for the remote peer_id
+        logger.debug("multiaddrs of remote peer is %s", remote_peer_multiaddrs)
         logger.debug("received a request for %s from %s", ID, peer_id)
 
-        protobuf = _mk_identify_protobuf(host)
+        # Select the first address if available, else None
+        observed_multiaddr = (
+            remote_peer_multiaddrs[0] if remote_peer_multiaddrs else None
+        )
+        protobuf = _mk_identify_protobuf(host, observed_multiaddr)
         response = protobuf.SerializeToString()
 
         try:

--- a/libp2p/identity/identify/protocol.py
+++ b/libp2p/identity/identify/protocol.py
@@ -15,16 +15,22 @@ from libp2p.custom_types import (
 from libp2p.network.stream.exceptions import (
     StreamClosed,
 )
+from libp2p.network.stream.net_stream_interface import (
+    INetStream,
+)
+from libp2p.utils import (
+    get_agent_version,
+)
 
 from .pb.identify_pb2 import (
     Identify,
 )
 
+logger = logging.getLogger("libp2p.identity.identify")
+
 ID = TProtocol("/ipfs/id/1.0.0")
 PROTOCOL_VERSION = "ipfs/0.1.0"
-# TODO dynamically generate the agent version
-AGENT_VERSION = "py-libp2p/alpha"
-logger = logging.getLogger("libp2p.identity.identify")
+AGENT_VERSION = get_agent_version()
 
 
 def _multiaddr_to_bytes(maddr: Multiaddr) -> bytes:

--- a/libp2p/io/abc.py
+++ b/libp2p/io/abc.py
@@ -2,6 +2,9 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from typing import (
+    Optional,
+)
 
 
 class Closer(ABC):
@@ -35,7 +38,14 @@ class ReadWriter(Reader, Writer):
 
 
 class ReadWriteCloser(Reader, Writer, Closer):
-    pass
+    @abstractmethod
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """
+        Return the remote address of the connected peer.
+
+        :return: A tuple of (host, port) or None if not available
+        """
+        ...
 
 
 class MsgReader(ABC):
@@ -66,3 +76,9 @@ class Encrypter(ABC):
 
 class EncryptedMsgReadWriter(MsgReadWriteCloser, Encrypter):
     """Read/write message with encryption/decryption."""
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Get remote address if supported by the underlying connection."""
+        if hasattr(self, "conn") and hasattr(self.conn, "get_remote_address"):
+            return self.conn.get_remote_address()
+        return None

--- a/libp2p/io/trio.py
+++ b/libp2p/io/trio.py
@@ -1,4 +1,7 @@
 import logging
+from typing import (
+    Optional,
+)
 
 import trio
 
@@ -42,3 +45,11 @@ class TrioTCPStream(ReadWriteCloser):
 
     async def close(self) -> None:
         await self.stream.aclose()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Return the remote address as (host, port) tuple."""
+        try:
+            return self.stream.socket.getpeername()
+        except (AttributeError, OSError) as e:
+            logger.error("Error getting remote address: %s", e)
+            return None

--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -1,3 +1,7 @@
+from typing import (
+    Optional,
+)
+
 from libp2p.abc import (
     IRawConnection,
 )
@@ -42,3 +46,7 @@ class RawConnection(IRawConnection):
 
     async def close(self) -> None:
         await self.stream.close()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Delegate to the underlying stream's get_remote_address method."""
+        return self.stream.get_remote_address()

--- a/libp2p/network/stream/net_stream.py
+++ b/libp2p/network/stream/net_stream.py
@@ -78,6 +78,10 @@ class NetStream(INetStream):
     async def reset(self) -> None:
         await self.muxed_stream.reset()
 
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Delegate to the underlying muxed stream."""
+        return self.muxed_stream.get_remote_address()
+
     # TODO: `remove`: Called by close and write when the stream is in specific states.
     #   It notifies `ClosedStream` after `SwarmConn.remove_stream` is called.
     # Reference: https://github.com/libp2p/go-libp2p-swarm/blob/99831444e78c8f23c9335c17d8f7c700ba25ca14/swarm_stream.go  # noqa: E501

--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -1,3 +1,7 @@
+from typing import (
+    Optional,
+)
+
 from libp2p.abc import (
     IRawConnection,
     ISecureConn,
@@ -73,6 +77,12 @@ class InsecureSession(BaseSession):
             is_initiator=is_initiator,
         )
         self.conn = conn
+        # Cache the remote address to avoid repeated lookups
+        # through the delegation chain
+        try:
+            self.remote_peer_addr = conn.get_remote_address()
+        except AttributeError:
+            self.remote_peer_addr = None
 
     async def write(self, data: bytes) -> None:
         await self.conn.write(data)
@@ -82,6 +92,12 @@ class InsecureSession(BaseSession):
 
     async def close(self) -> None:
         await self.conn.close()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """
+        Delegate to the underlying connection's get_remote_address method.
+        """
+        return self.conn.get_remote_address()
 
 
 async def run_handshake(

--- a/libp2p/security/secure_session.py
+++ b/libp2p/security/secure_session.py
@@ -1,4 +1,7 @@
 import io
+from typing import (
+    Optional,
+)
 
 from libp2p.crypto.keys import (
     PrivateKey,
@@ -40,6 +43,10 @@ class SecureSession(BaseSession):
         self.conn = conn
 
         self._reset_internal_buffer()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Delegate to the underlying connection's get_remote_address method."""
+        return self.conn.get_remote_address()
 
     def _reset_internal_buffer(self) -> None:
         self.buf = io.BytesIO()

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -365,3 +365,7 @@ class Mplex(IMuxedConn):
                 await send_channel.aclose()
         self.event_closed.set()
         await self.new_stream_send_channel.aclose()
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Delegate to the underlying Mplex connection's secured_conn."""
+        return self.secured_conn.get_remote_address()

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -1,5 +1,6 @@
 from typing import (
     TYPE_CHECKING,
+    Optional,
 )
 
 import trio
@@ -252,3 +253,7 @@ class MplexStream(IMuxedStream):
         """
         self.write_deadline = ttl
         return True
+
+    def get_remote_address(self) -> Optional[tuple[str, int]]:
+        """Delegate to the parent Mplex connection."""
+        return self.muxed_conn.get_remote_address()

--- a/libp2p/utils.py
+++ b/libp2p/utils.py
@@ -1,4 +1,8 @@
+from importlib.metadata import (
+    version,
+)
 import itertools
+import logging
 import math
 
 from libp2p.exceptions import (
@@ -11,6 +15,8 @@ from libp2p.io.abc import (
 from .io.utils import (
     read_exactly,
 )
+
+logger = logging.getLogger("libp2p.utils")
 
 # Unsigned LEB128(varint codec)
 # Reference: https://github.com/ethereum/py-wasm/blob/master/wasm/parsers/leb128.py
@@ -84,3 +90,19 @@ async def read_delim(reader: Reader) -> bytes:
             f'`msg_bytes` is not delimited by b"\\n": `msg_bytes`={msg_bytes!r}'
         )
     return msg_bytes[:-1]
+
+
+def get_agent_version() -> str:
+    """
+    Return the version of libp2p.
+
+    If the version cannot be determined due to an exception, return "py-libp2p/unknown".
+
+    :return: The version of libp2p.
+    :rtype: str
+    """
+    try:
+        return f"py-libp2p/{version('libp2p')}"
+    except Exception as e:
+        logger.warning("Could not fetch libp2p version: %s", e)
+        return "py-libp2p/unknown"

--- a/tests/core/identity/identify/test_protocol.py
+++ b/tests/core/identity/identify/test_protocol.py
@@ -1,4 +1,9 @@
+import logging
+
 import pytest
+from multiaddr import (
+    Multiaddr,
+)
 
 from libp2p.identity.identify.pb.identify_pb2 import (
     Identify,
@@ -14,6 +19,8 @@ from libp2p.tools.factories import (
     host_pair_factory,
 )
 
+logger = logging.getLogger("libp2p.identity.identify-test")
+
 
 @pytest.mark.trio
 async def test_identify_protocol(security_protocol):
@@ -28,8 +35,8 @@ async def test_identify_protocol(security_protocol):
         identify_response = Identify()
         identify_response.ParseFromString(response)
 
-        # sanity check
-        assert identify_response == _mk_identify_protobuf(host_a)
+        logger.debug("host_a: %s", host_a.get_addrs())
+        logger.debug("host_b: %s", host_b.get_addrs())
 
         # Check protocol version
         assert identify_response.protocol_version == PROTOCOL_VERSION
@@ -45,8 +52,23 @@ async def test_identify_protocol(security_protocol):
             map(_multiaddr_to_bytes, host_a.get_addrs())
         )
 
-        # TODO: Check observed address
-        # assert identify_response.observed_addr == host_b.get_addrs()[0]
+        # Check observed address
+        host_b_addr = host_b.get_addrs()[0]
+        cleaned_addr = Multiaddr.join(
+            *(
+                host_b_addr.split()[:-1]
+                if str(host_b_addr.split()[-1]).startswith("/p2p/")
+                else host_b_addr.split()
+            )
+        )
+
+        logger.debug("observed_addr: %s", Multiaddr(identify_response.observed_addr))
+        logger.debug("host_b.get_addrs()[0]: %s", host_b.get_addrs()[0])
+        logger.debug("cleaned_addr= %s", cleaned_addr)
+        assert identify_response.observed_addr == _multiaddr_to_bytes(cleaned_addr)
 
         # Check protocols
         assert set(identify_response.protocols) == set(host_a.get_mux().get_protocols())
+
+        # sanity check
+        assert identify_response == _mk_identify_protobuf(host_a, cleaned_addr)

--- a/tests/core/identity/identify/test_protocol.py
+++ b/tests/core/identity/identify/test_protocol.py
@@ -28,6 +28,9 @@ async def test_identify_protocol(security_protocol):
         host_a,
         host_b,
     ):
+        # Here, host_b is the requester and host_a is the responder.
+        # observed_addr represent host_b’s address as observed by host_a
+        # (i.e., the address from which host_b’s request was received).
         stream = await host_b.new_stream(host_a.get_id(), (ID,))
         response = await stream.read()
         await stream.close()
@@ -53,6 +56,8 @@ async def test_identify_protocol(security_protocol):
         )
 
         # Check observed address
+        # TODO: use decapsulateCode(protocols('p2p').code)
+        # when the Multiaddr class will implement it
         host_b_addr = host_b.get_addrs()[0]
         cleaned_addr = Multiaddr.join(
             *(

--- a/tests/core/identity/identify/test_protocol.py
+++ b/tests/core/identity/identify/test_protocol.py
@@ -4,8 +4,11 @@ from libp2p.identity.identify.pb.identify_pb2 import (
     Identify,
 )
 from libp2p.identity.identify.protocol import (
+    AGENT_VERSION,
     ID,
+    PROTOCOL_VERSION,
     _mk_identify_protobuf,
+    _multiaddr_to_bytes,
 )
 from libp2p.tools.factories import (
     host_pair_factory,
@@ -24,4 +27,26 @@ async def test_identify_protocol(security_protocol):
 
         identify_response = Identify()
         identify_response.ParseFromString(response)
+
+        # sanity check
         assert identify_response == _mk_identify_protobuf(host_a)
+
+        # Check protocol version
+        assert identify_response.protocol_version == PROTOCOL_VERSION
+
+        # Check agent version
+        assert identify_response.agent_version == AGENT_VERSION
+
+        # Check public key
+        assert identify_response.public_key == host_a.get_public_key().serialize()
+
+        # Check listen addresses
+        assert identify_response.listen_addrs == list(
+            map(_multiaddr_to_bytes, host_a.get_addrs())
+        )
+
+        # TODO: Check observed address
+        # assert identify_response.observed_addr == host_b.get_addrs()[0]
+
+        # Check protocols
+        assert set(identify_response.protocols) == set(host_a.get_mux().get_protocols())

--- a/tests/core/identity/identify/test_protocol.py
+++ b/tests/core/identity/identify/test_protocol.py
@@ -14,12 +14,34 @@ from libp2p.identity.identify.protocol import (
     PROTOCOL_VERSION,
     _mk_identify_protobuf,
     _multiaddr_to_bytes,
+    _remote_address_to_multiaddr,
 )
 from libp2p.tools.factories import (
     host_pair_factory,
 )
 
-logger = logging.getLogger("libp2p.identity.identify-test")
+
+def clean_multiaddr(addr: Multiaddr) -> Multiaddr:
+    """
+    Clean a multiaddr by removing the '/p2p/' part if it exists.
+
+    Args:
+        addr: The multiaddr to clean
+
+    Returns:
+        The cleaned multiaddr
+    """
+    return Multiaddr.join(
+        *(
+            addr.split()[:-1]
+            if str(addr.split()[-1]).startswith("/p2p/")
+            else addr.split()
+        )
+    )
+
+
+# logger = logging.getLogger("libp2p.identity.identify-test")
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.trio
@@ -29,8 +51,8 @@ async def test_identify_protocol(security_protocol):
         host_b,
     ):
         # Here, host_b is the requester and host_a is the responder.
-        # observed_addr represent host_b’s address as observed by host_a
-        # (i.e., the address from which host_b’s request was received).
+        # observed_addr represent host_b's address as observed by host_a
+        # (i.e., the address from which host_b's request was received).
         stream = await host_b.new_stream(host_a.get_id(), (ID,))
         response = await stream.read()
         await stream.close()
@@ -59,13 +81,7 @@ async def test_identify_protocol(security_protocol):
         # TODO: use decapsulateCode(protocols('p2p').code)
         # when the Multiaddr class will implement it
         host_b_addr = host_b.get_addrs()[0]
-        cleaned_addr = Multiaddr.join(
-            *(
-                host_b_addr.split()[:-1]
-                if str(host_b_addr.split()[-1]).startswith("/p2p/")
-                else host_b_addr.split()
-            )
-        )
+        cleaned_addr = clean_multiaddr(host_b_addr)
 
         logger.debug("observed_addr: %s", Multiaddr(identify_response.observed_addr))
         logger.debug("host_b.get_addrs()[0]: %s", host_b.get_addrs()[0])
@@ -77,3 +93,66 @@ async def test_identify_protocol(security_protocol):
 
         # sanity check
         assert identify_response == _mk_identify_protobuf(host_a, cleaned_addr)
+
+
+@pytest.mark.trio
+async def test_complete_remote_address_delegation_chain(security_protocol):
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        logger.debug(
+            "test_complete_remote_address_delegation_chain security_protocol: %s",
+            security_protocol,
+        )
+
+        # Create a stream from host_a to host_b
+        stream = await host_a.new_stream(host_b.get_id(), (ID,))
+
+        # Get references to all components in the delegation chain
+        mplex_stream = stream.muxed_stream
+        swarm_conn = host_a.get_network().connections[host_b.get_id()]
+        mplex = swarm_conn.muxed_conn
+        secure_session = mplex.secured_conn
+        raw_connection = secure_session.conn
+        trio_tcp_stream = raw_connection.stream
+
+        # Get remote addresses at each layer
+        stream_addr = stream.get_remote_address()
+        muxed_stream_addr = stream.muxed_stream.get_remote_address()
+        mplex_addr = mplex_stream.muxed_conn.get_remote_address()
+        secure_session_addr = mplex.secured_conn.get_remote_address()
+        raw_connection_addr = secure_session.conn.get_remote_address()
+        trio_tcp_stream_addr = raw_connection.stream.get_remote_address()
+        socket_addr = trio_tcp_stream.stream.socket.getpeername()
+
+        # Log all addresses
+        logger.debug("NetStream address: %s", stream_addr)
+        logger.debug("MplexStream address: %s", muxed_stream_addr)
+        logger.debug("Mplex address: %s", mplex_addr)
+        logger.debug("SecureSession address: %s", secure_session_addr)
+        logger.debug("RawConnection address: %s", raw_connection_addr)
+        logger.debug("TrioTCPStream address: %s", trio_tcp_stream_addr)
+        logger.debug("Socket address: %s", socket_addr)
+
+        # Verify complete delegation chain
+        assert (
+            stream_addr
+            == muxed_stream_addr
+            == mplex_addr
+            == secure_session_addr
+            == raw_connection_addr
+            == trio_tcp_stream_addr
+            == socket_addr
+        )
+
+        # Convert to multiaddr and verify it matches host_b's cleaned address
+        remote_address_multiaddr = _remote_address_to_multiaddr(stream_addr)
+        host_b_addr = clean_multiaddr(host_b.get_addrs()[0])
+
+        logger.debug("Remote address multiaddr: %s", remote_address_multiaddr)
+        logger.debug("Host B cleaned address: %s", host_b_addr)
+
+        assert remote_address_multiaddr == host_b_addr
+
+        await stream.close()


### PR DESCRIPTION
**NOTE: this is a draft pull request**
The returned info agent version was a generic `py-libp2p/unknown`
I've added a function in `libp2p/utils.py` that return the agent version so that I can return it in the `agentVersion` field of `identify protocol` modifying `libp2p/identity/identify/protocol.py`

I've improved the test `tests/core/identity/identify/test_protocol.py` adding tests so that every field is verified.

I'm planning to complete https://github.com/libp2p/py-libp2p/issues/358 adding missing `observed address` from `stream` and then `identify/push` .
Specs are here https://github.com/libp2p/specs/blob/master/identify/README.md 

🕷️
