### PR TITLE
Move factories into tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ validate-newsfragments:
 check-docs: build-docs validate-newsfragments
 
 build-docs:
-	sphinx-apidoc -o docs/ . setup.py "*conftest*"
+	sphinx-apidoc -o docs/ . setup.py "*conftest*" tests/
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -278,6 +278,9 @@ texinfo_documents = [
     ),
 ]
 
+# Prevent autodoc from trying to import module from tests.factories
+autodoc_mock_imports = ["tests.factories"]
+
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []
 

--- a/docs/libp2p.tools.rst
+++ b/docs/libp2p.tools.rst
@@ -22,14 +22,6 @@ libp2p.tools.constants module
    :undoc-members:
    :show-inheritance:
 
-libp2p.tools.factories module
------------------------------
-
-.. automodule:: libp2p.tools.factories
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 libp2p.tools.utils module
 -------------------------
 

--- a/libp2p/tools/pubsub/dummy_account_node.py
+++ b/libp2p/tools/pubsub/dummy_account_node.py
@@ -16,7 +16,7 @@ from libp2p.tools.async_service import (
     Service,
     background_trio_service,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     PubsubFactory,
 )
 

--- a/newsfragments/503.internal.rst
+++ b/newsfragments/503.internal.rst
@@ -1,0 +1,1 @@
+moved ``libp2p/tools/factories`` to ``tests``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
 )
 

