### PR TITLE
docs: add section about adding examples to contributing guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -110,6 +110,47 @@ Good documentation will lead to quicker adoption and happier users. Please check
 guide on
 `how to create documentation for the Python Ethereum ecosystem <https://github.com/ethereum/snake-charmers-tactical-manual/blob/main/documentation.md>`_.
 
+Adding Examples
+~~~~~~~~~~~~~~~
+
+To add a new example (e.g., identify):
+
+1. Create a directory in ``examples/identify``
+2. Create a file ``examples/identify/identify.py`` with the example code
+3. Add ``__init__.py`` to make it a proper Python package (automatically discovered by find_packages() in ``setup.py``)
+4. Add the example in the example list ``docs/examples.rst``
+5. Add example tests in ``tests/core/examples/test_examples.py``
+6. Add the example documentation in ``docs/examples.identify.rst``
+7. Add a news fragment for the new release in file ``newsfragments/536.feature.rst`` (fix-id.type.rst)
+8. Generate doc files with ``make docs`` or ``make linux-docs`` in linux (generates files ``libp2p.identity.identify.rst libp2p.identity.rst libp2p.identity.identify.pb.rst``)
+9. Add the example to ``setup.py``:
+
+   .. code:: python
+
+       entry_points={
+           "console_scripts": [
+               "chat-demo=examples.chat.chat:main",
+               "echo-demo=examples.echo.echo:main",
+               "ping-demo=examples.ping.ping:main",
+               "identify-demo=examples.identify.identify:main",
+           ],
+       }
+
+10. Run ``make package-test`` to test the release:
+
+    .. code:: sh
+
+        .....
+        Activate with `source /tmp/tmpb9ybjgtg/package-smoke-test/bin/activate`
+        Press enter when the test has completed. The directory will be deleted.
+
+    Then test the example:
+
+    .. code:: sh
+
+        source /tmp/tmpb9ybjgtg/package-smoke-test/bin/activate
+        (package-smoke-test) $ identify-demo
+
 Pull Requests
 ~~~~~~~~~~~~~
 

--- a/newsfragments/550.feature.rst
+++ b/newsfragments/550.feature.rst
@@ -1,0 +1,1 @@
+Added documentation on how to add examples to the libp2p package.


### PR DESCRIPTION
## What was wrong?

Issue https://github.com/libp2p/py-libp2p/issues/550

The developer documentation for py-libp2p was missing a clear, step-by-step example on how to integrate an example into the base code. This made it challenging for contributors to understand how to extend and utilize the library effectively.

## How was it fixed?

This PR enhances the developer documentation by adding a new section titled **"Adding an Example to the Base Code"**. The changes include:

- **Documentation Update:**
  - A detailed section explaining where and how to add examples.
  - Step-by-step instructions with code snippets and commentary.
- **Example Addition:**
  - A minimal, clear example demonstrating a common use-case.
  - Guidelines for running and testing the example.

These changes aim to improve clarity for developers, ease the onboarding of new contributors, and enhance the overall documentation quality.

![image](https://github.com/user-attachments/assets/8a4893cc-73e7-4bea-b8fa-de756781a7d4)

