### PR TITLE
update license info in description per latest python packaging guide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(
     python_requires=">=3.9, <4",
     extras_require=extras_require,
     py_modules=["libp2p"],
-    license="MIT/APACHE2.0",
+    license="MIT AND Apache-2.0",
+    license_files=("LICENSE-MIT", "LICENSE-APACHE"),
     zip_safe=False,
     keywords="libp2p p2p",
     packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),
@@ -92,8 +93,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
## What was wrong?

We've had this warning in CI for a bit:

```sh
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License
        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
```


## How was it fixed?

Followed the link, updated to the format described.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/f7529ebd-0408-488e-bd9d-c748f1a97b83)
