### PR TITLE
WIP: Progress on py-libp2p and rust-libp2p interop for Ping

### DIFF
--- a/examples/ping/ping.py
+++ b/examples/ping/ping.py
@@ -1,121 +1,465 @@
 import argparse
-
 import multiaddr
 import trio
+import logging
+import struct
+import os
+from typing import Optional, Dict, Any
 
-from libp2p import (
-    new_host,
-)
-from libp2p.custom_types import (
-    TProtocol,
-)
-from libp2p.network.stream.net_stream import (
-    INetStream,
-)
-from libp2p.peer.peerinfo import (
-    info_from_p2p_addr,
+from libp2p import new_host, generate_new_rsa_identity
+from libp2p.custom_types import TProtocol
+from libp2p.network.stream.net_stream import INetStream
+from libp2p.security.noise.transport import Transport as NoiseTransport
+from libp2p.stream_muxer.yamux.yamux import Yamux, YamuxStream, PROTOCOL_ID as YAMUX_PROTOCOL_ID
+from cryptography.hazmat.primitives.asymmetric import x25519
+from libp2p.crypto.keys import KeyPair
+
+# Configure detailed logging
+logging.basicConfig(
+    level=logging.DEBUG, 
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler('ping_debug.log', mode='w', encoding='utf-8')
+    ]
 )
 
+# Protocol constants - must match rust-libp2p exactly
 PING_PROTOCOL_ID = TProtocol("/ipfs/ping/1.0.0")
 PING_LENGTH = 32
-RESP_TIMEOUT = 60
+RESP_TIMEOUT = 30
+MAX_FRAME_SIZE = 1024 * 1024  # 1MB max frame size
 
+class InteropYamux(Yamux):
+    """Enhanced Yamux with proper rust-libp2p interoperability"""
+    
+    def __init__(self, *args, **kwargs):
+        logging.info("InteropYamux.__init__ called")
+        super().__init__(*args, **kwargs)
+        self.frame_count = 0
+        self.debug_frames = True
 
+    async def _read_exact_bytes(self, n):
+        """Read exactly n bytes from the connection with proper error handling"""
+        if n == 0:
+            return b""
+            
+        if n > MAX_FRAME_SIZE:
+            logging.error(f"Requested read size {n} exceeds maximum {MAX_FRAME_SIZE}")
+            return None
+            
+        data = b""
+        while len(data) < n:
+            try:
+                remaining = n - len(data)
+                chunk = await self.secured_conn.read(remaining)
+            except (trio.ClosedResourceError, trio.BrokenResourceError):
+                logging.debug(f"Connection closed while reading {n} bytes (got {len(data)}) for peer {self.peer_id}")
+                return None
+            except Exception as e:
+                logging.error(f"Error reading {n} bytes: {e}")
+                return None
+                
+            if not chunk:
+                logging.debug(f"Connection closed while reading {n} bytes (got {len(data)}) for peer {self.peer_id}")
+                return None
+            data += chunk
+        return data
+
+    async def handle_incoming(self):
+        """Enhanced incoming frame handler with better error recovery"""
+        logging.info(f"Starting Yamux for {self.peer_id}")
+        
+        consecutive_errors = 0
+        max_consecutive_errors = 3
+        
+        while not self.event_shutting_down.is_set():
+            try:
+                # Read frame header (12 bytes)
+                header_data = await self._read_exact_bytes(12)
+                if header_data is None:
+                    logging.debug(f"Connection closed or incomplete header for peer {self.peer_id}")
+                    break
+
+                # Quick sanity check for protocol data leakage
+                if b'/ipfs' in header_data or b'multi' in header_data or b'noise' in header_data:
+                    logging.error(f"Protocol data in header position: {header_data.hex()}")
+                    break
+
+                try:
+                    # Unpack header: version, type, flags, stream_id, length
+                    version, msg_type, flags, stream_id, length = struct.unpack(">BBHII", header_data)
+                    
+                    # Validate header values strictly
+                    if version != 0:
+                        logging.error(f"Invalid yamux version {version}, expected 0")
+                        break
+                    
+                    if msg_type not in [0, 1, 2, 3]:
+                        logging.error(f"Invalid message type {msg_type}, expected 0-3")
+                        break
+                        
+                    if length > MAX_FRAME_SIZE:
+                        logging.error(f"Frame too large: {length} > {MAX_FRAME_SIZE}")
+                        break
+                    
+                    # Additional validation for ping frames
+                    if msg_type == 2 and length != 4:
+                        logging.error(f"Invalid ping frame length: {length}, expected 4")
+                        break
+
+                    # Log frame details
+                    logging.debug(f"Received header for peer {self.peer_id}: type={msg_type}, flags={flags}, stream_id={stream_id}, length={length}")
+                    
+                    consecutive_errors = 0  # Reset error counter on successful parse
+
+                except struct.error as e:
+                    consecutive_errors += 1
+                    logging.error(f"Header parse error #{consecutive_errors}: {e}, data: {header_data.hex()}")
+                    if consecutive_errors >= max_consecutive_errors:
+                        logging.error("Too many consecutive header parse errors, closing connection")
+                        break
+                    continue
+
+                # Read payload if present
+                payload = b""
+                if length > 0:
+                    payload = await self._read_exact_bytes(length)
+                    if payload is None:
+                        logging.debug(f"Failed to read payload of {length} bytes for peer {self.peer_id}")
+                        break
+                    if len(payload) != length:
+                        logging.error(f"Payload length mismatch: got {len(payload)}, expected {length}")
+                        break
+
+                # Process frame by type
+                if msg_type == 0:  # Data frame
+                    await self._handle_data_frame(stream_id, flags, payload)
+                    
+                elif msg_type == 1:  # Window update
+                    await self._handle_window_update(stream_id, payload)
+                    
+                elif msg_type == 2:  # Ping frame
+                    await self._handle_ping_frame(stream_id, flags, payload)
+                    
+                elif msg_type == 3:  # GoAway frame
+                    await self._handle_goaway_frame(payload)
+                    break
+
+            except (trio.ClosedResourceError, trio.BrokenResourceError):
+                logging.debug(f"Connection closed during frame processing for peer {self.peer_id}")
+                break
+            except Exception as e:
+                consecutive_errors += 1
+                logging.error(f"Frame processing error #{consecutive_errors}: {e}")
+                if consecutive_errors >= max_consecutive_errors:
+                    logging.error("Too many consecutive frame processing errors, closing connection")
+                    break
+
+        await self._cleanup_on_error()
+
+    async def _handle_data_frame(self, stream_id, flags, payload):
+        """Handle data frames with proper stream lifecycle"""
+        if stream_id == 0:
+            logging.warning("Received data frame for stream 0 (control stream)")
+            return
+
+        # Handle SYN flag - new stream creation
+        if flags & 0x1:  # SYN flag
+            if stream_id in self.streams:
+                logging.warning(f"SYN received for existing stream {stream_id}")
+            else:
+                logging.debug(f"Creating new stream {stream_id} for peer {self.peer_id}")
+                stream = YamuxStream(self, stream_id, is_outbound=False)
+                async with self.streams_lock:
+                    self.streams[stream_id] = stream
+                
+                # Send the new stream to the handler
+                await self.new_stream_send_channel.send(stream)
+                logging.debug(f"Sent stream {stream_id} to handler")
+                
+        # Add data to stream buffer if stream exists
+        if stream_id in self.streams:
+            stream = self.streams[stream_id]
+            if payload:
+                # Add to stream's receive buffer
+                async with self.streams_lock:
+                    if not hasattr(stream, '_receive_buffer'):
+                        stream._receive_buffer = bytearray()
+                    if not hasattr(stream, '_receive_event'):
+                        stream._receive_event = trio.Event()
+                    stream._receive_buffer.extend(payload)
+                    stream._receive_event.set()
+            
+            # Handle stream closure flags
+            if flags & 0x2:  # FIN flag
+                stream.recv_closed = True
+                logging.debug(f"Stream {stream_id} received FIN")
+            if flags & 0x4:  # RST flag
+                stream.reset_received = True
+                logging.debug(f"Stream {stream_id} received RST")
+        else:
+            if payload:
+                logging.warning(f"Received data for unknown stream {stream_id}")
+
+    async def _handle_window_update(self, stream_id, payload):
+        """Handle window update frames"""
+        if len(payload) != 4:
+            logging.warning(f"Invalid window update payload length: {len(payload)}")
+            return
+            
+        delta = struct.unpack(">I", payload)[0]
+        logging.debug(f"Window update: stream={stream_id}, delta={delta}")
+        
+        async with self.streams_lock:
+            if stream_id in self.streams:
+                if not hasattr(self.streams[stream_id], 'send_window'):
+                    self.streams[stream_id].send_window = 256 * 1024  # Default window
+                self.streams[stream_id].send_window += delta
+
+    async def _handle_ping_frame(self, stream_id, flags, payload):
+        """Handle ping/pong frames with proper validation"""
+        if len(payload) != 4:
+            logging.warning(f"Invalid ping payload length: {len(payload)} (expected 4)")
+            return
+            
+        ping_value = struct.unpack(">I", payload)[0]
+        
+        if flags & 0x1:  # SYN flag - ping request
+            logging.debug(f"Received ping request with value {ping_value} for peer {self.peer_id}")
+            # Send pong response (ACK flag = 0x2)
+            try:
+                pong_header = struct.pack(">BBHII", 0, 2, 0x2, 0, 4)  # Version=0, Type=2, Flags=ACK, StreamID=0, Length=4
+                pong_payload = struct.pack(">I", ping_value)
+                await self.secured_conn.write(pong_header + pong_payload)
+                logging.debug(f"Sent pong response with value {ping_value}")
+            except Exception as e:
+                logging.error(f"Failed to send pong response: {e}")
+        else:
+            # Pong response
+            logging.debug(f"Received pong response with value {ping_value}")
+
+    async def _handle_goaway_frame(self, payload):
+        """Handle GoAway frames"""
+        if len(payload) != 4:
+            logging.warning(f"Invalid GoAway payload length: {len(payload)}")
+            return
+            
+        code = struct.unpack(">I", payload)[0]
+        logging.info(f"Received GoAway frame with code {code}")
+        self.event_shutting_down.set()
+ 
 async def handle_ping(stream: INetStream) -> None:
