### PR TITLE
Rufuse large RSA keys

### DIFF
--- a/libp2p/crypto/rsa.py
+++ b/libp2p/crypto/rsa.py
@@ -9,6 +9,9 @@ from Crypto.Signature import (
     pkcs1_15,
 )
 
+from libp2p.crypto.exceptions import (
+    CryptographyError,
+)
 from libp2p.crypto.keys import (
     KeyPair,
     KeyType,
@@ -16,9 +19,26 @@ from libp2p.crypto.keys import (
     PublicKey,
 )
 
+MAX_RSA_KEY_SIZE = 4096
+
+
+def validate_rsa_key_size(key: RsaKey) -> None:
+    """
+    Validate that an RSA key's size is within acceptable bounds.
+
+    :param key: The RSA key to validate
+    :raises CryptographyError: If the key size exceeds the maximum allowed size
+    """
+    key_size = key.size_in_bits()
+    if key_size > MAX_RSA_KEY_SIZE:
+        msg = f"RSA key size {key_size} "
+        msg += f"exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
+        raise CryptographyError(msg)
+
 
 class RSAPublicKey(PublicKey):
     def __init__(self, impl: RsaKey) -> None:
+        validate_rsa_key_size(impl)
         self.impl = impl
 
     def to_bytes(self) -> bytes:
@@ -27,6 +47,7 @@ class RSAPublicKey(PublicKey):
     @classmethod
     def from_bytes(cls, key_bytes: bytes) -> "RSAPublicKey":
         rsakey = RSA.import_key(key_bytes)
+        validate_rsa_key_size(rsakey)
         return cls(rsakey)
 
     def get_type(self) -> KeyType:
@@ -43,10 +64,15 @@ class RSAPublicKey(PublicKey):
 
 class RSAPrivateKey(PrivateKey):
     def __init__(self, impl: RsaKey) -> None:
+        validate_rsa_key_size(impl)
         self.impl = impl
 
     @classmethod
     def new(cls, bits: int = 2048, e: int = 65537) -> "RSAPrivateKey":
+        if bits > MAX_RSA_KEY_SIZE:
+            msg = f"Requested RSA key size {bits} "
+            msg += f"exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
+            raise CryptographyError(msg)
         private_key_impl = RSA.generate(bits, e=e)
         return cls(private_key_impl)
 

--- a/libp2p/crypto/rsa.py
+++ b/libp2p/crypto/rsa.py
@@ -22,18 +22,31 @@ from libp2p.crypto.keys import (
 MAX_RSA_KEY_SIZE = 4096
 
 
+def validate_rsa_key_length(key_length: int) -> None:
+    """
+    Validate that the RSA key length is positive and within the allowed maximum.
+
+    :param key_length: RSA key size in bits.
+    :raises CryptographyError:
+        If the key size is not positive or exceeds MAX_RSA_KEY_SIZE.
+    """
+    if key_length <= 0:
+        raise CryptographyError("RSA key size must be positive")
+    if key_length > MAX_RSA_KEY_SIZE:
+        raise CryptographyError(
+            f"RSA key size {key_length} exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
+        )
+
+
 def validate_rsa_key_size(key: RsaKey) -> None:
     """
     Validate that an RSA key's size is within acceptable bounds.
 
-    :param key: The RSA key to validate
-    :raises CryptographyError: If the key size exceeds the maximum allowed size
+    :param key: The RSA key to validate.
+    :raises CryptographyError: If the key size is invalid.
     """
     key_size = key.size_in_bits()
-    if key_size > MAX_RSA_KEY_SIZE:
-        msg = f"RSA key size {key_size} "
-        msg += f"exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
-        raise CryptographyError(msg)
+    validate_rsa_key_length(key_size)
 
 
 class RSAPublicKey(PublicKey):
@@ -69,10 +82,7 @@ class RSAPrivateKey(PrivateKey):
 
     @classmethod
     def new(cls, bits: int = 2048, e: int = 65537) -> "RSAPrivateKey":
-        if bits > MAX_RSA_KEY_SIZE:
-            msg = f"Requested RSA key size {bits} "
-            msg += f"exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
-            raise CryptographyError(msg)
+        validate_rsa_key_length(bits)
         private_key_impl = RSA.generate(bits, e=e)
         return cls(private_key_impl)
 

--- a/newsfragments/523.feature.rst
+++ b/newsfragments/523.feature.rst
@@ -1,1 +1,2 @@
-Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks.
+Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks.Consolidated validation logic to use a single error message source and
+added tests to catch invalid key sizes (including negative values).

--- a/newsfragments/523.feature.rst
+++ b/newsfragments/523.feature.rst
@@ -1,0 +1,1 @@
+Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks.

--- a/newsfragments/523.security.rst
+++ b/newsfragments/523.security.rst
@@ -1,0 +1,2 @@
+Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks
+from malicious peers using oversized keys.

--- a/newsfragments/523.security.rst
+++ b/newsfragments/523.security.rst
@@ -1,2 +1,0 @@
-Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks
-from malicious peers using oversized keys.

--- a/tests/core/crypto/test_rsa.py
+++ b/tests/core/crypto/test_rsa.py
@@ -1,0 +1,30 @@
+import pytest
+
+from libp2p.crypto.exceptions import (
+    CryptographyError,
+)
+from libp2p.crypto.rsa import (
+    MAX_RSA_KEY_SIZE,
+    RSAPrivateKey,
+    validate_rsa_key_size,
+)
+
+
+def test_validate_rsa_key_size():
+    # Test valid key size
+    key = RSAPrivateKey.new(2048)
+    validate_rsa_key_size(key.impl)
+
+    # Test key size too large
+    with pytest.raises(
+        CryptographyError, match=f".*exceeds maximum allowed size {MAX_RSA_KEY_SIZE}"
+    ):
+        RSAPrivateKey.new(MAX_RSA_KEY_SIZE + 1)
+
+    # Test negative key size (this would be caught when creating the key)
+    with pytest.raises(CryptographyError, match="RSA key size must be positive"):
+        RSAPrivateKey.new(-1)
+
+    # Test zero key size
+    with pytest.raises(CryptographyError, match="RSA key size must be positive"):
+        RSAPrivateKey.new(0)


### PR DESCRIPTION
## What was wrong?
There is no length limit for RSA keys, which allows a malicious peer to generate excessively large RSA keys and exploit this to launch a resource exhaustion attack. This forces nodes to spend unnecessary time verifying large signatures, potentially degrading network performance.
Issue #526 

## How was it fixed?
The fix involves imposing a limit on the maximum allowed RSA key length when generating or parsing RSA keys. This prevents the possibility of abuse by enforcing a reasonable upper bound of 4KB on key size.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.southernliving.com/thmb/a4b73J7C4S4wgSmymmEgXRCmACA=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/GettyImages-185743593-2000-507c6c8883a44851885ea4fbc10a2c9e.jpg)
