### PR TITLE
feat: identify-push protocol. initial release

### DIFF
--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -38,7 +38,7 @@ There is also a more interactive version of the example which runs as separate l
     Peer ID: QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
 
     Run dialer with command:
-    identify-push-listener-dialer -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+    identify-push-listener-dialer-demo -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
 
     Waiting for incoming connections... (Ctrl+C to exit)
 

--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -1,0 +1,21 @@
+examples.identify\_push package
+===============================
+
+Submodules
+----------
+
+examples.identify\_push.identify\_push\_example module
+------------------------------------------------------
+
+.. automodule:: examples.identify_push.identify_push_example
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: examples.identify_push
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -29,7 +29,7 @@ There is also a more interactive version of the example which runs as separate l
 
 .. code-block:: console
 
-    $ identify-push-listener-dialer
+    $ identify-push-listener-dialer-demo
 
     ==== Starting Identify-Push Listener on port 8888 ====
 

--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -42,7 +42,7 @@ There is also a more interactive version of the example which runs as separate l
 
     Waiting for incoming connections... (Ctrl+C to exit)
 
-Copy the line that starts with ``identify-push-listener-dialer -d ...``, open a new terminal in the same
+Copy the line that starts with ``identify-push-listener-dialer-demo -d ...``, open a new terminal in the same
 folder and paste it in:
 
 .. code-block:: console

--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -1,21 +1,79 @@
-examples.identify\_push package
-===============================
+Identify Push Protocol Demo
+===========================
 
-Submodules
-----------
+This example demonstrates how to use the libp2p ``identify-push`` protocol, which allows nodes to proactively push their identity information to peers when it changes.
 
-examples.identify\_push.identify\_push\_example module
-------------------------------------------------------
+.. code-block:: console
 
-.. automodule:: examples.identify_push.identify_push_example
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    $ python -m pip install libp2p
+    Collecting libp2p
+    ...
+    Successfully installed libp2p-x.x.x
+    $ identify-push-demo
+    ==== Starting Identify-Push Example ====
 
-Module contents
----------------
+    Host 1 listening on /ip4/127.0.0.1/tcp/xxxxx/p2p/QmAbCdEfGhIjKlMnOpQrStUvWxYz
+    Peer ID: QmAbCdEfGhIjKlMnOpQrStUvWxYz
+    Host 2 listening on /ip4/127.0.0.1/tcp/xxxxx/p2p/QmZyXwVuTaBcDeRsSkJpOpWrSt
+    Peer ID: QmZyXwVuTaBcDeRsSkJpOpWrSt
 
-.. automodule:: examples.identify_push
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    Connecting Host 2 to Host 1...
+    Host 2 successfully connected to Host 1
+
+    Host 1 pushing identify information to Host 2...
+    Identify push completed successfully!
+
+    Example completed successfully!
+
+There is also a more interactive version of the example which runs as separate listener and dialer processes:
+
+.. code-block:: console
+
+    $ identify-push-listener-dialer
+
+    ==== Starting Identify-Push Listener on port 8888 ====
+
+    Listener host ready!
+    Listening on: /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+    Peer ID: QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+
+    Run dialer with command:
+    identify-push-listener-dialer -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+
+    Waiting for incoming connections... (Ctrl+C to exit)
+
+Copy the line that starts with ``identify-push-listener-dialer -d ...``, open a new terminal in the same
+folder and paste it in:
+
+.. code-block:: console
+
+    $ identify-push-listener-dialer -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+
+    ==== Starting Identify-Push Dialer on port 8889 ====
+
+    Dialer host ready!
+    Listening on: /ip4/0.0.0.0/tcp/8889/p2p/QmZyXwVuTaBcDeRsSkJpOpWrSt
+
+    Connecting to peer: QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+    Successfully connected to listener!
+
+    Pushing identify information to listener...
+    Identify push completed successfully!
+
+    Example completed successfully!
+
+The identify-push protocol enables libp2p nodes to proactively notify their peers when their metadata changes, such as supported protocols or listening addresses. This helps maintain an up-to-date view of the network without requiring regular polling.
+
+The full source code for these examples is below:
+
+Basic example:
+
+.. literalinclude:: ../examples/identify_push/identify_push_demo.py
+    :language: python
+    :linenos:
+
+Listener/Dialer example:
+
+.. literalinclude:: ../examples/identify_push/identify_push_listener_dialer.py
+    :language: python
+    :linenos:

--- a/docs/examples.identify_push.rst
+++ b/docs/examples.identify_push.rst
@@ -47,7 +47,7 @@ folder and paste it in:
 
 .. code-block:: console
 
-    $ identify-push-listener-dialer -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
+    $ identify-push-listener-dialer-demo -d /ip4/0.0.0.0/tcp/8888/p2p/QmUiN4R3fNrCoQugGgmmb3v35neMEjKFNrsbNGVDsRHWpM
 
     ==== Starting Identify-Push Dialer on port 8889 ====
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,6 +6,7 @@ Examples
    :caption: Examples:
 
    examples.identify
+   examples.identify_push
    examples.chat
    examples.echo
    examples.ping

--- a/docs/libp2p.identity.identify_push.rst
+++ b/docs/libp2p.identity.identify_push.rst
@@ -1,0 +1,21 @@
+libp2p.identity.identify\_push package
+======================================
+
+Submodules
+----------
+
+libp2p.identity.identify\_push.identify\_push module
+----------------------------------------------------
+
+.. automodule:: libp2p.identity.identify_push.identify_push
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: libp2p.identity.identify_push
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/libp2p.identity.rst
+++ b/docs/libp2p.identity.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    libp2p.identity.identify
+   libp2p.identity.identify_push
 
 Module contents
 ---------------

--- a/examples/identify_push/identify_push_demo.py
+++ b/examples/identify_push/identify_push_demo.py
@@ -35,10 +35,6 @@ from libp2p.peer.peerinfo import (
 )
 
 # Configure logging
-# logging.basicConfig(
-#    level=logging.DEBUG,
-#    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-# )
 logger = logging.getLogger(__name__)
 
 
@@ -100,28 +96,17 @@ async def main() -> None:
             if success:
                 logger.info("Identify push completed successfully")
                 print("Identify push completed successfully!")
-
-                logger.info("Example completed successfully")
-                print("\nExample completed successfully!")
             else:
                 logger.warning("Identify push didn't complete successfully")
                 print("\nWarning: Identify push didn't complete successfully")
 
-                logger.warning("Example completed with warnings")
-                print("Example completed with warnings")
         except Exception as e:
             logger.error(f"Error during identify push: {str(e)}")
             print(f"\nError during identify push: {str(e)}")
 
-            logger.error("Example completed with errors")
-            print("Example completed with errors")
-
-
 if __name__ == "__main__":
     trio.run(main)
 
-
-# Non-async entry point for console script
 def run_main():
     """Non-async entry point for the console script."""
     trio.run(main)

--- a/examples/identify_push/identify_push_demo.py
+++ b/examples/identify_push/identify_push_demo.py
@@ -35,10 +35,10 @@ from libp2p.peer.peerinfo import (
 )
 
 # Configure logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
+# logging.basicConfig(
+#    level=logging.DEBUG,
+#    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+# )
 logger = logging.getLogger(__name__)
 
 
@@ -118,4 +118,10 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    trio.run(main)
+
+
+# Non-async entry point for console script
+def run_main():
+    """Non-async entry point for the console script."""
     trio.run(main)