-    while True:
-        try:
+    peer_id = stream.muxed_conn.peer_id
+    logging.info(f"Handling ping stream from {peer_id}")
+
+    try:
+        with trio.fail_after(RESP_TIMEOUT):
+            # Read initial protocol negotiation
+            initial_data = await stream.read(1024)
+            logging.debug(f"Received initial stream data from {peer_id}: {initial_data.hex()} (length={len(initial_data)})")
+            if initial_data == b"/ipfs/ping/1.0.0\n":
+                logging.debug(f"Confirmed /ipfs/ping/1.0.0 protocol negotiation from {peer_id}")
+            else:
+                logging.warning(f"Unexpected initial data: {initial_data!r}")
+
+            # Read ping payload
             payload = await stream.read(PING_LENGTH)
-            peer_id = stream.muxed_conn.peer_id
-            if payload is not None:
-                print(f"received ping from {peer_id}")
+            if not payload:
+                logging.info(f"Stream closed by {peer_id}")
+                return
+            if len(payload) != PING_LENGTH:
+                logging.warning(f"Unexpected payload length {len(payload)} from {peer_id}: {payload.hex()}")
+                return
+            logging.info(f"Received ping from {peer_id}: {payload[:8].hex()}... (length={len(payload)})")
+            await stream.write(payload)
+            logging.info(f"Sent pong to {peer_id}: {payload[:8].hex()}...")
 
-                await stream.write(payload)
-                print(f"responded with pong to {peer_id}")
-
-        except Exception:
-            await stream.reset()
-            break
-
+    except trio.TooSlowError:
+        logging.warning(f"Ping timeout with {peer_id}")
+    except trio.BrokenResourceError:
+        logging.info(f"Connection broken with {peer_id}")
+    except Exception as e:
+        logging.error(f"Error handling ping from {peer_id}: {e}")
+    finally:
+        try:
+            await stream.close()
+            logging.debug(f"Closed ping stream with {peer_id}")
+        except:
+            pass
 
 async def send_ping(stream: INetStream) -> None:
+    peer_id = stream.muxed_conn.peer_id
     try:
