### PR TITLE
Fix flaky test_simple_last_seen_cache with retry loop and docstring

### DIFF
--- a/newsfragments/558.bugfix.rst
+++ b/newsfragments/558.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed flaky test_simple_last_seen_cache by adding a retry loop for reliable expiry detection across platforms.


### PR DESCRIPTION
## What was wrong?

Issue #558 

The test `test_simple_last_seen_cache` in `tests/core/tools/timed_cache/test_timed_cache.py` was flaky on Windows due to timing jitter with `LastSeenCache` expiry and sweep intervals, failing to consistently detect expired entries.

## How was it fixed?

Summary of approach:
Updated `test_simple_last_seen_cache` to use a retry loop (up to 1s) after sleeping past the TTL (2.5s), ensuring the cache sweep is detected reliably across platforms.

### To-Do

- [x] Clean up commit history (single commit)
- [x] Add or update documentation related to these changes (docstring added)
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Kitten](https://i.pinimg.com/474x/7a/23/b1/7a23b17de2db58d12f3561351c793e05.jpg)