--- a/examples/identify_push/identify_push_demo.py
+++ b/examples/identify_push/identify_push_demo.py
@@ -104,8 +104,10 @@ async def main() -> None:
             logger.error(f"Error during identify push: {str(e)}")
             print(f"\nError during identify push: {str(e)}")
 
+
 if __name__ == "__main__":
     trio.run(main)
+
 
 def run_main():
     """Non-async entry point for the console script."""

--- a/examples/identify_push/identify_push_demo.py
+++ b/examples/identify_push/identify_push_demo.py
@@ -43,6 +43,8 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
+    print("\n==== Starting Identify-Push Example ====\n")
+
     # Create key pairs for the two hosts
     key_pair_1 = create_new_key_pair()
     key_pair_2 = create_new_key_pair()
@@ -70,27 +72,49 @@ async def main() -> None:
     async with host_1.run([listen_addr_1]), host_2.run([listen_addr_2]):
         # Get the addresses of both hosts
         addr_1 = host_1.get_addrs()[0]
-        logger.info("Host 1 listening on %s", addr_1)
+        logger.info(f"Host 1 listening on {addr_1}")
+        print(f"Host 1 listening on {addr_1}")
+        print(f"Peer ID: {host_1.get_id().pretty()}")
 
         addr_2 = host_2.get_addrs()[0]
-        logger.info("Host 2 listening on %s", addr_2)
+        logger.info(f"Host 2 listening on {addr_2}")
+        print(f"Host 2 listening on {addr_2}")
+        print(f"Peer ID: {host_2.get_id().pretty()}")
+
+        print("\nConnecting Host 2 to Host 1...")
 
         # Connect host_2 to host_1
         peer_info = info_from_p2p_addr(addr_1)
         await host_2.connect(peer_info)
         logger.info("Host 2 connected to Host 1")
-
-        # Wait a bit for the connection to establish
-        await trio.sleep(1)
+        print("Host 2 successfully connected to Host 1")
 
         # Push identify information from host_1 to host_2
         logger.info("Host 1 pushing identify information to Host 2")
-        await push_identify_to_peer(host_1, host_2.get_id())
+        print("\nHost 1 pushing identify information to Host 2...")
 
-        # Wait a bit for the push to complete
-        await trio.sleep(1)
+        try:
+            # Call push_identify_to_peer which now returns a boolean
+            success = await push_identify_to_peer(host_1, host_2.get_id())
 
-        logger.info("Example completed successfully")
+            if success:
+                logger.info("Identify push completed successfully")
+                print("Identify push completed successfully!")
+
+                logger.info("Example completed successfully")
+                print("\nExample completed successfully!")
+            else:
+                logger.warning("Identify push didn't complete successfully")
+                print("\nWarning: Identify push didn't complete successfully")
+
+                logger.warning("Example completed with warnings")
+                print("Example completed with warnings")
+        except Exception as e:
+            logger.error(f"Error during identify push: {str(e)}")
+            print(f"\nError during identify push: {str(e)}")
+
+            logger.error("Example completed with errors")
+            print("Example completed with errors")
 
 
 if __name__ == "__main__":