--- a/tests/core/examples/test_examples.py
+++ b/tests/core/examples/test_examples.py
@@ -7,11 +7,11 @@ from libp2p.host.exceptions import (
 from libp2p.peer.peerinfo import (
     info_from_p2p_addr,
 )
-from libp2p.tools.factories import (
-    HostFactory,
-)
 from libp2p.tools.utils import (
     MAX_READ_LEN,
+)
+from tests.factories import (
+    HostFactory,
 )
 
 CHAT_PROTOCOL_ID = "/chat/1.0.0"

--- a/tests/core/host/test_connected_peers.py
+++ b/tests/core/host/test_connected_peers.py
@@ -3,7 +3,7 @@ import pytest
 from libp2p.peer.peerinfo import (
     info_from_p2p_addr,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
 )
 

--- a/tests/core/host/test_live_peers.py
+++ b/tests/core/host/test_live_peers.py
@@ -4,7 +4,7 @@ import trio
 from libp2p.peer.peerinfo import (
     info_from_p2p_addr,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
 )
 

--- a/tests/core/host/test_ping.py
+++ b/tests/core/host/test_ping.py
@@ -8,7 +8,7 @@ from libp2p.host.ping import (
     PING_LENGTH,
     PingService,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     host_pair_factory,
 )
 

--- a/tests/core/host/test_routed_host.py
+++ b/tests/core/host/test_routed_host.py
@@ -6,7 +6,7 @@ from libp2p.host.exceptions import (
 from libp2p.peer.peerinfo import (
     PeerInfo,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
     RoutedHostFactory,
 )

--- a/tests/core/identity/identify/test_protocol.py
+++ b/tests/core/identity/identify/test_protocol.py
@@ -7,7 +7,7 @@ from libp2p.identity.identify.protocol import (
     ID,
     _mk_identify_protobuf,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     host_pair_factory,
 )
 

--- a/tests/core/network/conftest.py
+++ b/tests/core/network/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from libp2p.tools.factories import (
+from tests.factories import (
     net_stream_pair_factory,
     swarm_conn_pair_factory,
     swarm_pair_factory,

--- a/tests/core/network/test_notify.py
+++ b/tests/core/network/test_notify.py
@@ -22,11 +22,11 @@ from libp2p.tools.async_service import (
 from libp2p.tools.constants import (
     LISTEN_MADDR,
 )
-from libp2p.tools.factories import (
-    SwarmFactory,
-)
 from libp2p.tools.utils import (
     connect_swarm,
+)
+from tests.factories import (
+    SwarmFactory,
 )
 
 

--- a/tests/core/network/test_swarm.py
+++ b/tests/core/network/test_swarm.py
@@ -10,11 +10,11 @@ from trio.testing import (
 from libp2p.network.exceptions import (
     SwarmException,
 )
-from libp2p.tools.factories import (
-    SwarmFactory,
-)
 from libp2p.tools.utils import (
     connect_swarm,
+)
+from tests.factories import (
+    SwarmFactory,
 )
 
 

--- a/tests/core/protocol_muxer/test_protocol_muxer.py
+++ b/tests/core/protocol_muxer/test_protocol_muxer.py
@@ -6,11 +6,11 @@ from trio.testing import (
 from libp2p.host.exceptions import (
     StreamFailure,
 )
-from libp2p.tools.factories import (
-    HostFactory,
-)
 from libp2p.tools.utils import (
     create_echo_stream_handler,
+)
+from tests.factories import (
+    HostFactory,
 )
 
 PROTOCOL_ECHO = "/echo/1.0.0"

--- a/tests/core/pubsub/test_floodsub.py
+++ b/tests/core/pubsub/test_floodsub.py
@@ -6,15 +6,15 @@ import trio
 from libp2p.peer.id import (
     ID,
 )
-from libp2p.tools.factories import (
-    PubsubFactory,
-)
 from libp2p.tools.pubsub.floodsub_integration_test_settings import (
     floodsub_protocol_pytest_params,
     perform_test_from_obj,
 )
 from libp2p.tools.utils import (
     connect,
+)
+from tests.factories import (
+    PubsubFactory,
 )
 
 

--- a/tests/core/pubsub/test_gossipsub.py
+++ b/tests/core/pubsub/test_gossipsub.py
@@ -6,16 +6,16 @@ import trio
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID,
 )
-from libp2p.tools.factories import (
-    IDFactory,
-    PubsubFactory,
-)
 from libp2p.tools.pubsub.utils import (
     dense_connect,
     one_to_all_connect,
 )
 from libp2p.tools.utils import (
     connect,
+)
+from tests.factories import (
+    IDFactory,
+    PubsubFactory,
 )
 
 

--- a/tests/core/pubsub/test_gossipsub_backward_compatibility.py
+++ b/tests/core/pubsub/test_gossipsub_backward_compatibility.py
@@ -5,12 +5,12 @@ import pytest
 from libp2p.tools.constants import (
     FLOODSUB_PROTOCOL_ID,
 )
-from libp2p.tools.factories import (
-    PubsubFactory,
-)
 from libp2p.tools.pubsub.floodsub_integration_test_settings import (
     floodsub_protocol_pytest_params,
     perform_test_from_obj,
+)
+from tests.factories import (
+    PubsubFactory,
 )
 
 

--- a/tests/core/pubsub/test_pubsub.py
+++ b/tests/core/pubsub/test_pubsub.py
@@ -21,11 +21,6 @@ from libp2p.pubsub.pubsub import (
 from libp2p.tools.constants import (
     MAX_READ_LEN,
 )
-from libp2p.tools.factories import (
-    IDFactory,
-    PubsubFactory,
-    net_stream_pair_factory,
-)
 from libp2p.tools.pubsub.utils import (
     make_pubsub_msg,
 )
@@ -34,6 +29,11 @@ from libp2p.tools.utils import (
 )
 from libp2p.utils import (
     encode_varint_prefixed,
+)
+from tests.factories import (
+    IDFactory,
+    PubsubFactory,
+    net_stream_pair_factory,
 )
 
 TESTING_TOPIC = "TEST_SUBSCRIBE"

--- a/tests/core/security/noise/test_msg_read_writer.py
+++ b/tests/core/security/noise/test_msg_read_writer.py
@@ -4,7 +4,7 @@ from libp2p.security.noise.io import (
     MAX_NOISE_MESSAGE_LEN,
     NoisePacketReadWriter,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     raw_conn_factory,
 )
 

--- a/tests/core/security/noise/test_noise.py
+++ b/tests/core/security/noise/test_noise.py
@@ -3,7 +3,7 @@ import pytest
 from libp2p.security.noise.messages import (
     NoiseHandshakePayload,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     noise_conn_factory,
     noise_handshake_payload_factory,
 )

--- a/tests/core/security/test_secio.py
+++ b/tests/core/security/test_secio.py
@@ -14,7 +14,7 @@ from libp2p.security.secio.transport import (
 from libp2p.tools.constants import (
     MAX_READ_LEN,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     raw_conn_factory,
 )
 

--- a/tests/core/security/test_security_multistream.py
+++ b/tests/core/security/test_security_multistream.py
@@ -12,7 +12,7 @@ from libp2p.security.secio.transport import ID as SECIO_PROTOCOL_ID
 from libp2p.security.secure_session import (
     SecureSession,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     host_pair_factory,
 )
 

--- a/tests/core/stream_muxer/conftest.py
+++ b/tests/core/stream_muxer/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from libp2p.tools.factories import (
+from tests.factories import (
     mplex_conn_pair_factory,
     mplex_stream_pair_factory,
 )

--- a/tests/core/test_libp2p/test_libp2p.py
+++ b/tests/core/test_libp2p/test_libp2p.py
@@ -10,12 +10,12 @@ from libp2p.network.stream.exceptions import (
 from libp2p.tools.constants import (
     MAX_READ_LEN,
 )
-from libp2p.tools.factories import (
-    HostFactory,
-)
 from libp2p.tools.utils import (
     connect,
     create_echo_stream_handler,
+)
+from tests.factories import (
+    HostFactory,
 )
 
 PROTOCOL_ID_0 = TProtocol("/echo/0")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -102,23 +102,20 @@ from libp2p.tools.async_service import (
     background_trio_service,
 )
 from libp2p.tools.constants import (
+    FLOODSUB_PROTOCOL_ID,
     GOSSIPSUB_PARAMS,
+    GOSSIPSUB_PROTOCOL_ID,
+    LISTEN_MADDR,
+)
+from libp2p.tools.utils import (
+    connect,
+    connect_swarm,
 )
 from libp2p.transport.tcp.tcp import (
     TCP,
 )
 from libp2p.transport.upgrader import (
     TransportUpgrader,
-)
-
-from .constants import (
-    FLOODSUB_PROTOCOL_ID,
-    GOSSIPSUB_PROTOCOL_ID,
-    LISTEN_MADDR,
-)
-from .utils import (
-    connect,
-    connect_swarm,
 )
 
 DEFAULT_SECURITY_PROTOCOL_ID = PLAINTEXT_PROTOCOL_ID

--- a/tests/interop/conftest.py
+++ b/tests/interop/conftest.py
@@ -17,7 +17,7 @@ from libp2p.io.abc import (
 )
 from libp2p.security.noise.transport import PROTOCOL_ID as NOISE_PROTOCOL_ID
 from libp2p.security.secio.transport import ID as SECIO_PROTOCOL_ID
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
     PubsubFactory,
 )

--- a/tests/interop/test_bindings.py
+++ b/tests/interop/test_bindings.py
@@ -1,7 +1,7 @@
 import pytest
 import trio
 
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
 )
 from tests.utils.interop.utils import (

--- a/tests/interop/test_echo.py
+++ b/tests/interop/test_echo.py
@@ -16,7 +16,7 @@ from libp2p.peer.peerinfo import (
     PeerInfo,
     info_from_p2p_addr,
 )
-from libp2p.tools.factories import (
+from tests.factories import (
     HostFactory,
 )
 from tests.utils.interop.envs import (

--- a/tests/interop/test_pubsub.py
+++ b/tests/interop/test_pubsub.py
@@ -19,11 +19,11 @@ from libp2p.pubsub.pb import (
 from libp2p.pubsub.subscription import (
     TrioSubscriptionAPI,
 )
-from libp2p.tools.factories import (
-    PubsubFactory,
-)
 from libp2p.utils import (
     read_varint_prefixed_bytes,
+)
+from tests.factories import (
+    PubsubFactory,
 )
 from tests.utils.interop.utils import (
     connect,


### PR DESCRIPTION
## What was wrong?

Closes #503 

## How was it fixed?

The factory definitions in `libp2p/tools/factories` were moved into the `tests` folder since they are only used for testing. This keeps test-related utilities out of the public-facing codebase and aligns with best practices.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://i.pinimg.com/736x/a7/d8/a3/a7d8a30385880e65b8fe68bc1d068b9f.jpg>)