-        payload = b"\x01" * PING_LENGTH
-        print(f"sending ping to {stream.muxed_conn.peer_id}")
-
-        await stream.write(payload)
-
+        payload = os.urandom(PING_LENGTH)
+        logging.info(f"Sending ping to {peer_id}: {payload[:8].hex()}...")
         with trio.fail_after(RESP_TIMEOUT):
+            await stream.write(payload)
+            logging.debug(f"Ping sent to {peer_id}")
             response = await stream.read(PING_LENGTH)
-
+        if not response:
+            logging.error(f"No pong response from {peer_id}")
+            return
+        if len(response) != PING_LENGTH:
+            logging.warning(f"Pong length mismatch: got {len(response)}, expected {PING_LENGTH}")
         if response == payload:
-            print(f"received pong from {stream.muxed_conn.peer_id}")
-
+            logging.info(f"Ping successful! Pong matches from {peer_id}")
+        else:
+            logging.warning(f"Pong mismatch from {peer_id}")
+    except trio.TooSlowError:
+        logging.error(f"Ping timeout to {peer_id}")
     except Exception as e:
-        print(f"error occurred : {e}")
+        logging.error(f"Error sending ping to {peer_id}: {e}")
+    finally:
+        try:
+            await stream.close()
+        except:
+            pass
 
+def create_noise_keypair():
+    try:
+        x25519_private_key = x25519.X25519PrivateKey.generate()
+        
+        class NoisePrivateKey:
+            def __init__(self, key):
+                self._key = key
+                
+            def to_bytes(self):
+                return self._key.private_bytes_raw()
+                
+            def public_key(self):
+                return NoisePublicKey(self._key.public_key())
+            
+            def get_public_key(self):
+                return NoisePublicKey(self._key.public_key())
+
+        class NoisePublicKey:
+            def __init__(self, key):
+                self._key = key
+            
+            def to_bytes(self):
+                return self._key.public_bytes_raw()
+
+        return NoisePrivateKey(x25519_private_key)
+    except Exception as e:
+        logging.error(f"Failed to create Noise keypair: {e}")
+        return None
+
+def info_from_p2p_addr(addr):
+    """Extract peer info from multiaddr - you'll need to implement this"""
+    # This is a placeholder - you need to implement the actual parsing
+    # based on your libp2p implementation
+    pass
 
 async def run(port: int, destination: str) -> None:
-    localhost_ip = "127.0.0.1"
     listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
-    host = new_host()
+    
+    try:
+        key_pair = generate_new_rsa_identity()
+        logging.debug("Generated RSA keypair")
+        
+        noise_privkey = create_noise_keypair()
+        logging.debug("Generated Noise keypair")
+    except Exception as e:
+        logging.error(f"Key generation failed: {e}")
+        raise
+    
+    noise_transport = NoiseTransport(key_pair, noise_privkey=noise_privkey)
+    logging.debug(f"Noise transport initialized: {noise_transport}")
+    sec_opt = {TProtocol("/noise"): noise_transport}
+    muxer_opt = {TProtocol(YAMUX_PROTOCOL_ID): InteropYamux}
+    
+    logging.info(f"Using muxer: {muxer_opt}")
+    
+    host = new_host(
+        key_pair=key_pair,
+        sec_opt=sec_opt,
+        muxer_opt=muxer_opt
+    )
+    
+    peer_id = host.get_id().pretty()
+    logging.info(f"Host peer ID: {peer_id}")
 
     async with host.run(listen_addrs=[listen_addr]), trio.open_nursery() as nursery:
         if not destination:
             host.set_stream_handler(PING_PROTOCOL_ID, handle_ping)
-
-            print(
-                "Run this from the same folder in another console:\n\n"
-                f"ping-demo -p {int(port) + 1} "
-                f"-d /ip4/{localhost_ip}/tcp/{port}/p2p/{host.get_id().pretty()}\n"
-            )
-            print("Waiting for incoming connection...")
-
+            
+            logging.info(f"Server listening on {listen_addr}")
+            logging.info(f"Full address: {listen_addr}/p2p/{peer_id}")
+            logging.info("Waiting for connections...")
+            
+            await trio.sleep_forever()
         else:
             maddr = multiaddr.Multiaddr(destination)
             info = info_from_p2p_addr(maddr)
-            await host.connect(info)
-            stream = await host.new_stream(info.peer_id, [PING_PROTOCOL_ID])
+            
+            logging.info(f"Connecting to {info.peer_id}")
+            
+            try:
+                with trio.fail_after(30):
+                    await host.connect(info)
+                    logging.info(f"Connected to {info.peer_id}")
+                    
+                    await trio.sleep(2.0)
+                    
+                    logging.info(f"Opening ping stream to {info.peer_id}")
+                    stream = await host.new_stream(info.peer_id, [PING_PROTOCOL_ID])
+                    logging.info(f"Opened ping stream to {info.peer_id}")
+                    
+                    await trio.sleep(0.5)
+                    
+                    await send_ping(stream)
+                    
+                    logging.info("Ping completed successfully")
+                    
+                    logging.info("Keeping connection alive for 5 seconds...")
+                    await trio.sleep(5.0)
+            except trio.TooSlowError:
+                logging.error(f"Connection timeout to {info.peer_id}")
+                raise
+            except Exception as e:
+                logging.error(f"Connection failed to {info.peer_id}: {e}")
+                import traceback
+                traceback.print_exc()
+                raise
 
-            nursery.start_soon(send_ping, stream)
+def info_from_p2p_addr(addr):
+    """Extract peer info from multiaddr"""
+    from libp2p.peer.id import ID
+    
+    # Parse the multiaddr to extract peer ID
+    protocols = addr.protocols()
+    peer_id_str = None
+    
+    for proto in protocols:
+        if proto.code == 421:  # p2p protocol
+            peer_id_str = proto.value
+            break
+    
+    if not peer_id_str:
+        raise ValueError("No peer ID found in multiaddr")
+    
+    class PeerInfo:
+        def __init__(self, peer_id, addrs):
+            self.peer_id = peer_id
+            self.addrs = addrs
+    
+    return PeerInfo(ID.from_base58(peer_id_str), [addr])
 