--- a/examples/identify_push/identify_push_example.py
+++ b/examples/identify_push/identify_push_example.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the identify/push protocol.
+
+This example shows how to:
+1. Set up a host with the identify/push protocol handler
+2. Connect to another peer
+3. Push identify information to the peer
+4. Receive and process identify/push messages
+"""
+
+import logging
+
+import trio
+
+from libp2p import (
+    new_host,
+)
+from libp2p.crypto.secp256k1 import (
+    create_new_key_pair,
+)
+from libp2p.custom_types import (
+    TProtocol,
+)
+from libp2p.identity.identify import (
+    identify_handler_for,
+)
+from libp2p.identity.identify_push import (
+    ID_PUSH,
+    identify_push_handler_for,
+    push_identify_to_peer,
+)
+from libp2p.peer.peerinfo import (
+    info_from_p2p_addr,
+)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    # Create key pairs for the two hosts
+    key_pair_1 = create_new_key_pair()
+    key_pair_2 = create_new_key_pair()
+
+    # Create the first host
+    host_1 = new_host(key_pair=key_pair_1)
+
+    # Set up the identify and identify/push handlers
+    host_1.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host_1))
+    host_1.set_stream_handler(ID_PUSH, identify_push_handler_for(host_1))
+
+    # Create the second host
+    host_2 = new_host(key_pair=key_pair_2)
+
+    # Set up the identify and identify/push handlers
+    host_2.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host_2))
+    host_2.set_stream_handler(ID_PUSH, identify_push_handler_for(host_2))
+
+    # Start listening on random ports using the run context manager
+    import multiaddr
+
+    listen_addr_1 = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+    listen_addr_2 = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+
+    async with host_1.run([listen_addr_1]), host_2.run([listen_addr_2]):
+        # Get the addresses of both hosts
+        addr_1 = host_1.get_addrs()[0]
+        logger.info("Host 1 listening on %s", addr_1)
+
+        addr_2 = host_2.get_addrs()[0]
+        logger.info("Host 2 listening on %s", addr_2)
+
+        # Connect host_2 to host_1
+        peer_info = info_from_p2p_addr(addr_1)
+        await host_2.connect(peer_info)
+        logger.info("Host 2 connected to Host 1")
+
+        # Wait a bit for the connection to establish
+        await trio.sleep(1)
+
+        # Push identify information from host_1 to host_2
+        logger.info("Host 1 pushing identify information to Host 2")
+        await push_identify_to_peer(host_1, host_2.get_id())
+
+        # Wait a bit for the push to complete
+        await trio.sleep(1)
+
+        logger.info("Example completed successfully")
+
+
+if __name__ == "__main__":
+    trio.run(main)

--- a/examples/identify_push/identify_push_listener_dialer.py
+++ b/examples/identify_push/identify_push_listener_dialer.py
@@ -54,10 +54,6 @@ from libp2p.peer.peerinfo import (
 )
 
 # Configure logging
-# logging.basicConfig(
-#    level=logging.DEBUG,
-#    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-# )
 logger = logging.getLogger("libp2p.identity.identify-push-example")
 
 # Default port configuration

--- a/examples/identify_push/identify_push_listener_dialer.py
+++ b/examples/identify_push/identify_push_listener_dialer.py
@@ -31,17 +31,15 @@ from libp2p import (
 from libp2p.crypto.secp256k1 import (
     create_new_key_pair,
 )
-from libp2p.custom_types import (
-    TProtocol,
-)
 from libp2p.identity.identify import (
     identify_handler_for,
 )
+from libp2p.identity.identify import ID as ID_IDENTIFY
 from libp2p.identity.identify_push import (
-    ID_PUSH,
     identify_push_handler_for,
     push_identify_to_peer,
 )
+from libp2p.identity.identify_push import ID_PUSH as ID_IDENTIFY_PUSH
 from libp2p.peer.peerinfo import (
     info_from_p2p_addr,
 )
@@ -52,6 +50,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger("libp2p.identity.identify-push-example")
+
+# Default port configuration
+DEFAULT_PORT = 8888
 
 
 async def run_listener(port: int) -> None:
@@ -65,22 +66,23 @@ async def run_listener(port: int) -> None:
     host = new_host(key_pair=key_pair)
 
     # Set up the identify and identify/push handlers
-    host.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host))
-    host.set_stream_handler(ID_PUSH, identify_push_handler_for(host))
+    host.set_stream_handler(ID_IDENTIFY, identify_handler_for(host))
+    host.set_stream_handler(ID_IDENTIFY_PUSH, identify_push_handler_for(host))
 
     # Start listening
     listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
 
     async with host.run([listen_addr]):
         addr = host.get_addrs()[0]
-        logger.info("Listener host ready")
-        logger.info("Listening on: %s", addr)
-        logger.info("Peer ID: %s", host.get_id().pretty())
-
-        # Print user-friendly information
+        logger.info("Listener host ready!")
         print("Listener host ready!")
+
+        logger.info(f"Listening on: {addr}")
         print(f"Listening on: {addr}")
+
+        logger.info(f"Peer ID: {host.get_id().pretty()}")
         print(f"Peer ID: {host.get_id().pretty()}")
+
         print("\nRun dialer with command:")
         print(f"python identify_push_listener_dialer.py -d {addr}")
         print("\nWaiting for incoming connections... (Ctrl+C to exit)")
@@ -100,49 +102,60 @@ async def run_dialer(port: int, destination: str) -> None:
     host = new_host(key_pair=key_pair)
 
     # Set up the identify and identify/push handlers
-    host.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host))
-    host.set_stream_handler(ID_PUSH, identify_push_handler_for(host))
+    host.set_stream_handler(ID_IDENTIFY, identify_handler_for(host))
+    host.set_stream_handler(ID_IDENTIFY_PUSH, identify_push_handler_for(host))
 
     # Start listening on a different port
     listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
 
     async with host.run([listen_addr]):
-        logger.info("Dialer host ready")
-        logger.info("Listening on: %s", host.get_addrs()[0])
-
+        logger.info("Dialer host ready!")
         print("Dialer host ready!")
+
+        logger.info(f"Listening on: {host.get_addrs()[0]}")
         print(f"Listening on: {host.get_addrs()[0]}")
 
         # Parse the destination multiaddress and connect to the listener
         maddr = multiaddr.Multiaddr(destination)
         peer_info = info_from_p2p_addr(maddr)
-        logger.info("Connecting to peer: %s", peer_info.peer_id)
+        logger.info(f"Connecting to peer: {peer_info.peer_id}")
         print(f"\nConnecting to peer: {peer_info.peer_id}")
 
         try:
             await host.connect(peer_info)
-            logger.info("Successfully connected to listener")
+            logger.info("Successfully connected to listener!")
             print("Successfully connected to listener!")
 
-            # Wait briefly for the connection to establish
-            await trio.sleep(1)
-
             # Push identify information to the listener
-            logger.info("Pushing identify information to listener")
+            logger.info("Pushing identify information to listener...")
             print("\nPushing identify information to listener...")
-            await push_identify_to_peer(host, peer_info.peer_id)
 
-            logger.info("Identify push completed. Waiting a moment...")
-            print("Identify push completed successfully!")
+            try:
+                # Call push_identify_to_peer which returns a boolean
+                success = await push_identify_to_peer(host, peer_info.peer_id)
 
-            # Keep the connection open for a bit to observe what happens
-            print("Waiting a moment to keep connection open...")
-            await trio.sleep(5)
+                if success:
+                    logger.info("Identify push completed successfully!")
+                    print("Identify push completed successfully!")
 
-            logger.info("Example completed successfully")
-            print("\nExample completed successfully!")
+                    logger.info("Example completed successfully!")
+                    print("\nExample completed successfully!")
+                else:
+                    logger.warning("Identify push didn't complete successfully.")
+                    print("\nWarning: Identify push didn't complete successfully.")
+
+                    logger.warning("Example completed with warnings.")
+                    print("Example completed with warnings.")
+            except Exception as e:
+                logger.error(f"Error during identify push: {str(e)}")
+                print(f"\nError during identify push: {str(e)}")
+
+                logger.error("Example completed with errors.")
+                print("Example completed with errors.")
+                # Continue execution despite the push error
+
         except Exception as e:
-            logger.error("Error during dialer operation: %s", str(e))
+            logger.error(f"Error during dialer operation: {str(e)}")
             print(f"\nError during dialer operation: {str(e)}")
             raise
 
@@ -156,7 +169,8 @@ def main() -> None:
     """
 
     example = (
-        "/ip4/127.0.0.1/tcp/8888/p2p/QmQn4SwGkDZkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
+        f"/ip4/127.0.0.1/tcp/{DEFAULT_PORT}/p2p/"
+        "QmQn4SwGkDZkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
     )
 
     parser = argparse.ArgumentParser(description=description)
@@ -164,7 +178,10 @@ def main() -> None:
         "-p",
         "--port",
         type=int,
