### PR TITLE
Fix exception handling in `TCPListener.listen()`

### DIFF
--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -70,7 +70,7 @@ class TCPListener(IListener):
                 remote_host,remote_port = tcp_stream.get_remote_address()    
                 await self.handler(tcp_stream)
             except Exception as e:
-                logger.error(f"Connection from {remote_host}:{remote_port} failed.")
+                logger.debug(f"Connection from {remote_host}:{remote_port} failed.")
 
         listeners = await nursery.start(
             serve_tcp,

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -63,13 +63,13 @@ class TCPListener(IListener):
             await trio.serve_tcp(handler, port, host=host, task_status=task_status)
 
         async def handler(stream: trio.SocketStream) -> None:
-            remote_host : str = ""
-            remote_port : int = 0
+            remote_host: str = ""
+            remote_port: int = 0
             try:
                 tcp_stream = TrioTCPStream(stream)
-                remote_host,remote_port = tcp_stream.get_remote_address()    
+                remote_host, remote_port = tcp_stream.get_remote_address()
                 await self.handler(tcp_stream)
-            except Exception as e:
+            except Exception:
                 logger.debug(f"Connection from {remote_host}:{remote_port} failed.")
 
         listeners = await nursery.start(

--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -63,8 +63,14 @@ class TCPListener(IListener):
             await trio.serve_tcp(handler, port, host=host, task_status=task_status)
 
         async def handler(stream: trio.SocketStream) -> None:
-            tcp_stream = TrioTCPStream(stream)
-            await self.handler(tcp_stream)
+            remote_host : str = ""
+            remote_port : int = 0
+            try:
+                tcp_stream = TrioTCPStream(stream)
+                remote_host,remote_port = tcp_stream.get_remote_address()    
+                await self.handler(tcp_stream)
+            except Exception as e:
+                logger.error(f"Connection from {remote_host}:{remote_port} failed.")
 
         listeners = await nursery.start(
             serve_tcp,

--- a/newsfragments/586.bugfix.rst
+++ b/newsfragments/586.bugfix.rst
@@ -1,2 +1,2 @@
-``handler()`` inside ``TCPListener.listen()`` does not catch exceptions thrown during handshaking steps (from ```Sawrm``).
+``handler()`` inside ``TCPListener.listen()`` does not catch exceptions thrown during handshaking steps (from ``Sawrm``).
 These innocuous exceptions will become fatal and crash the process if not handled.

--- a/newsfragments/586.bugfix.rst
+++ b/newsfragments/586.bugfix.rst
@@ -1,0 +1,2 @@
+``handler()`` inside ``TCPListener.listen()`` does not catch exceptions thrown during handshaking steps (from ```Sawrm``).
+These innocuous exceptions will become fatal and crash the process if not handled.


### PR DESCRIPTION
## What was wrong?

Issue #586 
@seetadev 

## How was it fixed?
Exception handling logic was added to `TCPListener.listen()`
Exceptions raised during handshaking are logged as `debug`

Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