-            return
-
-        await trio.sleep_forever()
-
-
-def main() -> None:
-    description = """
-    This program demonstrates a simple p2p ping application using libp2p.
-    To use it, first run 'python ping.py -p <PORT>', where <PORT> is the port number.
-    Then, run another instance with 'python ping.py -p <ANOTHER_PORT> -d <DESTINATION>',
-    where <DESTINATION> is the multiaddress of the previous listener host.
-    """
-
-    example_maddr = (
-        "/ip4/127.0.0.1/tcp/8000/p2p/QmQn4SwGkDZKkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
-    )
-
-    parser = argparse.ArgumentParser(description=description)
-
-    parser.add_argument(
-        "-p", "--port", default=8000, type=int, help="source port number"
-    )
-    parser.add_argument(
-        "-d",
-        "--destination",
-        type=str,
-        help=f"destination multiaddr string, e.g. {example_maddr}",
-    )
+def main():
+    parser = argparse.ArgumentParser(description="libp2p ping with Rust interoperability")
+    parser.add_argument("-p", "--port", default=8000, type=int, help="Port to listen on")
+    parser.add_argument("-d", "--destination", type=str, help="Destination multiaddr")
+    
     args = parser.parse_args()
-
-    if not args.port:
-        raise RuntimeError("failed to determine local port")
-
+    
     try:
-        trio.run(run, *(args.port, args.destination))
+        trio.run(run, args.port, args.destination)
     except KeyboardInterrupt:
-        pass
-
+        logging.info("Terminated by user")
+    except Exception as e:
+        logging.error(f"Fatal error: {e}")
+        raise
 
 if __name__ == "__main__":
     main()

--- a/examples/ping/ping.py
+++ b/examples/ping/ping.py
@@ -1,27 +1,39 @@
 import argparse
+import logging
+import os
+import struct
+
+from cryptography.hazmat.primitives.asymmetric import (
+    x25519,
+)
 import multiaddr
 import trio
-import logging
-import struct
-import os
-from typing import Optional, Dict, Any
 
-from libp2p import new_host, generate_new_rsa_identity
-from libp2p.custom_types import TProtocol
-from libp2p.network.stream.net_stream import INetStream
+from libp2p import (
+    generate_new_rsa_identity,
+    new_host,
+)
+from libp2p.custom_types import (
+    TProtocol,
+)
+from libp2p.network.stream.net_stream import (
+    INetStream,
+)
 from libp2p.security.noise.transport import Transport as NoiseTransport
-from libp2p.stream_muxer.yamux.yamux import Yamux, YamuxStream, PROTOCOL_ID as YAMUX_PROTOCOL_ID
-from cryptography.hazmat.primitives.asymmetric import x25519
-from libp2p.crypto.keys import KeyPair
+from libp2p.stream_muxer.yamux.yamux import (
+    Yamux,
+    YamuxStream,
+)
+from libp2p.stream_muxer.yamux.yamux import PROTOCOL_ID as YAMUX_PROTOCOL_ID
 
 # Configure detailed logging
 logging.basicConfig(
-    level=logging.DEBUG, 
-    format='%(asctime)s - %(levelname)s - %(message)s',
+    level=logging.DEBUG,
+    format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler('ping_debug.log', mode='w', encoding='utf-8')
-    ]
+        logging.FileHandler("ping_debug.log", mode="w", encoding="utf-8"),
+    ],
 )
 
 # Protocol constants - must match rust-libp2p exactly
@@ -30,9 +42,10 @@ PING_LENGTH = 32
 RESP_TIMEOUT = 30
 MAX_FRAME_SIZE = 1024 * 1024  # 1MB max frame size
 
+
 class InteropYamux(Yamux):
     """Enhanced Yamux with proper rust-libp2p interoperability"""
-    
+
     def __init__(self, *args, **kwargs):
         logging.info("InteropYamux.__init__ called")
         super().__init__(*args, **kwargs)
@@ -43,25 +56,31 @@ class InteropYamux(Yamux):
         """Read exactly n bytes from the connection with proper error handling"""
         if n == 0:
             return b""
-            
+
         if n > MAX_FRAME_SIZE:
             logging.error(f"Requested read size {n} exceeds maximum {MAX_FRAME_SIZE}")
             return None
-            
+
         data = b""
         while len(data) < n:
             try:
                 remaining = n - len(data)
                 chunk = await self.secured_conn.read(remaining)
             except (trio.ClosedResourceError, trio.BrokenResourceError):
-                logging.debug(f"Connection closed while reading {n} bytes (got {len(data)}) for peer {self.peer_id}")
+                logging.debug(
+                    f"Connection closed while reading {n}"
+                    f"bytes (got {len(data)}) for peer {self.peer_id}"
+                )
                 return None
             except Exception as e:
                 logging.error(f"Error reading {n} bytes: {e}")
                 return None
-                
+
             if not chunk:
-                logging.debug(f"Connection closed while reading {n} bytes (got {len(data)}) for peer {self.peer_id}")
+                logging.debug(
+                    f"Connection closed while reading {n}"
+                    f"bytes (got {len(data)}) for peer {self.peer_id}"
+                )
                 return None
             data += chunk
         return data
@@ -69,55 +88,75 @@ class InteropYamux(Yamux):
     async def handle_incoming(self):
         """Enhanced incoming frame handler with better error recovery"""
         logging.info(f"Starting Yamux for {self.peer_id}")
-        
+
         consecutive_errors = 0
         max_consecutive_errors = 3
-        
+
         while not self.event_shutting_down.is_set():
             try:
                 # Read frame header (12 bytes)
                 header_data = await self._read_exact_bytes(12)
                 if header_data is None:
-                    logging.debug(f"Connection closed or incomplete header for peer {self.peer_id}")
+                    logging.debug(
+                        f"Connection closed or incomplete"
+                        f"header for peer {self.peer_id}"
+                    )
                     break
 
                 # Quick sanity check for protocol data leakage
-                if b'/ipfs' in header_data or b'multi' in header_data or b'noise' in header_data:
-                    logging.error(f"Protocol data in header position: {header_data.hex()}")
+                if (
+                    b"/ipfs" in header_data
+                    or b"multi" in header_data
+                    or b"noise" in header_data
+                ):
+                    logging.error(
+                        f"Protocol data in header position: {header_data.hex()}"
+                    )
                     break
 
                 try:
                     # Unpack header: version, type, flags, stream_id, length