-        help="port to listen on (default: 8888 for listener, 8889 for dialer)",
+        help=(
+            f"port to listen on (default: {DEFAULT_PORT} for listener, "
+            f"{DEFAULT_PORT + 1} for dialer)"
+        ),
     )
     parser.add_argument(
         "-d",
@@ -176,12 +193,12 @@ def main() -> None:
 
     try:
         if args.destination:
-            # Run in dialer mode with default port 8889 if not specified
-            port = args.port if args.port is not None else 8889
+            # Run in dialer mode with default port DEFAULT_PORT + 1 if not specified
+            port = args.port if args.port is not None else DEFAULT_PORT + 1
             trio.run(run_dialer, port, args.destination)
         else:
-            # Run in listener mode with default port 8888 if not specified
-            port = args.port if args.port is not None else 8888
+            # Run in listener mode with default port DEFAULT_PORT if not specified
+            port = args.port if args.port is not None else DEFAULT_PORT
             trio.run(run_listener, port)
     except KeyboardInterrupt:
         print("\nInterrupted by user")

--- a/examples/identify_push/identify_push_listener_dialer.py
+++ b/examples/identify_push/identify_push_listener_dialer.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the identify/push protocol with separate listener and dialer
+roles.
+
+This example shows how to:
+1. Set up a listener host with the identify/push protocol handler
+2. Connect to the listener from a dialer peer
+3. Push identify information to the listener
+4. Receive and process identify/push messages
+
+Usage:
+    # First run this script as a listener (default port 8888):
+    python identify_push_listener_dialer.py
+
+    # Then in another console, run as a dialer (default port 8889):
+    python identify_push_listener_dialer.py -d /ip4/127.0.0.1/tcp/8888/p2p/PEER_ID
+    (where PEER_ID is the peer ID displayed by the listener)
+"""
+
+import argparse
+import logging
+import sys
+
+import multiaddr
+import trio
+
+from libp2p import (
+    new_host,
+)
+from libp2p.crypto.secp256k1 import (
+    create_new_key_pair,
+)
+from libp2p.custom_types import (
+    TProtocol,
+)
+from libp2p.identity.identify import (
+    identify_handler_for,
+)
+from libp2p.identity.identify_push import (
+    ID_PUSH,
+    identify_push_handler_for,
+    push_identify_to_peer,
+)
+from libp2p.peer.peerinfo import (
+    info_from_p2p_addr,
+)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("libp2p.identity.identify-push-example")
+
+
+async def run_listener(port: int) -> None:
+    """Run a host in listener mode."""
+    print(f"\n==== Starting Identify-Push Listener on port {port} ====\n")
+
+    # Create key pair for the listener
+    key_pair = create_new_key_pair()
+
+    # Create the listener host
+    host = new_host(key_pair=key_pair)
+
+    # Set up the identify and identify/push handlers
+    host.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host))
+    host.set_stream_handler(ID_PUSH, identify_push_handler_for(host))
+
+    # Start listening
+    listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
+
+    async with host.run([listen_addr]):
+        addr = host.get_addrs()[0]
+        logger.info("Listener host ready")
+        logger.info("Listening on: %s", addr)
+        logger.info("Peer ID: %s", host.get_id().pretty())
+
+        # Print user-friendly information
+        print("Listener host ready!")
+        print(f"Listening on: {addr}")
+        print(f"Peer ID: {host.get_id().pretty()}")
+        print("\nRun dialer with command:")
+        print(f"python identify_push_listener_dialer.py -d {addr}")
+        print("\nWaiting for incoming connections... (Ctrl+C to exit)")
+
+        # Keep running until interrupted
+        await trio.sleep_forever()
+
+
+async def run_dialer(port: int, destination: str) -> None:
+    """Run a host in dialer mode that connects to a listener."""
+    print(f"\n==== Starting Identify-Push Dialer on port {port} ====\n")
+
+    # Create key pair for the dialer
+    key_pair = create_new_key_pair()
+
+    # Create the dialer host
+    host = new_host(key_pair=key_pair)
+
+    # Set up the identify and identify/push handlers
+    host.set_stream_handler(TProtocol("/ipfs/id/1.0.0"), identify_handler_for(host))
+    host.set_stream_handler(ID_PUSH, identify_push_handler_for(host))
+
+    # Start listening on a different port
+    listen_addr = multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")
+
+    async with host.run([listen_addr]):
+        logger.info("Dialer host ready")
+        logger.info("Listening on: %s", host.get_addrs()[0])
+
+        print("Dialer host ready!")
+        print(f"Listening on: {host.get_addrs()[0]}")
+
+        # Parse the destination multiaddress and connect to the listener
+        maddr = multiaddr.Multiaddr(destination)
+        peer_info = info_from_p2p_addr(maddr)
+        logger.info("Connecting to peer: %s", peer_info.peer_id)
+        print(f"\nConnecting to peer: {peer_info.peer_id}")
+
+        try:
+            await host.connect(peer_info)
+            logger.info("Successfully connected to listener")
+            print("Successfully connected to listener!")
+
+            # Wait briefly for the connection to establish
+            await trio.sleep(1)
+
+            # Push identify information to the listener
+            logger.info("Pushing identify information to listener")
+            print("\nPushing identify information to listener...")
+            await push_identify_to_peer(host, peer_info.peer_id)
+
+            logger.info("Identify push completed. Waiting a moment...")
+            print("Identify push completed successfully!")
+
+            # Keep the connection open for a bit to observe what happens
+            print("Waiting a moment to keep connection open...")
+            await trio.sleep(5)
+
+            logger.info("Example completed successfully")
+            print("\nExample completed successfully!")
+        except Exception as e:
+            logger.error("Error during dialer operation: %s", str(e))
+            print(f"\nError during dialer operation: {str(e)}")
+            raise
+
+
+def main() -> None:
+    """Parse arguments and start the appropriate mode."""
+    description = """
+    This program demonstrates the libp2p identify/push protocol.
+    Without arguments, it runs as a listener on port 8888.
+    With -d parameter, it runs as a dialer on port 8889.
+    """
+
+    example = (
+        "/ip4/127.0.0.1/tcp/8888/p2p/QmQn4SwGkDZkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
+    )
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        help="port to listen on (default: 8888 for listener, 8889 for dialer)",
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        type=str,
+        help=f"destination multiaddr string, e.g. {example}",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.destination:
+            # Run in dialer mode with default port 8889 if not specified
+            port = args.port if args.port is not None else 8889
+            trio.run(run_dialer, port, args.destination)
+        else:
+            # Run in listener mode with default port 8888 if not specified
+            port = args.port if args.port is not None else 8888
+            trio.run(run_listener, port)
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+        logger.info("Interrupted by user")
+    except Exception as e:
+        print(f"\nError: {str(e)}")
+        logger.error("Error: %s", str(e))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/libp2p/identity/__init__.py
+++ b/libp2p/identity/__init__.py
@@ -1,0 +1,9 @@
+from . import (
+    identify,
+    identify_push,
+)
+
+__all__ = [
+    "identify",
+    "identify_push",
+]

--- a/libp2p/identity/identify/__init__.py
+++ b/libp2p/identity/identify/__init__.py
@@ -1,0 +1,9 @@
+from .identify import (
+    ID,
+    identify_handler_for,
+)
+
+__all__ = [
+    "ID",
+    "identify_handler_for",
+]

--- a/libp2p/identity/identify_push/__init__.py
+++ b/libp2p/identity/identify_push/__init__.py
@@ -1,0 +1,13 @@
+from .identify_push import (
+    ID_PUSH,
+    identify_push_handler_for,
+    push_identify_to_peer,
+    push_identify_to_peers,
+)
+
+__all__ = [
+    "ID_PUSH",
+    "identify_push_handler_for",
+    "push_identify_to_peer",
+    "push_identify_to_peers",
+]

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -185,6 +185,10 @@ async def push_identify_to_peers(
         peer_ids = set(host.get_peerstore().peer_ids())
 
     # Push to each peer in parallel using a trio.Nursery
+    # TODO: Consider using a bounded nursery to limit concurrency
+    # and avoid overwhelming the network. This can be done by using
+    # trio.open_nursery(max_concurrent=10) or similar.
+    # For now, we will use an unbounded nursery for simplicity.
     async with trio.open_nursery() as nursery:
         for peer_id in peer_ids:
             nursery.start_soon(push_identify_to_peer, host, peer_id, observed_multiaddr)

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -135,12 +135,18 @@ async def _update_peerstore_from_identify(
 
 async def push_identify_to_peer(
     host: IHost, peer_id: ID, observed_multiaddr: Optional[Multiaddr] = None
-) -> None:
+) -> bool:
     """
     Push an identify message to a specific peer.
 
     This function opens a stream to the peer using the identify/push protocol,
     sends the identify message, and closes the stream.
+
+    Returns
+    -------
+    bool
+        True if the push was successful, False otherwise.
+
     """
     try:
         # Create a new stream to the peer using the identify/push protocol
@@ -157,8 +163,10 @@ async def push_identify_to_peer(
         await stream.close()
 
         logger.debug("Successfully pushed identify to peer %s", peer_id)
+        return True
     except Exception as e:
         logger.error("Error pushing identify to peer %s: %s", peer_id, e)
+        return False
 
 
 async def push_identify_to_peers(

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -1,0 +1,180 @@
+import logging
+from typing import (
+    Optional,
+)
+
+from multiaddr import (
+    Multiaddr,
+)
+
+from libp2p.abc import (
+    IHost,
+    INetStream,
+    IPeerStore,
+)
+from libp2p.crypto.serialization import (
+    deserialize_public_key,
+)
+from libp2p.custom_types import (
+    StreamHandlerFn,
+    TProtocol,
+)
+from libp2p.network.stream.exceptions import (
+    StreamClosed,
+)
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.utils import (
+    get_agent_version,
+)
+
+from ..identify.identify import (
+    _mk_identify_protobuf,
+)
+from ..identify.pb.identify_pb2 import (
+    Identify,
+)
+
+logger = logging.getLogger(__name__)
+
+# Protocol ID for identify/push
+ID_PUSH = TProtocol("/ipfs/id/push/1.0.0")
+PROTOCOL_VERSION = "ipfs/0.1.0"
+AGENT_VERSION = get_agent_version()
+
+
+def identify_push_handler_for(host: IHost) -> StreamHandlerFn:
+    """
+    Create a handler for the identify/push protocol.
+
+    This handler receives pushed identify messages from remote peers and updates
+    the local peerstore with the new information.
+    """
+
+    async def handle_identify_push(stream: INetStream) -> None:
+        peer_id = stream.muxed_conn.peer_id
+
+        try:
+            # Read the identify message from the stream
+            data = await stream.read()
+            identify_msg = Identify()
+            identify_msg.ParseFromString(data)
+
+            # Update the peerstore with the new information
+            await _update_peerstore_from_identify(
+                host.get_peerstore(), peer_id, identify_msg
+            )
+
+            logger.debug("Successfully processed identify/push from peer %s", peer_id)
+        except StreamClosed:
+            logger.debug(
+                "Stream closed while processing identify/push from %s", peer_id
+            )
+        except Exception as e:
+            logger.error("Error processing identify/push from %s: %s", peer_id, e)
+        finally:
+            # Close the stream after processing
+            await stream.close()
+
+    return handle_identify_push
+
+
+async def _update_peerstore_from_identify(
+    peerstore: IPeerStore, peer_id: ID, identify_msg: Identify
+) -> None:
+    """
+    Update the peerstore with information from an identify message.
+
+    This function handles partial updates, where only some fields may be present
+    in the identify message.
+    """
+    # Update public key if present
+    if identify_msg.HasField("public_key"):
+        try:
+            # Note: This assumes the peerstore has a method to update the public key
+            # You may need to adjust this based on your actual peerstore implementation
+            peerstore.add_protocols(peer_id, [])
+            # The actual public key update would go here
+            pubkey = deserialize_public_key(identify_msg.public_key)
+            peerstore.add_pubkey(peer_id, pubkey)
+        except Exception as e:
+            logger.error("Error updating public key for peer %s: %s", peer_id, e)
+
+    # Update listen addresses if present
+    if identify_msg.listen_addrs:
+        try:
+            # Convert bytes to Multiaddr objects
+            addrs = [Multiaddr(addr) for addr in identify_msg.listen_addrs]
+            # Add the addresses to the peerstore
+            for addr in addrs:
+                # Use a default TTL of 2 hours (7200 seconds)
+                peerstore.add_addr(peer_id, addr, 7200)
+        except Exception as e:
+            logger.error("Error updating listen addresses for peer %s: %s", peer_id, e)
+
+    # Update protocols if present
+    if identify_msg.protocols:
+        try:
+            # Add the protocols to the peerstore
+            peerstore.add_protocols(peer_id, identify_msg.protocols)
+        except Exception as e:
+            logger.error("Error updating protocols for peer %s: %s", peer_id, e)
+
+    # Update observed address if present
+    if identify_msg.HasField("observed_addr") and identify_msg.observed_addr:
+        try:
+            # Convert bytes to Multiaddr object
+            observed_addr = Multiaddr(identify_msg.observed_addr)
+            # Add the observed address to the peerstore
+            # Use a default TTL of 2 hours (7200 seconds)
+            peerstore.add_addr(peer_id, observed_addr, 7200)
+        except Exception as e:
+            logger.error("Error updating observed address for peer %s: %s", peer_id, e)
+
+
+async def push_identify_to_peer(
+    host: IHost, peer_id: ID, observed_multiaddr: Optional[Multiaddr] = None
+) -> None:
+    """
+    Push an identify message to a specific peer.
+
+    This function opens a stream to the peer using the identify/push protocol,
+    sends the identify message, and closes the stream.
+    """
+    try:
+        # Create a new stream to the peer using the identify/push protocol
+        stream = await host.new_stream(peer_id, [ID_PUSH])
+
+        # Create the identify message
+        identify_msg = _mk_identify_protobuf(host, observed_multiaddr)
+        response = identify_msg.SerializeToString()
+
+        # Send the identify message
+        await stream.write(response)
+
+        # Close the stream
+        await stream.close()
+
+        logger.debug("Successfully pushed identify to peer %s", peer_id)
+    except Exception as e:
+        logger.error("Error pushing identify to peer %s: %s", peer_id, e)
+
+
+async def push_identify_to_peers(
+    host: IHost,
+    peer_ids: Optional[set[ID]] = None,
+    observed_multiaddr: Optional[Multiaddr] = None,
+) -> None:
+    """
+    Push an identify message to multiple peers.
+
+    If peer_ids is None, push to all connected peers.
+    """
+    if peer_ids is None:
+        # Get all connected peers
+        peer_ids = set(host.get_peerstore().peer_ids())
+
+    # Push to each peer
+    for peer_id in peer_ids:
+        await push_identify_to_peer(host, peer_id, observed_multiaddr)

--- a/newsfragments/552.feature.rst
+++ b/newsfragments/552.feature.rst
@@ -1,0 +1,1 @@
+Added identify-push protocol implementation and examples to demonstrate how peers can proactively push their identity information to other peers when it changes.

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,8 @@ setup(
             "echo-demo=examples.echo.echo:main",
             "ping-demo=examples.ping.ping:main",
             "identify-demo=examples.identify.identify:main",
+            "identify-push-demo=examples.identify_push.identify_push_demo:run_main",
+            "identify-push-listener-dialer-demo=examples.identify_push.identify_push_listener_dialer:main",
             "pubsub-demo=examples.pubsub.pubsub:main",
         ],
     },

--- a/tests/core/examples/test_examples.py
+++ b/tests/core/examples/test_examples.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import trio
 
@@ -30,6 +32,8 @@ from libp2p.tools.utils import (
 from tests.utils.factories import (
     HostFactory,
 )
+
+logger = logging.getLogger(__name__)
 
 CHAT_PROTOCOL_ID = "/chat/1.0.0"
 ECHO_PROTOCOL_ID = "/echo/1.0.0"
@@ -252,12 +256,24 @@ async def pubsub_demo(host_a, host_b):
 
 
 async def identify_push_demo(host_a, host_b):
-    # Set up the identify/push handlers
+    # Set up the identify/push handlers on both hosts
+    host_a.set_stream_handler(ID_PUSH, identify_push_handler_for(host_a))
     host_b.set_stream_handler(ID_PUSH, identify_push_handler_for(host_b))
+
+    # Ensure both hosts have the required protocols
+    # This is needed because the test hosts
+    # might not have all protocols loaded by default
+    host_a_protocols = set(host_a.get_mux().get_protocols())
+
+    # Log protocols before push
+    logger.debug("Host A protocols before push: %s", host_a_protocols)
 
     # Push identify information from host_a to host_b
     success = await push_identify_to_peer(host_a, host_b.get_id())
     assert success is True
+
+    # Add a small delay to allow processing
+    await trio.sleep(0.1)
 
     # Check that host_b's peerstore has been updated with host_a's information
     peer_id = host_a.get_id()
@@ -266,14 +282,25 @@ async def identify_push_demo(host_a, host_b):
     # Check that the peer is in the peerstore
     assert peer_id in peerstore.peer_ids()
 
-    # Check that the protocols were updated
-    host_a_protocols = set(host_a.get_mux().get_protocols())
+    # If peerstore has no protocols for this peer, manually update them for the test
     peerstore_protocols = set(peerstore.get_protocols(peer_id))
+
+    # Log protocols after push
+    logger.debug("Host A protocols after push: %s", host_a_protocols)
+    logger.debug("Peerstore protocols after push: %s", peerstore_protocols)
+
+    # Check that the protocols were updated
     assert all(protocol in peerstore_protocols for protocol in host_a_protocols)
 
     # Check that the addresses were updated
     host_a_addrs = set(host_a.get_addrs())
     peerstore_addrs = set(peerstore.addrs(peer_id))
+
+    # Log addresses after push
+    logger.debug("Host A addresses: %s", host_a_addrs)
+    logger.debug("Peerstore addresses: %s", peerstore_addrs)
+
+    # Check that the addresses were updated
     assert all(addr in peerstore_addrs for addr in host_a_addrs)
 
 

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -14,6 +14,7 @@ from libp2p.identity.identify_push.identify_push import (
     _update_peerstore_from_identify,
     identify_push_handler_for,
     push_identify_to_peer,
+    push_identify_to_peers,
 )
 from tests.utils.factories import (
     host_pair_factory,
@@ -24,6 +25,16 @@ logger = logging.getLogger("libp2p.identity.identify-push-test")
 
 @pytest.mark.trio
 async def test_identify_push_protocol(security_protocol):
+    """
+    Test the basic functionality of the identify/push protocol.
+
+    This test verifies that when host_a pushes identify information to host_b:
+    1. The information is correctly received and processed
+    2. The peerstore of host_b is updated with host_a's peer ID
+    3. The peerstore contains all of host_a's addresses
+    4. The peerstore contains all of host_a's supported protocols
+    5. The public key in the peerstore matches host_a's public key
+    """
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,
         host_b,
@@ -72,6 +83,17 @@ async def test_identify_push_protocol(security_protocol):
 
 @pytest.mark.trio
 async def test_identify_push_handler(security_protocol):
+    """
+    Test the identify_push_handler_for function specifically.
+
+    This test focuses on verifying that the handler function correctly:
+    1. Receives the identify message
+    2. Updates the peerstore with the peer information
+    3. Processes all fields of the identify message (addresses, protocols, public key)
+
+    Note: This test is similar to test_identify_push_protocol but specifically
+    focuses on the handler function's behavior.
+    """
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,
         host_b,
@@ -120,6 +142,16 @@ async def test_identify_push_handler(security_protocol):
 
 @pytest.mark.trio
 async def test_identify_push_to_peers(security_protocol):
+    """
+    Test the push_identify_to_peers function to broadcast identity to multiple peers.
+
+    This test verifies that:
+    1. Host_a can push identify information to multiple peers simultaneously
+    2. The identify information is correctly received by all connected peers
+    3. Both host_b and host_c have their peerstores updated with host_a's information
+
+    This tests the broadcasting capability of the identify/push protocol.
+    """
     # Create three hosts
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,
@@ -179,7 +211,115 @@ async def test_identify_push_to_peers(security_protocol):
 
 
 @pytest.mark.trio
+async def test_push_identify_to_peers_with_explicit_params(security_protocol):
+    """
+    Test the push_identify_to_peers function with explicit parameters.
+
+    This test verifies that:
+    1. The function correctly handles an explicitly provided set of peer IDs
+    2. The function correctly uses the provided observed_multiaddr
+    3. The identify information is only pushed to the specified peers
+    4. The observed address is correctly included in the identify message
+
+    This test ensures all parameters of push_identify_to_peers are properly tested.
+    """
+    import multiaddr
+
+    from libp2p import (
+        new_host,
+    )
+    from libp2p.crypto.secp256k1 import (
+        create_new_key_pair,
+    )
+    from libp2p.peer.peerinfo import (
+        info_from_p2p_addr,
+    )
+
+    # Create four hosts to thoroughly test selective pushing
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Create two additional hosts
+        key_pair_c = create_new_key_pair()
+        host_c = new_host(key_pair=key_pair_c)
+
+        key_pair_d = create_new_key_pair()
+        host_d = new_host(key_pair=key_pair_d)
+
+        # Set up the identify/push handlers for all hosts
+        host_b.set_stream_handler(ID_PUSH, identify_push_handler_for(host_b))
+        host_c.set_stream_handler(ID_PUSH, identify_push_handler_for(host_c))
+        host_d.set_stream_handler(ID_PUSH, identify_push_handler_for(host_d))
+
+        # Start listening on random ports
+        listen_addr_c = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+        listen_addr_d = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+
+        async with host_c.run([listen_addr_c]), host_d.run([listen_addr_d]):
+            # Connect all hosts to host_a
+            await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+            await host_d.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+
+            # Create a specific observed multiaddr for the test
+            observed_addr = multiaddr.Multiaddr("/ip4/192.0.2.1/tcp/1234")
+
+            # Only push to hosts B and C (not D)
+            selected_peers = {host_b.get_id(), host_c.get_id()}
+
+            # Push identify information from host_a to selected peers with observed addr
+            await push_identify_to_peers(
+                host=host_a, peer_ids=selected_peers, observed_multiaddr=observed_addr
+            )
+
+            # Wait a bit for the push to complete
+            await trio.sleep(0.1)
+
+            # Check that host_b's and host_c's peerstores have been updated
+            peerstore_b = host_b.get_peerstore()
+            peerstore_c = host_c.get_peerstore()
+            peerstore_d = host_d.get_peerstore()
+            peer_id_a = host_a.get_id()
+
+            # Hosts B and C should have peer_id_a in their peerstores
+            assert peer_id_a in peerstore_b.peer_ids()
+            assert peer_id_a in peerstore_c.peer_ids()
+
+            # Host D should NOT have peer_id_a in its peerstore from the push
+            # (it may still have it from the connection)
+            # So we check for the observed address instead, which would only be
+            # present from a push
+
+            # Hosts B and C should have the observed address in their peerstores
+            addrs_b = [str(addr) for addr in peerstore_b.addrs(peer_id_a)]
+            addrs_c = [str(addr) for addr in peerstore_c.addrs(peer_id_a)]
+
+            assert str(observed_addr) in addrs_b
+            assert str(observed_addr) in addrs_c
+
+            # If host D has addresses for peer_id_a, the observed address
+            # should not be there
+            if peer_id_a in peerstore_d.peer_ids():
+                addrs_d = [str(addr) for addr in peerstore_d.addrs(peer_id_a)]
+                assert str(observed_addr) not in addrs_d
+
+
+@pytest.mark.trio
 async def test_update_peerstore_from_identify(security_protocol):
+    """
+    Test the _update_peerstore_from_identify function directly.
+
+    This test verifies that the internal function responsible for updating
+    the peerstore from an identify message works correctly:
+    1. It properly updates the peerstore with all fields from the identify message
+    2. The peer ID is added to the peerstore
+    3. All addresses are correctly stored
+    4. All protocols are correctly stored
+    5. The public key is correctly stored
+
+    This tests the low-level peerstore update mechanism used by
+    the identify/push protocol.
+    """
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,
         host_b,
@@ -225,6 +365,19 @@ async def test_update_peerstore_from_identify(security_protocol):
 
 @pytest.mark.trio
 async def test_partial_update_peerstore_from_identify(security_protocol):
+    """
+    Test partial updates of the peerstore using the identify/push protocol.
+
+    This test verifies that:
+    1. A partial identify message (containing only some fields) correctly updates
+       the peerstore without affecting other existing information
+    2. New protocols are added to the existing set in the peerstore
+    3. The original protocols, addresses, and public key remain intact
+    4. The update is additive rather than replacing all existing data
+
+    This tests the ability of the identify/push protocol to handle incremental
+    or partial updates to peer information.
+    """
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,
         host_b,

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -1,0 +1,278 @@
+import logging
+
+import pytest
+import trio
+
+from libp2p.identity.identify.identify import (
+    _mk_identify_protobuf,
+)
+from libp2p.identity.identify.pb.identify_pb2 import (
+    Identify,
+)
+from libp2p.identity.identify_push.identify_push import (
+    ID_PUSH,
+    _update_peerstore_from_identify,
+    identify_push_handler_for,
+    push_identify_to_peer,
+)
+from tests.utils.factories import (
+    host_pair_factory,
+)
+
+logger = logging.getLogger("libp2p.identity.identify-push-test")
+
+
+@pytest.mark.trio
+async def test_identify_push_protocol(security_protocol):
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Set up the identify/push handlers
+        host_b.set_stream_handler(ID_PUSH, identify_push_handler_for(host_b))
+
+        # Push identify information from host_a to host_b
+        await push_identify_to_peer(host_a, host_b.get_id())
+
+        # Wait a bit for the push to complete
+        await trio.sleep(0.1)
+
+        # Get the peerstore from host_b
+        peerstore = host_b.get_peerstore()
+
+        # Check that host_b's peerstore has been updated with host_a's information
+        peer_id = host_a.get_id()
+
+        # Check that the peer is in the peerstore
+        assert peer_id in peerstore.peer_ids()
+
+        # Check that the addresses have been updated
+        host_a_addrs = set(host_a.get_addrs())
+        peerstore_addrs = set(peerstore.addrs(peer_id))
+
+        # The peerstore might have additional addresses from the connection
+        # So we just check that all of host_a's addresses are in the peerstore
+        assert all(addr in peerstore_addrs for addr in host_a_addrs)
+
+        # Check that the protocols have been updated
+        host_a_protocols = set(host_a.get_mux().get_protocols())
+        # Use get_protocols instead of protocols
+        peerstore_protocols = set(peerstore.get_protocols(peer_id))
+
+        # The peerstore might have additional protocols
+        # So we just check that all of host_a's protocols are in the peerstore
+        assert all(protocol in peerstore_protocols for protocol in host_a_protocols)
+
+        # Check that the public key has been updated
+        host_a_public_key = host_a.get_public_key().serialize()
+        peerstore_public_key = peerstore.pubkey(peer_id).serialize()
+
+        assert host_a_public_key == peerstore_public_key
+
+
+@pytest.mark.trio
+async def test_identify_push_handler(security_protocol):
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Set up the identify/push handlers
+        host_b.set_stream_handler(ID_PUSH, identify_push_handler_for(host_b))
+
+        # Push identify information from host_a to host_b
+        await push_identify_to_peer(host_a, host_b.get_id())
+
+        # Wait a bit for the push to complete
+        await trio.sleep(0.1)
+
+        # Get the peerstore from host_b
+        peerstore = host_b.get_peerstore()
+
+        # Check that host_b's peerstore has been updated with host_a's information
+        peer_id = host_a.get_id()
+
+        # Check that the peer is in the peerstore
+        assert peer_id in peerstore.peer_ids()
+
+        # Check that the addresses have been updated
+        host_a_addrs = set(host_a.get_addrs())
+        peerstore_addrs = set(peerstore.addrs(peer_id))
+
+        # The peerstore might have additional addresses from the connection
+        # So we just check that all of host_a's addresses are in the peerstore
+        assert all(addr in peerstore_addrs for addr in host_a_addrs)
+
+        # Check that the protocols have been updated
+        host_a_protocols = set(host_a.get_mux().get_protocols())
+        # Use get_protocols instead of protocols
+        peerstore_protocols = set(peerstore.get_protocols(peer_id))
+
+        # The peerstore might have additional protocols
+        # So we just check that all of host_a's protocols are in the peerstore
+        assert all(protocol in peerstore_protocols for protocol in host_a_protocols)
+
+        # Check that the public key has been updated
+        host_a_public_key = host_a.get_public_key().serialize()
+        peerstore_public_key = peerstore.pubkey(peer_id).serialize()
+
+        assert host_a_public_key == peerstore_public_key
+
+
+@pytest.mark.trio
+async def test_identify_push_to_peers(security_protocol):
+    # Create three hosts
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Create a third host
+        # Instead of using key_pair, create a new host directly
+        import multiaddr
+
+        from libp2p import (
+            new_host,
+        )
+        from libp2p.crypto.secp256k1 import (
+            create_new_key_pair,
+        )
+        from libp2p.peer.peerinfo import (
+            info_from_p2p_addr,
+        )
+
+        # Create a new key pair for host_c
+        key_pair_c = create_new_key_pair()
+        host_c = new_host(key_pair=key_pair_c)
+
+        # Set up the identify/push handlers
+        host_b.set_stream_handler(ID_PUSH, identify_push_handler_for(host_b))
+        host_c.set_stream_handler(ID_PUSH, identify_push_handler_for(host_c))
+
+        # Start listening on a random port using the run context manager
+        listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+        async with host_c.run([listen_addr]):
+            # Connect host_c to host_a and host_b
+            await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+            await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
+
+            # Push identify information from host_a to all connected peers
+            from libp2p.identity.identify_push.identify_push import (
+                push_identify_to_peers,
+            )
+
+            await push_identify_to_peers(host_a)
+
+            # Wait a bit for the push to complete
+            await trio.sleep(0.1)
+
+            # Check that host_b's peerstore has been updated with host_a's information
+            peerstore_b = host_b.get_peerstore()
+            peer_id_a = host_a.get_id()
+
+            # Check that the peer is in the peerstore
+            assert peer_id_a in peerstore_b.peer_ids()
+
+            # Check that host_c's peerstore has been updated with host_a's information
+            peerstore_c = host_c.get_peerstore()
+
+            # Check that the peer is in the peerstore
+            assert peer_id_a in peerstore_c.peer_ids()
+
+
+@pytest.mark.trio
+async def test_update_peerstore_from_identify(security_protocol):
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Get the peerstore from host_b
+        peerstore = host_b.get_peerstore()
+
+        # Create an identify message with host_a's information
+        identify_msg = _mk_identify_protobuf(host_a, None)
+
+        # Update the peerstore with the identify message
+        await _update_peerstore_from_identify(peerstore, host_a.get_id(), identify_msg)
+
+        # Check that the peerstore has been updated with host_a's information
+        peer_id = host_a.get_id()
+
+        # Check that the peer is in the peerstore
+        assert peer_id in peerstore.peer_ids()
+
+        # Check that the addresses have been updated
+        host_a_addrs = set(host_a.get_addrs())
+        peerstore_addrs = set(peerstore.addrs(peer_id))
+
+        # The peerstore might have additional addresses from the connection
+        # So we just check that all of host_a's addresses are in the peerstore
+        assert all(addr in peerstore_addrs for addr in host_a_addrs)
+
+        # Check that the protocols have been updated
+        host_a_protocols = set(host_a.get_mux().get_protocols())
+        # Use get_protocols instead of protocols
+        peerstore_protocols = set(peerstore.get_protocols(peer_id))
+
+        # The peerstore might have additional protocols
+        # So we just check that all of host_a's protocols are in the peerstore
+        assert all(protocol in peerstore_protocols for protocol in host_a_protocols)
+
+        # Check that the public key has been updated
+        host_a_public_key = host_a.get_public_key().serialize()
+        peerstore_public_key = peerstore.pubkey(peer_id).serialize()
+
+        assert host_a_public_key == peerstore_public_key
+
+
+@pytest.mark.trio
+async def test_partial_update_peerstore_from_identify(security_protocol):
+    async with host_pair_factory(security_protocol=security_protocol) as (
+        host_a,
+        host_b,
+    ):
+        # Get the peerstore from host_b
+        peerstore = host_b.get_peerstore()
+
+        # First, update the peerstore with all of host_a's information
+        identify_msg_full = _mk_identify_protobuf(host_a, None)
+        await _update_peerstore_from_identify(
+            peerstore, host_a.get_id(), identify_msg_full
+        )
+
+        # Now create a partial identify message with only some fields
+        identify_msg_partial = Identify()
+
+        # Only include the protocols field
+        identify_msg_partial.protocols.extend(["new_protocol_1", "new_protocol_2"])
+
+        # Update the peerstore with the partial identify message
+        await _update_peerstore_from_identify(
+            peerstore, host_a.get_id(), identify_msg_partial
+        )
+
+        # Check that the peerstore has been updated with the new protocols
+        peer_id = host_a.get_id()
+
+        # Check that the peer is still in the peerstore
+        assert peer_id in peerstore.peer_ids()
+
+        # Check that the new protocols have been added
+        # Use get_protocols instead of protocols
+        peerstore_protocols = set(peerstore.get_protocols(peer_id))
+
+        # The new protocols should be in the peerstore
+        assert "new_protocol_1" in peerstore_protocols
+        assert "new_protocol_2" in peerstore_protocols
+
+        # The original protocols should still be in the peerstore
+        host_a_protocols = set(host_a.get_mux().get_protocols())
+        assert all(protocol in peerstore_protocols for protocol in host_a_protocols)
+
+        # The addresses should still be in the peerstore
+        host_a_addrs = set(host_a.get_addrs())
+        peerstore_addrs = set(peerstore.addrs(peer_id))
+        assert all(addr in peerstore_addrs for addr in host_a_addrs)
+
+        # The public key should still be in the peerstore
+        host_a_public_key = host_a.get_public_key().serialize()
+        peerstore_public_key = peerstore.pubkey(peer_id).serialize()
+        assert host_a_public_key == peerstore_public_key

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -20,6 +20,18 @@ from tests.utils.factories import (
     host_pair_factory,
 )
 
+import multiaddr
+
+from libp2p import (
+    new_host,
+)
+from libp2p.crypto.secp256k1 import (
+    create_new_key_pair,
+)
+from libp2p.peer.peerinfo import (
+    info_from_p2p_addr,
+)
+
 logger = logging.getLogger("libp2p.identity.identify-push-test")
 
 
@@ -159,17 +171,7 @@ async def test_identify_push_to_peers(security_protocol):
     ):
         # Create a third host
         # Instead of using key_pair, create a new host directly
-        import multiaddr
-
-        from libp2p import (
-            new_host,
-        )
-        from libp2p.crypto.secp256k1 import (
-            create_new_key_pair,
-        )
-        from libp2p.peer.peerinfo import (
-            info_from_p2p_addr,
-        )
+        
 
         # Create a new key pair for host_c
         key_pair_c = create_new_key_pair()
@@ -187,10 +189,6 @@ async def test_identify_push_to_peers(security_protocol):
             await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
 
             # Push identify information from host_a to all connected peers
-            from libp2p.identity.identify_push.identify_push import (
-                push_identify_to_peers,
-            )
-
             await push_identify_to_peers(host_a)
 
             # Wait a bit for the push to complete
@@ -223,18 +221,7 @@ async def test_push_identify_to_peers_with_explicit_params(security_protocol):
 
     This test ensures all parameters of push_identify_to_peers are properly tested.
     """
-    import multiaddr
-
-    from libp2p import (
-        new_host,
-    )
-    from libp2p.crypto.secp256k1 import (
-        create_new_key_pair,
-    )
-    from libp2p.peer.peerinfo import (
-        info_from_p2p_addr,
-    )
-
+    
     # Create four hosts to thoroughly test selective pushing
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -1,8 +1,15 @@
 import logging
 
 import pytest
+import multiaddr
 import trio
 
+from libp2p import (
+    new_host,
+)
+from libp2p.crypto.secp256k1 import (
+    create_new_key_pair,
+)
 from libp2p.identity.identify.identify import (
     _mk_identify_protobuf,
 )
@@ -16,20 +23,11 @@ from libp2p.identity.identify_push.identify_push import (
     push_identify_to_peer,
     push_identify_to_peers,
 )
-from tests.utils.factories import (
-    host_pair_factory,
-)
-
-import multiaddr
-
-from libp2p import (
-    new_host,
-)
-from libp2p.crypto.secp256k1 import (
-    create_new_key_pair,
-)
 from libp2p.peer.peerinfo import (
     info_from_p2p_addr,
+)
+from tests.utils.factories import (
+    host_pair_factory,
 )
 
 logger = logging.getLogger("libp2p.identity.identify-push-test")
@@ -171,7 +169,6 @@ async def test_identify_push_to_peers(security_protocol):
     ):
         # Create a third host
         # Instead of using key_pair, create a new host directly
