### PR TITLE
Run tox correctly in ci

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
           if [[ "$toxenv" == 'docs' ]]; then
             echo 'TOXENV=docs' | tee -a $GITHUB_ENV
           else
-            echo "TOXENV=${python}-${toxenv}" | tr -d '.' | tee -a $GITHUB_ENV
+            echo "TOXENV=py${python}-${toxenv}" | tr -d '.' | tee -a $GITHUB_ENV
           fi
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '.project-template|docs/conf.py|.*pb2\..*'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: check-toml
@@ -38,7 +38,7 @@ repos:
         additional_dependencies:
         -   tomli  # required until >= python311
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.22
     hooks:
     -   id: mdformat
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -31,92 +31,92 @@ py-libp2p aims for conformity with [the standard libp2p modules](https://libp2p.
 
 | libp2p Node  | Status |
 | ------------ | :----: |
-| **`libp2p`** |   ✅    |
+| **`libp2p`** |   ✅   |
 
 | Core Protocols | Status |
 | -------------- | :----: |
-| **`Ping`**     |   ✅    |
-| **`Identify`** |   ✅    |
+| **`Ping`**     |   ✅   |
+| **`Identify`** |   ✅   |
 
 | Transport Protocols | Status |
 | ------------------- | :----: |
-| **`TCP`**           |   ✅    |
+| **`TCP`**           |   ✅   |
 | **`QUIC`**          |   🛠️   |
-| **`UDP`**           |   🚫    |
-| **`WebSockets`**    |   ❌    |
-| **`UTP`**           |   ❌    |
-| **`WebRTC`**        |   ❌    |
-| **`SCTP`**          |   ❌    |
-| **`Tor`**           |   ❌    |
-| **`i2p`**           |   ❌    |
-| **`cjdns`**         |   ❌    |
-| **`Bluetooth LE`**  |   ❌    |
-| **`Audio TP`**      |   ❌    |
-| **`Zerotier`**      |   ❌    |
+| **`UDP`**           |   🚫   |
+| **`WebSockets`**    |   ❌   |
+| **`UTP`**           |   ❌   |
+| **`WebRTC`**        |   ❌   |
+| **`SCTP`**          |   ❌   |
+| **`Tor`**           |   ❌   |
+| **`i2p`**           |   ❌   |
+| **`cjdns`**         |   ❌   |
+| **`Bluetooth LE`**  |   ❌   |
+| **`Audio TP`**      |   ❌   |
+| **`Zerotier`**      |   ❌   |
 
 | Stream Muxers    | Status |
 | ---------------- | :----: |
-| **`multiplex`**  |   ✅    |
-| **`yamux`**      |   🚫    |
-| **`benchmarks`** |   ❌    |
-| **`muxado`**     |   ❌    |
-| **`spdystream`** |   ❌    |
-| **`spdy`**       |   ❌    |
-| **`http2`**      |   ❌    |
-| **`QUIC`**       |   ❌    |
+| **`multiplex`**  |   ✅   |
+| **`yamux`**      |   🚫   |
+| **`benchmarks`** |   ❌   |
+| **`muxado`**     |   ❌   |
+| **`spdystream`** |   ❌   |
+| **`spdy`**       |   ❌   |
+| **`http2`**      |   ❌   |
+| **`QUIC`**       |   ❌   |
 
 | Protocol Muxers   | Status |
 | ----------------- | :----: |
-| **`multiselect`** |   ✅    |
+| **`multiselect`** |   ✅   |
 
 | Switch (Swarm)     | Status |
 | ------------------ | :----: |
-| **`Switch`**       |   ✅    |
-| **`Dialer stack`** |   ✅    |
+| **`Switch`**       |   ✅   |
+| **`Dialer stack`** |   ✅   |
 
 | Peer Discovery       | Status |
 | -------------------- | :----: |
-| **`bootstrap list`** |   🚫    |
-| **`Kademlia DHT`**   |   ❌    |
-| **`mDNS`**           |   ❌    |
-| **`PEX`**            |   ❌    |
-| **`DNS`**            |   ❌    |
+| **`bootstrap list`** |   🚫   |
+| **`Kademlia DHT`**   |   ❌   |
+| **`mDNS`**           |   ❌   |
+| **`PEX`**            |   ❌   |
+| **`DNS`**            |   ❌   |
 
 | Content Routing    | Status |
 | ------------------ | :----: |
-| **`Kademlia DHT`** |   ❌    |
-| **`floodsub`**     |   ✅    |
-| **`gossipsub`**    |   ✅    |
-| **`PHT`**          |   ❌    |
+| **`Kademlia DHT`** |   ❌   |
+| **`floodsub`**     |   ✅   |
+| **`gossipsub`**    |   ✅   |
+| **`PHT`**          |   ❌   |
 
 | Peer Routing       | Status |
 | ------------------ | :----: |
-| **`Kademlia DHT`** |   ❌    |
-| **`floodsub`**     |   ✅    |
-| **`gossipsub`**    |   ✅    |
-| **`PHT`**          |   ❌    |
+| **`Kademlia DHT`** |   ❌   |
+| **`floodsub`**     |   ✅   |
+| **`gossipsub`**    |   ✅   |
+| **`PHT`**          |   ❌   |
 
 | NAT Traversal            | Status |
 | ------------------------ | :----: |
-| **`nat-pmp`**            |   ❌    |
-| **`upnp`**               |   ❌    |
-| **`ext addr discovery`** |   ❌    |
-| **`STUN-like`**          |   ❌    |
-| **`line-switch relay`**  |   ❌    |
-| **`pkt-switch relay`**   |   ❌    |
+| **`nat-pmp`**            |   ❌   |
+| **`upnp`**               |   ❌   |
+| **`ext addr discovery`** |   ❌   |
+| **`STUN-like`**          |   ❌   |
+| **`line-switch relay`**  |   ❌   |
+| **`pkt-switch relay`**   |   ❌   |
 
 | Exchange         | Status |
 | ---------------- | :----: |
-| **`HTTP`**       |   ❌    |
-| **`Bitswap`**    |   ❌    |
-| **`Bittorrent`** |   ❌    |
+| **`HTTP`**       |   ❌   |
+| **`Bitswap`**    |   ❌   |
+| **`Bittorrent`** |   ❌   |
 
 | Consensus      | Status |
 | -------------- | :----: |
-| **`Paxos`**    |   ❌    |
-| **`Raft`**     |   ❌    |
-| **`PBTF`**     |   ❌    |
-| **`Nakamoto`** |   ❌    |
+| **`Paxos`**    |   ❌   |
+| **`Raft`**     |   ❌   |
+| **`PBTF`**     |   ❌   |
+| **`Nakamoto`** |   ❌   |
 
 ## Explanation of Basic Two Node Communication
 
@@ -138,7 +138,7 @@ Several components of the libp2p stack take part when establishing a connection 
 
 _(non-normative, useful for team notes, not a reference)_
 
-**Initiate the connection**: A host is simply a node in the libp2p network that is able to communicate with other nodes in the network. In order for X and Y to communicate with one another, one of the hosts must initiate the connection.  Let's say that X is going to initiate the connection. X will first open a connection to Y. This connection is where all of the actual communication will take place.
+**Initiate the connection**: A host is simply a node in the libp2p network that is able to communicate with other nodes in the network. In order for X and Y to communicate with one another, one of the hosts must initiate the connection. Let's say that X is going to initiate the connection. X will first open a connection to Y. This connection is where all of the actual communication will take place.
 
 **Communication over one connection with multiple protocols**: X and Y can communicate over the same connection using different protocols and the multiplexer will appropriately route messages for a given protocol to a particular handler function for that protocol, which allows for each host to handle different protocols with separate functions. Furthermore, we can use multiple streams for a given protocol that allow for the same protocol and same underlying connection to be used for communication about separate topics between nodes X and Y.
 

--- a/newsfragments/522.internal.rst
+++ b/newsfragments/522.internal.rst
@@ -1,0 +1,1 @@
+Fixes broken CI lint run, bumps ``pre-commit-hooks`` version to ``5.0.0`` and ``mdformat`` to ``0.7.22``.


### PR DESCRIPTION
## What was wrong?

CI for lint and most likely wheel were not running properly. There was also some linting churn on README.md.

## How was it fixed?

add missing `py`

bumped versions of pre-commit hooks for `pre-commit-hooks` and `mdformat`.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/e86d7e89-12a7-49f9-af52-d7d0b6ba3f38)