-                    version, msg_type, flags, stream_id, length = struct.unpack(">BBHII", header_data)
-                    
+                    version, msg_type, flags, stream_id, length = struct.unpack(
+                        ">BBHII", header_data
+                    )
+
                     # Validate header values strictly
                     if version != 0:
                         logging.error(f"Invalid yamux version {version}, expected 0")
                         break
-                    
+
                     if msg_type not in [0, 1, 2, 3]:
                         logging.error(f"Invalid message type {msg_type}, expected 0-3")
                         break
-                        
+
                     if length > MAX_FRAME_SIZE:
                         logging.error(f"Frame too large: {length} > {MAX_FRAME_SIZE}")
                         break
-                    
+
                     # Additional validation for ping frames
                     if msg_type == 2 and length != 4:
-                        logging.error(f"Invalid ping frame length: {length}, expected 4")
+                        logging.error(
+                            f"Invalid ping frame length: {length}, expected 4"
+                        )
                         break
 
                     # Log frame details
-                    logging.debug(f"Received header for peer {self.peer_id}: type={msg_type}, flags={flags}, stream_id={stream_id}, length={length}")
-                    
+                    logging.debug(
+                        f"Received header for peer {self.peer_id}"
+                        f": type={msg_type}, flags={flags},"
+                        f"stream_id={stream_id}, length={length}"
+                    )
+
                     consecutive_errors = 0  # Reset error counter on successful parse
 
                 except struct.error as e:
                     consecutive_errors += 1
-                    logging.error(f"Header parse error #{consecutive_errors}: {e}, data: {header_data.hex()}")
+                    logging.error(
+                        f"Header parse error #{consecutive_errors}"
+                        f": {e}, data: {header_data.hex()}"
+                    )
                     if consecutive_errors >= max_consecutive_errors:
-                        logging.error("Too many consecutive header parse errors, closing connection")
+                        logging.error("Too many consecutive header parse errors")
                         break
                     continue
 
@@ -126,34 +165,42 @@ class InteropYamux(Yamux):
                 if length > 0:
                     payload = await self._read_exact_bytes(length)
                     if payload is None:
-                        logging.debug(f"Failed to read payload of {length} bytes for peer {self.peer_id}")
+                        logging.debug(
+                            f"Failed to read payload of"
+                            f"{length} bytes for peer {self.peer_id}"
+                        )
                         break
                     if len(payload) != length:
-                        logging.error(f"Payload length mismatch: got {len(payload)}, expected {length}")
+                        logging.error(
+                            f"Payload length mismatch:"
+                            f"got {len(payload)}, expected {length}"
+                        )
                         break
 
                 # Process frame by type
                 if msg_type == 0:  # Data frame
                     await self._handle_data_frame(stream_id, flags, payload)
-                    
+
                 elif msg_type == 1:  # Window update
                     await self._handle_window_update(stream_id, payload)
-                    
+
                 elif msg_type == 2:  # Ping frame
                     await self._handle_ping_frame(stream_id, flags, payload)
-                    
+
                 elif msg_type == 3:  # GoAway frame
                     await self._handle_goaway_frame(payload)
                     break
 
             except (trio.ClosedResourceError, trio.BrokenResourceError):
-                logging.debug(f"Connection closed during frame processing for peer {self.peer_id}")
+                logging.debug(
+                    f"Connection closed during frame processing for peer {self.peer_id}"
+                )
                 break
             except Exception as e:
                 consecutive_errors += 1
                 logging.error(f"Frame processing error #{consecutive_errors}: {e}")
                 if consecutive_errors >= max_consecutive_errors:
-                    logging.error("Too many consecutive frame processing errors, closing connection")
+                    logging.error("Too many consecutive frame processing errors")
                     break
 
         await self._cleanup_on_error()
@@ -169,28 +216,30 @@ class InteropYamux(Yamux):
             if stream_id in self.streams:
                 logging.warning(f"SYN received for existing stream {stream_id}")
             else:
-                logging.debug(f"Creating new stream {stream_id} for peer {self.peer_id}")
+                logging.debug(
+                    f"Creating new stream {stream_id} for peer {self.peer_id}"
+                )
                 stream = YamuxStream(self, stream_id, is_outbound=False)
                 async with self.streams_lock:
                     self.streams[stream_id] = stream
-                
+
                 # Send the new stream to the handler
                 await self.new_stream_send_channel.send(stream)
                 logging.debug(f"Sent stream {stream_id} to handler")
-                
+
         # Add data to stream buffer if stream exists
         if stream_id in self.streams:
             stream = self.streams[stream_id]
             if payload:
                 # Add to stream's receive buffer
                 async with self.streams_lock:
-                    if not hasattr(stream, '_receive_buffer'):
+                    if not hasattr(stream, "_receive_buffer"):
                         stream._receive_buffer = bytearray()
-                    if not hasattr(stream, '_receive_event'):
+                    if not hasattr(stream, "_receive_event"):
                         stream._receive_event = trio.Event()
                     stream._receive_buffer.extend(payload)
                     stream._receive_event.set()
-            
+
             # Handle stream closure flags
             if flags & 0x2:  # FIN flag
                 stream.recv_closed = True
@@ -207,13 +256,13 @@ class InteropYamux(Yamux):
         if len(payload) != 4:
             logging.warning(f"Invalid window update payload length: {len(payload)}")
             return
-            
+
         delta = struct.unpack(">I", payload)[0]
         logging.debug(f"Window update: stream={stream_id}, delta={delta}")
-        
+
         async with self.streams_lock:
             if stream_id in self.streams:
-                if not hasattr(self.streams[stream_id], 'send_window'):
+                if not hasattr(self.streams[stream_id], "send_window"):
                     self.streams[stream_id].send_window = 256 * 1024  # Default window
                 self.streams[stream_id].send_window += delta
 
@@ -222,14 +271,18 @@ class InteropYamux(Yamux):
         if len(payload) != 4:
             logging.warning(f"Invalid ping payload length: {len(payload)} (expected 4)")
             return
-            
+
         ping_value = struct.unpack(">I", payload)[0]
-        
+
         if flags & 0x1:  # SYN flag - ping request
-            logging.debug(f"Received ping request with value {ping_value} for peer {self.peer_id}")
+            logging.debug(
+                f"Received ping request with value {ping_value} for peer {self.peer_id}"
+            )
             # Send pong response (ACK flag = 0x2)
             try:
-                pong_header = struct.pack(">BBHII", 0, 2, 0x2, 0, 4)  # Version=0, Type=2, Flags=ACK, StreamID=0, Length=4
+                pong_header = struct.pack(
+                    ">BBHII", 0, 2, 0x2, 0, 4
+                )  # Version=0, Type=2, Flags=ACK, StreamID=0, Length=4
                 pong_payload = struct.pack(">I", ping_value)
                 await self.secured_conn.write(pong_header + pong_payload)
                 logging.debug(f"Sent pong response with value {ping_value}")
@@ -244,11 +297,12 @@ class InteropYamux(Yamux):
         if len(payload) != 4:
             logging.warning(f"Invalid GoAway payload length: {len(payload)}")
             return
-            
+
         code = struct.unpack(">I", payload)[0]
         logging.info(f"Received GoAway frame with code {code}")
         self.event_shutting_down.set()
- 
+
+
 async def handle_ping(stream: INetStream) -> None:
     peer_id = stream.muxed_conn.peer_id
     logging.info(f"Handling ping stream from {peer_id}")
@@ -257,9 +311,14 @@ async def handle_ping(stream: INetStream) -> None:
         with trio.fail_after(RESP_TIMEOUT):
             # Read initial protocol negotiation
             initial_data = await stream.read(1024)
-            logging.debug(f"Received initial stream data from {peer_id}: {initial_data.hex()} (length={len(initial_data)})")
+            logging.debug(
+                f"Received initial stream data from {peer_id}"
+                f": {initial_data.hex()} (length={len(initial_data)})"
+            )
             if initial_data == b"/ipfs/ping/1.0.0\n":
-                logging.debug(f"Confirmed /ipfs/ping/1.0.0 protocol negotiation from {peer_id}")
+                logging.debug(
+                    f"Confirmed /ipfs/ping/1.0.0 protocol negotiation from {peer_id}"
+                )
             else:
                 logging.warning(f"Unexpected initial data: {initial_data!r}")
 
@@ -269,9 +328,15 @@ async def handle_ping(stream: INetStream) -> None:
                 logging.info(f"Stream closed by {peer_id}")
                 return
             if len(payload) != PING_LENGTH:
-                logging.warning(f"Unexpected payload length {len(payload)} from {peer_id}: {payload.hex()}")
+                logging.warning(
+                    f"Unexpected payload length"
+                    f" {len(payload)} from {peer_id}: {payload.hex()}"
+                )
                 return
-            logging.info(f"Received ping from {peer_id}: {payload[:8].hex()}... (length={len(payload)})")
+            logging.info(
+                f"Received ping from {peer_id}:"
+                f" {payload[:8].hex()}... (length={len(payload)})"
+            )
             await stream.write(payload)
             logging.info(f"Sent pong to {peer_id}: {payload[:8].hex()}...")
 
@@ -285,8 +350,9 @@ async def handle_ping(stream: INetStream) -> None:
         try:
             await stream.close()
             logging.debug(f"Closed ping stream with {peer_id}")
-        except:
+        except Exception:
             pass
+
 
 async def send_ping(stream: INetStream) -> None:
     peer_id = stream.muxed_conn.peer_id
@@ -301,7 +367,9 @@ async def send_ping(stream: INetStream) -> None:
             logging.error(f"No pong response from {peer_id}")
             return
         if len(response) != PING_LENGTH:
-            logging.warning(f"Pong length mismatch: got {len(response)}, expected {PING_LENGTH}")
+            logging.warning(
+                f"Pong length mismatch: got {len(response)}, expected {PING_LENGTH}"
+            )
         if response == payload:
             logging.info(f"Ping successful! Pong matches from {peer_id}")
         else:
@@ -313,30 +381,31 @@ async def send_ping(stream: INetStream) -> None:
     finally:
         try:
             await stream.close()
-        except:
+        except Exception:
             pass
+
 
 def create_noise_keypair():
     try:
         x25519_private_key = x25519.X25519PrivateKey.generate()
-        
+
         class NoisePrivateKey:
             def __init__(self, key):
                 self._key = key
-                
+
             def to_bytes(self):
                 return self._key.private_bytes_raw()
-                
+
             def public_key(self):
                 return NoisePublicKey(self._key.public_key())
-            
+
             def get_public_key(self):
                 return NoisePublicKey(self._key.public_key())
 
         class NoisePublicKey:
             def __init__(self, key):
                 self._key = key
-            
+
             def to_bytes(self):
                 return self._key.public_bytes_raw()
 
@@ -345,73 +414,70 @@ def create_noise_keypair():
         logging.error(f"Failed to create Noise keypair: {e}")
         return None
 
+
 def info_from_p2p_addr(addr):
     """Extract peer info from multiaddr - you'll need to implement this"""
     # This is a placeholder - you need to implement the actual parsing
     # based on your libp2p implementation
-    pass
+
 
 async def run(port: int, destination: str) -> None:
     listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
-    
+
     try:
         key_pair = generate_new_rsa_identity()
         logging.debug("Generated RSA keypair")
-        
+
         noise_privkey = create_noise_keypair()
         logging.debug("Generated Noise keypair")
     except Exception as e:
         logging.error(f"Key generation failed: {e}")
         raise
-    
+
     noise_transport = NoiseTransport(key_pair, noise_privkey=noise_privkey)
     logging.debug(f"Noise transport initialized: {noise_transport}")
     sec_opt = {TProtocol("/noise"): noise_transport}
     muxer_opt = {TProtocol(YAMUX_PROTOCOL_ID): InteropYamux}
-    
+
     logging.info(f"Using muxer: {muxer_opt}")
-    
-    host = new_host(
-        key_pair=key_pair,
-        sec_opt=sec_opt,
-        muxer_opt=muxer_opt
-    )
-    
+
+    host = new_host(key_pair=key_pair, sec_opt=sec_opt, muxer_opt=muxer_opt)
+
     peer_id = host.get_id().pretty()
     logging.info(f"Host peer ID: {peer_id}")
 
-    async with host.run(listen_addrs=[listen_addr]), trio.open_nursery() as nursery:
+    async with host.run(listen_addrs=[listen_addr]), trio.open_nursery():
         if not destination:
             host.set_stream_handler(PING_PROTOCOL_ID, handle_ping)