-        
 
         # Create a new key pair for host_c
         key_pair_c = create_new_key_pair()
@@ -221,7 +218,7 @@ async def test_push_identify_to_peers_with_explicit_params(security_protocol):
 
     This test ensures all parameters of push_identify_to_peers are properly tested.
     """
-    
+
     # Create four hosts to thoroughly test selective pushing
     async with host_pair_factory(security_protocol=security_protocol) as (
         host_a,


### PR DESCRIPTION
# Identify Push Protocol Implementation

## What was wrong?

Issue https://github.com/libp2p/py-libp2p/issues/552 - Missing implementation of the identify push protocol in py-libp2p.

The libp2p identify push protocol allows peers to proactively notify their connected peers about changes in their advertised addresses, protocols, or other metadata. While the regular identify protocol allows peers to query for this information, identify push enables real-time updates without polling.

The identify push protocol was defined in the libp2p specifications but was not yet implemented in the Python libp2p implementation, which could lead to inconsistencies in peer metadata when network conditions change.

## How was it fixed?

An implementation of the identify push protocol was added to the py-libp2p library with the following components:

1. Created a new module `libp2p/identity/identify_push/` containing the protocol implementation
2. Implemented the identify push protocol with identifier `/ipfs/id/push/1.0.0`
3. Added a handler for receiving pushed identify information from peers
4. Added functionality to push identify information to connected peers
5. Added proper peerstore update logic to process received identify information
6. Implemented tests to verify the functionality of the identify push protocol
7. Added example scripts demonstrating how to use the identify push protocol

The implementation allows peers to:
- Push their identity information to connected peers when it changes
- Receive and process identity updates from connected peers
- Update their peerstore with the latest information about peers

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/1ba9a286-02e6-4c84-be56-e3d6fcae1fc1)

