### PR TITLE
docs: add Sphinx-style docstrings in abc.py

### DIFF
--- a/newsfragments/535.docs.rst
+++ b/newsfragments/535.docs.rst
@@ -1,0 +1,1 @@
+Adds detailed Sphinx-style docstrings to ``abc.py``.


### PR DESCRIPTION
## What was wrong?
The interfaces in `abc.py` lacked proper Sphinx-formatted documentation comments. This made it harder to understand and maintain the codebase.
Issue #530 

## How was it fixed?

- Added Sphinx-style docstrings to all interfaces in `abc.py`.
- Ensured compliance with linting and documentation formatting requirements.
- Improved clarity and consistency of documentation across interfaces.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://www.fodors.com/wp-content/uploads/2020/03/CutestBabyAnimals__HERO_shutterstock_115739671.jpg>)