-            
+
             logging.info(f"Server listening on {listen_addr}")
             logging.info(f"Full address: {listen_addr}/p2p/{peer_id}")
             logging.info("Waiting for connections...")
-            
+
             await trio.sleep_forever()
         else:
             maddr = multiaddr.Multiaddr(destination)
             info = info_from_p2p_addr(maddr)
-            
+
             logging.info(f"Connecting to {info.peer_id}")
-            
+
             try:
                 with trio.fail_after(30):
                     await host.connect(info)
                     logging.info(f"Connected to {info.peer_id}")
-                    
+
                     await trio.sleep(2.0)
-                    
+
                     logging.info(f"Opening ping stream to {info.peer_id}")
                     stream = await host.new_stream(info.peer_id, [PING_PROTOCOL_ID])
                     logging.info(f"Opened ping stream to {info.peer_id}")
-                    
+
                     await trio.sleep(0.5)
-                    
+
                     await send_ping(stream)
-                    
+
                     logging.info("Ping completed successfully")
-                    
+
                     logging.info("Keeping connection alive for 5 seconds...")
                     await trio.sleep(5.0)
             except trio.TooSlowError:
@@ -420,39 +486,22 @@ async def run(port: int, destination: str) -> None:
             except Exception as e:
                 logging.error(f"Connection failed to {info.peer_id}: {e}")
                 import traceback
+
                 traceback.print_exc()
                 raise
 
-def info_from_p2p_addr(addr):
-    """Extract peer info from multiaddr"""
-    from libp2p.peer.id import ID
-    
-    # Parse the multiaddr to extract peer ID
-    protocols = addr.protocols()
-    peer_id_str = None
-    
-    for proto in protocols:
-        if proto.code == 421:  # p2p protocol
-            peer_id_str = proto.value
-            break
-    
-    if not peer_id_str:
-        raise ValueError("No peer ID found in multiaddr")
-    
-    class PeerInfo:
-        def __init__(self, peer_id, addrs):
-            self.peer_id = peer_id
-            self.addrs = addrs
-    
-    return PeerInfo(ID.from_base58(peer_id_str), [addr])
 
 def main():
-    parser = argparse.ArgumentParser(description="libp2p ping with Rust interoperability")
-    parser.add_argument("-p", "--port", default=8000, type=int, help="Port to listen on")
+    parser = argparse.ArgumentParser(
+        description="libp2p ping with Rust interoperability"
+    )
+    parser.add_argument(
+        "-p", "--port", default=8000, type=int, help="Port to listen on"
+    )
     parser.add_argument("-d", "--destination", type=str, help="Destination multiaddr")
-    
+
     args = parser.parse_args()
-    
+
     try:
         trio.run(run, args.port, args.destination)
     except KeyboardInterrupt:
@@ -460,6 +509,7 @@ def main():
     except Exception as e:
         logging.error(f"Fatal error: {e}")
         raise
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Description
This is a work-in-progress (WIP) pull request to improve interoperability between `py-libp2p` and `rust-libp2p`, focusing on the Noise XX handshake and Yamux multiplexing. The goal is to enable a successful ping exchange between a Python client and a Rust server.

### Changes
- **examples/ping/ping.py**: 
  - Modified to use a `KeyPair` derived from Rust’s private and public keys for testing (e.g., private: `6866d018...`, public: `0d3fb3dc...`). These are placeholders and change per Rust run; future work should dynamically fetch them.
  - Updated `Transport` instantiation to pass `noise_privkey=key_pair.private_key` instead of `noise_keypair` (fixed `call-arg` error).
  - Added type annotations and `cast(TProtocol, ...)` for `muxer_transports_by_protocol` to resolve `mypy` errors.

- **libp2p/stream_muxer/yamux/yamux.py**: 
  - Updated header size to 12 bytes (`!BBHI`) per the Yamux spec, fixing the previous 8-byte mismatch.
  - Improved stream handling for `FLAG_SYN` and `FLAG_FIN`.

- **libp2p/security/noise/transport.py**: 
  - Adjusted `secure_inbound` signature to match `ISecureTransport` (removed `peer_id` parameter).

- **libp2p/security/noise/patterns.py**: 
  - Made `remote_peer_id` optional in `PatternXX.handshake_inbound` to match `IPattern` interface, fixing `override` error.

### Current Status
- **Noise Handshake**: 
  - Completes on Python side but fails on Rust side with `BadSignature` during **Msg #3** verification. Logs show Python’s Noise public key (`ecc32c64...`) doesn’t match the expected Rust key (`0d3fb3dc...`), despite setting the `KeyPair`.
  - The hardcoded Rust keys in `ping.py` are temporary and change per Rust run, indicating a need for dynamic key exchange or configuration.

- **Muxing**: 
  - Fails with `IncompleteReadError` after the handshake, likely due to Rust closing the connection post-`BadSignature`.
  - Yamux header updated to 12 bytes, but compatibility untested until handshake succeeds.

- **Next Steps**: 
  - Debug why `Transport` uses a different Noise key despite setting `noise_privkey`.
  - Implement dynamic key retrieval from Rust instead of hardcoding.
  - Verify Yamux interoperability once the handshake is fixed.
  - Run full interop test with updated Rust logs.

