### PR TITLE
Fix/issue 565 timedcache test readding after expiry

### DIFF
--- a/libp2p/tools/timed_cache/first_seen_cache.py
+++ b/libp2p/tools/timed_cache/first_seen_cache.py
@@ -9,12 +9,24 @@ class FirstSeenCache(BaseTimedCache):
     """Cache where expiry is set only when first added."""
 
     def add(self, key: bytes) -> bool:
+        now = int(time.time())
         with self.lock:
             if key in self.cache:
+                # Check if the key is expired
+                if self.cache[key] <= now:
+                    # Key is expired, update the expiry and treat as a new entry
+                    self.cache[key] = now + self.ttl
+                    return True
                 return False
-            self.cache[key] = int(time.time()) + self.ttl
+            self.cache[key] = now + self.ttl
             return True
 
     def has(self, key: bytes) -> bool:
+        now = int(time.time())
         with self.lock:
-            return key in self.cache
+            if key in self.cache:
+                # Check if key is expired
+                if self.cache[key] <= now:
+                    return False
+                return True
+            return False


### PR DESCRIPTION
# TimedCache Bug Fix

## Issue Description

The `py-libp2p` project had a bug in the `FirstSeenCache` implementation where expired cache entries couldn't be re-added to the cache.

The failing test `test_readding_after_expiry` revealed this issue:

```python
@pytest.mark.trio
async def test_readding_after_expiry():
    """Test that an item can be re-added after expiry."""
    cache = FirstSeenCache(ttl=2, sweep_interval=1)
    cache.add(MSG_1)
    await trio.sleep(2)  # Let it expire
    assert cache.add(MSG_1) is True  # Should allow re-adding
    assert cache.has(MSG_1) is True
    cache.stop()
```

The test was failing with the error:
```
AssertionError: assert False is True
 +  where False = add(b'msg1')
 +    where add = <libp2p.tools.timed_cache.first_seen_cache.FirstSeenCache object at 0x112856660>.add
```

## Root Cause

The issue was in the `FirstSeenCache` implementation:

1. The `add()` method only checked if the key was present in the cache, not whether it had expired
2. The `has()` method similarly only checked for the key's presence, not its expiration state
3. Background sweeper removes expired entries periodically, but during the gap between expiration and removal, the cache behaved incorrectly

Original implementation:
```python
def add(self, key: bytes) -> bool:
    with self.lock:
        if key in self.cache:
            return False
        self.cache[key] = int(time.time()) + self.ttl
        return True

def has(self, key: bytes) -> bool:
    with self.lock:
        return key in self.cache
```

## Solution

The fix adds explicit expiration checks in both methods:

1. In `add()`: If the key exists but is expired, treat it as a new entry
2. In `has()`: Return `False` if the key is expired, even if it's still in the cache

Updated implementation:
```python
def add(self, key: bytes) -> bool:
    now = int(time.time())
    with self.lock:
        if key in self.cache:
            # Check if the key is expired
            if self.cache[key] <= now:
                # Key is expired, update the expiry and treat as a new entry
                self.cache[key] = now + self.ttl
                return True
            return False
        self.cache[key] = now + self.ttl
        return True

def has(self, key: bytes) -> bool:
    now = int(time.time())
    with self.lock:
        if key in self.cache:
            # Check if key is expired
            if self.cache[key] <= now:
                return False
            return True
        return False
```

This change ensures that expired entries can be properly re-added to the cache, and that `has()` correctly reports whether an entry is valid (not expired).

## Cross-Platform Considerations

Interestingly, this bug is a classic example of a "time bomb" bug - one that depends on specific timing conditions and therefore behaves differently across operating systems:

- The test was failing on macOS and Windows
- The same test was passing on Linux

This inconsistency likely occurred due to operating system differences in:

1. **Thread scheduling**: Linux's scheduler might have prioritized the background sweeper thread differently, allowing it to run during the test's sleep period and remove the expired entry
2. **Sleep precision**: `trio.sleep(2)` might have slightly different actual durations on different systems
3. **System clock precision**: Time measurement granularity can vary between operating systems
4. **Process prioritization**: Background tasks receive different CPU time allocations across platforms

The fix we implemented addresses the root cause by making the behavior deterministic and timing-independent. Rather than relying on when the background sweeper happens to run, we explicitly check for expiration in the methods themselves. This ensures consistent behavior regardless of operating system thread scheduling peculiarities.

## Verification

After making these changes, all tests pass, including the previously failing `test_readding_after_expiry` test. 

![image](https://github.com/user-attachments/assets/111c46b7-c657-4cfa-a198-67d6d6f59488)