### Logs
- **Python**: 
```
DEBUG:root:Local Peer ID: 12D3KooWRhnLFgm53oxqcC3teSWQKFaCt1oa2NfmCRps7yrC5SQF
DEBUG:root:Public Key from Private: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Expected Public Key: aa7f2550cd849dc2a78e6a4d76c103f492c55bb75cc41adc6ae09ff2312d0a9e
DEBUG:async_service.Manager:<Manager[Swarm] flags=SRcfe>: _handle_cancelled waiting for cancellation
DEBUG:libp2p.transport.tcp:serve_tcp 0.0.0.0 8001
DEBUG:libp2p.network.swarm:attempting to dial peer 12D3KooWGjG2AC1hoU3DURkkvLSEJnvg1cTyLRajW9YMe8ejS5ac
DEBUG:libp2p.network.swarm:dialed peer 12D3KooWGjG2AC1hoU3DURkkvLSEJnvg1cTyLRajW9YMe8ejS5ac over base transport
DEBUG:root:Using libp2p key: <libp2p.crypto.ed25519.Ed25519PrivateKey object at 0x000001E4C4485050>, noise key: None
DEBUG:root:libp2p_privkey pubkey: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:noise_static_key pubkey: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Starting outbound handshake with peer 12D3KooWGjG2AC1hoU3DURkkvLSEJnvg1cTyLRajW9YMe8ejS5ac
DEBUG:root:Wrote encrypted message: 6c743a7731bc7c34ea196f821404b05f8b3a3803b2b19efdcf1220c395d3040c
DEBUG:root:Sent Msg #1: 6c743a7731bc7c34ea196f821404b05f8b3a3803b2b19efdcf1220c395d3040c
DEBUG:root:Received Msg #2: 0a240801122066b2f3edfd6f987a0d9e9e070a52154c2592e81dd2b7ee84a472ab50d8fd41151240cae7954cd98fdd8d81349a58af954589fd079a118c7471c54165d7767c66a1ed1658548fd92734580f3d30fd970754d133b56f73a5210fd983c423e909cda604
DEBUG:root:Public key bytes: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Transcript for signature: 6e6f6973652d6c69627032702d7374617469632d6b65793aec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Signing with privkey, pubkey: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Signature: 1d9e7046271c6bc4a797686f446f77e78007bcf3d9edcfcb309bffee4ce39a2ca1ceca898edcea541c211fd46d275b2409cd24f39b5ba73ace8f229f55dd0c08
DEBUG:root:Signature verified locally
DEBUG:root:Raw public key bytes: ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8, length: 32
DEBUG:root:Serialized pubkey: 08011220ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b8
DEBUG:root:Serialized payload: 0a2408011220ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b812401d9e7046271c6bc4a797686f446f77e78007bcf3d9edcfcb309bffee4ce39a2ca1ceca898edcea541c211fd46d275b2409cd24f39b5ba73ace8f229f55dd0c08
DEBUG:root:Prepared Msg #3 raw: 0a2408011220ec0b3f57bd7cd213ea0f913947b374c27a3035654b068bd334722b85aaf176b812401d9e7046271c6bc4a797686f446f77e78007bcf3d9edcfcb309bffee4ce39a2ca1ceca898edcea541c211fd46d275b2409cd24f39b5ba73ace8f229f55dd0c08, length: 104     
DEBUG:root:Wrote encrypted message: 6bc32048aef6fd1013ac1f8f1eb7f68a7c6fcaa6832589426c556bac761b27d653cf0a13ca6653a647c60126f2d2afa5c1f2262a80e4b373a9c6f9fc6d96b505adcc578c0a358ca237fb01ccecc6a9b7a9cf5fd082b6e393f80eb8996a713f0837244db4a916e474437e73b1cb0ed297a3b77ba312f859a49f1c8bcd8b47d577ac0b2641de96bca24d82be33bc4615ea83dbadc19944662349cb1f72017a99ca83d48d986c7f3c37
DEBUG:root:Sent Msg #3 (s, se): 6bc32048aef6fd1013ac1f8f1eb7f68a7c6fcaa6832589426c556bac761b27d653cf0a13ca6653a647c60126f2d2afa5c1f2262a80e4b373a9c6f9fc6d96b505adcc578c0a358ca237fb01ccecc6a9b7a9cf5fd082b6e393f80eb8996a713f0837244db4a916e474437e73b1cb0ed297a3b77ba312f859a49f1c8bcd8b47d577ac0b2641de96bca24d82be33bc4615ea83dbadc19944662349cb1f72017a99ca83d48d986c7f3c37
DEBUG:root:Handshake completed
DEBUG:libp2p.network.swarm:upgraded security for peer 12D3KooWGjG2AC1hoU3DURkkvLSEJnvg1cTyLRajW9YMe8ejS5ac
DEBUG:libp2p.network.swarm:failed to upgrade mux for peer 12D3KooWGjG2AC1hoU3DURkkvLSEJnvg1cTyLRajW9YMe8ejS5ac
DEBUG:libp2p.network.swarm:encountered swarm exception when trying to connect to /ip4/127.0.0.1/tcp/35557, trying next address...Traceback (most recent call last):
```
- **Rust**:
```
2025-03-06T10:12:44.209617Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: multistream_select::protocol: Received message Header(V1)
2025-03-06T10:12:44.211197Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: multistream_select::protocol: Received message Protocol(Protocol("/noise"))
2025-03-06T10:12:44.211305Z DEBUG new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: multistream_select::listener_select: Listener: confirming protocol protocol=/noise
2025-03-06T10:12:44.213647Z DEBUG new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: multistream_select::listener_select: Listener: sent confirmed protocol protocol=/noise
2025-03-06T10:12:44.289501Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Incoming ciphertext has 32 bytes
2025-03-06T10:12:44.289570Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Decrypted cleartext has 0 bytes
2025-03-06T10:12:44.289588Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Encrypting 104 bytes
2025-03-06T10:12:44.290024Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Outgoing ciphertext has 200 bytes
2025-03-06T10:12:44.314637Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Incoming ciphertext has 168 bytes
2025-03-06T10:12:44.315002Z TRACE new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_noise::io::framed: Decrypted cleartext has 104 bytes
2025-03-06T10:12:44.320755Z DEBUG new_incoming_connection{remote_addr=/ip4/127.0.0.1/tcp/49616 id=1}: libp2p_core::upgrade::apply: Failed to upgrade inbound stream upgrade=/noise
2025-03-06T10:12:44.321646Z DEBUG Swarm::poll: libp2p_swarm: Incoming connection failed: Transport(Other(Custom 
{ kind: Other, error: Other(Left(Right(Apply(BadSignature)))) }))
```

### Request for Feedback
- Is `noise_privkey` in `Transport` being applied correctly to the Noise handshake? Logs suggest a mismatch.
- Why does the Noise handshake generate a different key pair (`ecc32c64...`) instead of using the provided `0d3fb3dc...`?
- Suggestions for dynamically fetching Rust’s key pair instead of hardcoding?
- Any tips to ensure Yamux compatibility with `rust-libp2p` once the handshake succeeds?

### Notes
- The Rust key pair (`6866d018...` and `0d3fb3dc...`) changes per run, so hardcoding is a temporary test measure. A production solution should query or negotiate keys.
- This PR is marked WIP and will be updated as progress continues.
