### PR TITLE
Direct Peers : Gossipsub V1.1

### DIFF
--- a/examples/pubsub/pubsub.py
+++ b/examples/pubsub/pubsub.py
@@ -136,6 +136,7 @@ async def run(topic: str, destination: Optional[str], port: Optional[int]) -> No
         degree=3,  # Number of peers to maintain in mesh
         degree_low=2,  # Lower bound for mesh peers
         degree_high=4,  # Upper bound for mesh peers
+        direct_peers={},  # Direct peers
         time_to_live=60,  # TTL for message cache in seconds
         gossip_window=2,  # Smaller window for faster gossip
         gossip_history=5,  # Keep more history

--- a/examples/pubsub/pubsub.py
+++ b/examples/pubsub/pubsub.py
@@ -136,7 +136,7 @@ async def run(topic: str, destination: Optional[str], port: Optional[int]) -> No
         degree=3,  # Number of peers to maintain in mesh
         degree_low=2,  # Lower bound for mesh peers
         degree_high=4,  # Upper bound for mesh peers
-        direct_peers=set(),  # Direct peers
+        direct_peers=None,  # Direct peers
         time_to_live=60,  # TTL for message cache in seconds
         gossip_window=2,  # Smaller window for faster gossip
         gossip_history=5,  # Keep more history

--- a/examples/pubsub/pubsub.py
+++ b/examples/pubsub/pubsub.py
@@ -136,7 +136,7 @@ async def run(topic: str, destination: Optional[str], port: Optional[int]) -> No
         degree=3,  # Number of peers to maintain in mesh
         degree_low=2,  # Lower bound for mesh peers
         degree_high=4,  # Upper bound for mesh peers
-        direct_peers={},  # Direct peers
+        direct_peers=set(),  # Direct peers
         time_to_live=60,  # TTL for message cache in seconds
         gossip_window=2,  # Smaller window for faster gossip
         gossip_history=5,  # Keep more history

--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -4,6 +4,7 @@ from collections import (
 from collections.abc import (
     Sequence,
 )
+import sys
 from typing import (
     Any,
 )
@@ -31,6 +32,8 @@ from .peerdata import (
 from .peerinfo import (
     PeerInfo,
 )
+
+PERMANENT_ADDR_TTL = sys.maxsize
 
 
 class PeerStore(IPeerStore):

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -142,6 +142,8 @@ class GossipSub(IPubsubRouter, Service):
         if self.pubsub is None:
             raise NoPubsubAttached
         self.manager.run_daemon_task(self.heartbeat)
+        if len(self.direct_peers) > 0:
+            self.manager.run_daemon_task(self.direct_connect_heartbeat)
         await self.manager.wait_finished()
 
     # Interface functions

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -89,7 +89,7 @@ class GossipSub(IPubsubRouter, Service):
     heartbeat_interval: int
 
     direct_peers: dict[ID, PeerInfo]
-    direct_connect_init_delay: float
+    direct_connect_initial_delay: float
     direct_connect_interval: int
 
     def __init__(
@@ -137,7 +137,7 @@ class GossipSub(IPubsubRouter, Service):
         for direct_peer in direct_peers or []:
             self.direct_peers[direct_peer.peer_id] = direct_peer
         self.direct_connect_interval = direct_connect_interval
-        self.direct_connect_init_delay = direct_connect_initial_delay
+        self.direct_connect_initial_delay = direct_connect_initial_delay
 
     async def run(self) -> None:
         if self.pubsub is None:
@@ -461,7 +461,7 @@ class GossipSub(IPubsubRouter, Service):
         """
         Connect to direct peers.
         """
-        await trio.sleep(self.direct_connect_init_delay)
+        await trio.sleep(self.direct_connect_initial_delay)
         while True:
             for direct_peer in self.direct_peers:
                 if direct_peer not in self.pubsub.peers:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -450,6 +450,24 @@ class GossipSub(IPubsubRouter, Service):
 
             await trio.sleep(self.heartbeat_interval)
 
+    async def direct_connect_heartbeat(self) -> None:
+        """
+        Connect to direct peers.
+        """
+        await trio.sleep(self.direct_connect_initial_delay)
+        while True:
+            for _peer in self.direct_peers:
+                if _peer.peer_id not in self.pubsub.peers:
+                    try:
+                        await self.pubsub.host.connect(_peer)
+                    except Exception as e:
+                        logger.debug(
+                            "failed to connect to a direct peer %s: %s",
+                            _peer.peer_id,
+                            e,
+                        )
+            await trio.sleep(self.direct_connect_interval)
+
     def mesh_heartbeat(
         self,
     ) -> tuple[DefaultDict[ID, list[str]], DefaultDict[ID, list[str]]]:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -89,7 +89,7 @@ class GossipSub(IPubsubRouter, Service):
     heartbeat_interval: int
 
     direct_peers: dict[ID, PeerInfo]
-    direct_connect_initial_delay: float
+    direct_connect_init_delay: float
     direct_connect_interval: int
 
     def __init__(
@@ -137,7 +137,7 @@ class GossipSub(IPubsubRouter, Service):
         for direct_peer in direct_peers or []:
             self.direct_peers[direct_peer.peer_id] = direct_peer
         self.direct_connect_interval = direct_connect_interval
-        self.direct_connect_initial_delay = direct_connect_initial_delay
+        self.direct_connect_init_delay = direct_connect_initial_delay
 
     async def run(self) -> None:
         if self.pubsub is None:
@@ -461,7 +461,7 @@ class GossipSub(IPubsubRouter, Service):
         """
         Connect to direct peers.
         """
-        await trio.sleep(self.direct_connect_initial_delay)
+        await trio.sleep(self.direct_connect_init_delay)
         while True:
             for direct_peer in self.direct_peers:
                 if direct_peer not in self.pubsub.peers:

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -89,7 +89,7 @@ class GossipSub(IPubsubRouter, Service):
     heartbeat_initial_delay: float
     heartbeat_interval: int
 
-    direct_peers: Set[PeerInfo]
+    direct_peers: set[PeerInfo]
     direct_connect_initial_delay: int
     direct_connect_interval: int
 
@@ -134,7 +134,7 @@ class GossipSub(IPubsubRouter, Service):
         self.heartbeat_interval = heartbeat_interval
 
         # Create direct peers
-        self.direct_peers = direct_peers
+        self.direct_peers = set(direct_peers)
         self.direct_connect_interval = direct_connect_interval
         self.direct_connect_initial_delay = direct_connect_initial_delay
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -697,6 +697,13 @@ class GossipSub(IPubsubRouter, Service):
 
         # Add peer to mesh for topic
         if topic in self.mesh:
+            if sender_peer_id in self.direct_peers:
+                logger.warning(
+                    "GRAFT: ignoring request from direct peer %s", sender_peer_id
+                )
+                await self.emit_prune(topic, sender_peer_id)
+                return
+
             if sender_peer_id not in self.mesh[topic]:
                 self.mesh[topic].add(sender_peer_id)
         else:

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -38,7 +38,7 @@ class GossipsubParams(NamedTuple):
     gossip_history: int = 5
     heartbeat_initial_delay: float = 0.1
     heartbeat_interval: float = 0.5
-    direct_connect_init_delay: float = 0.1
+    direct_connect_initial_delay: float = 0.1
     direct_connect_interval: int = 300
 
 

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -32,7 +32,7 @@ class GossipsubParams(NamedTuple):
     degree: int = 10
     degree_low: int = 9
     degree_high: int = 11
-    direct_peers: Sequence[PeerInfo] = list()
+    direct_peers: Sequence[PeerInfo] = None
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -1,5 +1,5 @@
 from collections.abc import (
-    Set,
+    Sequence,
 )
 from typing import (
     NamedTuple,
@@ -32,13 +32,13 @@ class GossipsubParams(NamedTuple):
     degree: int = 10
     degree_low: int = 9
     degree_high: int = 11
-    direct_peers: Set[PeerInfo] = set()
+    direct_peers: Sequence[PeerInfo] = list()
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5
     heartbeat_initial_delay: float = 0.1
     heartbeat_interval: float = 0.5
-    direct_connect_init_delay: int = 1
+    direct_connect_init_delay: float = 0.1
     direct_connect_interval: int = 300
 
 

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -38,6 +38,8 @@ class GossipsubParams(NamedTuple):
     gossip_history: int = 5
     heartbeat_initial_delay: float = 0.1
     heartbeat_interval: float = 0.5
+    direct_connect_init_delay: int = 1
+    direct_connect_interval: int = 300
 
 
 GOSSIPSUB_PARAMS = GossipsubParams()

--- a/libp2p/tools/constants.py
+++ b/libp2p/tools/constants.py
@@ -1,9 +1,15 @@
+from collections.abc import (
+    Set,
+)
 from typing import (
     NamedTuple,
 )
 
 import multiaddr
 
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
 from libp2p.pubsub import (
     floodsub,
     gossipsub,
@@ -26,6 +32,7 @@ class GossipsubParams(NamedTuple):
     degree: int = 10
     degree_low: int = 9
     degree_high: int = 11
+    direct_peers: Set[PeerInfo] = set()
     time_to_live: int = 30
     gossip_window: int = 3
     gossip_history: int = 5

--- a/newsfragments/594.feature.rst
+++ b/newsfragments/594.feature.rst
@@ -1,0 +1,1 @@
+added ``direct peers`` as part of gossipsub v1.1 upgrade.

--- a/tests/core/examples/test_examples.py
+++ b/tests/core/examples/test_examples.py
@@ -209,8 +209,8 @@ async def ping_demo(host_a, host_b):
 
 
 async def pubsub_demo(host_a, host_b):
-    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, 0.1, 1)
-    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, 0.1, 1)
+    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, set(), 0.1, 1)
+    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, set(), 0.1, 1)
     pubsub_a = Pubsub(host_a, gossipsub_a)
     pubsub_b = Pubsub(host_b, gossipsub_b)
     message_a_to_b = "Hello from A to B"

--- a/tests/core/examples/test_examples.py
+++ b/tests/core/examples/test_examples.py
@@ -209,8 +209,8 @@ async def ping_demo(host_a, host_b):
 
 
 async def pubsub_demo(host_a, host_b):
-    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, set(), 0.1, 1)
-    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, set(), 0.1, 1)
+    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 0.1, 1)
+    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 0.1, 1)
     pubsub_a = Pubsub(host_a, gossipsub_a)
     pubsub_b = Pubsub(host_b, gossipsub_b)
     message_a_to_b = "Hello from A to B"

--- a/tests/core/pubsub/test_gossipsub_direct_peers.py
+++ b/tests/core/pubsub/test_gossipsub_direct_peers.py
@@ -111,7 +111,7 @@ async def test_heartbeat_reconnect():
     """Test that heartbeat can reconnect with disconnected direct peers gracefully."""
     # Create first host
     async with PubsubFactory.create_batch_with_gossipsub(
-        1, heartbeat_interval=1, direct_connect_interval=2
+        1, heartbeat_interval=1, direct_connect_interval=3
     ) as pubsubs_gsub_0:
         host_0 = pubsubs_gsub_0[0].host
 
@@ -120,7 +120,7 @@ async def test_heartbeat_reconnect():
             1,
             heartbeat_interval=1,
             direct_peers=[info_from_p2p_addr(host_0.get_addrs()[0])],
-            direct_connect_interval=2,
+            direct_connect_interval=3,
         ) as pubsubs_gsub_1:
             host_1 = pubsubs_gsub_1[0].host
 
@@ -151,7 +151,7 @@ async def test_heartbeat_reconnect():
                 ), "Peer 0 still in gossipsub 1 after disconnection"
 
                 # Wait for heartbeat to reestablish connection
-                await trio.sleep(1)
+                await trio.sleep(2)
 
                 # Verify connection reestablishment
                 assert (

--- a/tests/core/pubsub/test_gossipsub_direct_peers.py
+++ b/tests/core/pubsub/test_gossipsub_direct_peers.py
@@ -77,29 +77,36 @@ async def test_reject_graft():
 
                 topic = "test_reject_graft"
 
-                # Gossipsub 0 joins topic
+                # Gossipsub 0 and 1 joins topic
                 await pubsubs_gsub_0[0].router.join(topic)
+                await pubsubs_gsub_1[0].router.join(topic)
 
                 # Pre-Graft assertions
                 assert (
                     topic in pubsubs_gsub_0[0].router.mesh
                 ), "topic not in mesh for gossipsub 0"
                 assert (
-                    topic not in pubsubs_gsub_1[0].router.mesh
-                ), "topic in mesh for gossipsub 1"
+                    topic in pubsubs_gsub_1[0].router.mesh
+                ), "topic not in mesh for gossipsub 1"
+                assert (
+                    host_1.get_id() not in pubsubs_gsub_0[0].router.mesh[topic]
+                ), "gossipsub 1 in mesh topic for gossipsub 0"
+                assert (
+                    host_0.get_id() not in pubsubs_gsub_1[0].router.mesh[topic]
+                ), "gossipsub 0 in mesh topic for gossipsub 1"
 
                 # Gossipsub 1 emits a graft request to Gossipsub 0
-                await pubsubs_gsub_1[0].router.emit_graft(topic, host_0.get_id())
+                await pubsubs_gsub_0[0].router.emit_graft(topic, host_1.get_id())
 
                 await trio.sleep(1)
 
                 # Post-Graft assertions
                 assert (
-                    topic in pubsubs_gsub_0[0].router.mesh
-                ), "topic not in mesh for gossipsub 0"
+                    host_1.get_id() not in pubsubs_gsub_0[0].router.mesh[topic]
+                ), "gossipsub 1 in mesh topic for gossipsub 0"
                 assert (
-                    topic not in pubsubs_gsub_1[0].router.mesh
-                ), "topic in mesh for gossipsub 1"
+                    host_0.get_id() not in pubsubs_gsub_1[0].router.mesh[topic]
+                ), "gossipsub 0 in mesh topic for gossipsub 1"
 
             except Exception as e:
                 print(f"Test failed with error: {e}")

--- a/tests/core/pubsub/test_gossipsub_peer_management.py
+++ b/tests/core/pubsub/test_gossipsub_peer_management.py
@@ -1,7 +1,3 @@
-from contextlib import (
-    asynccontextmanager,
-)
-
 import pytest
 import trio
 
@@ -22,44 +18,18 @@ from tests.utils.factories import (
 )
 
 
-@asynccontextmanager
-async def create_connected_pubsubs(num_nodes, **kwargs):
-    """Helper context manager to create and connect pubsub nodes."""
-    async with PubsubFactory.create_batch_with_gossipsub(
-        num_nodes, **kwargs
-    ) as pubsubs_gsub:
-        gossipsubs = [pubsub.router for pubsub in pubsubs_gsub]
-        hosts = [pubsub.host for pubsub in pubsubs_gsub]
-
-        # Connect all hosts to each other
-        for i in range(len(hosts)):
-            for j in range(i + 1, len(hosts)):
-                try:
-                    await connect(hosts[i], hosts[j])
-                except Exception as e:
-                    print(f"Failed to connect hosts {i} and {j}: {e}")
-                    raise
-
-        yield pubsubs_gsub, gossipsubs, hosts
-
-
 @pytest.mark.trio
 async def test_attach_peer_records():
     """Test that attach ensures existence of peer records in peer store."""
     # Create first host
     async with PubsubFactory.create_batch_with_gossipsub(1) as pubsubs_gsub_0:
         host_0 = pubsubs_gsub_0[0].host
-        gsub_0 = pubsubs_gsub_0[0].router
 
         # Create second host with first host as direct peer
         async with PubsubFactory.create_batch_with_gossipsub(
             1, direct_peers=[PeerInfo(host_0.get_id(), host_0.get_addrs())]
         ) as pubsubs_gsub_1:
             host_1 = pubsubs_gsub_1[0].host
-            gsub_1 = pubsubs_gsub_1[0].router
-
-            # Connect the hosts
-            await connect(host_0, host_1)
 
             # Wait for heartbeat to allow mesh to connect
             await trio.sleep(2)
@@ -78,50 +48,7 @@ async def test_attach_peer_records():
                 print(f"Host 0 ID: {host_0.get_id()}")
                 print(f"Host 1 ID: {host_1.get_id()}")
 
-                assert host_1.get_id() in peer_ids_0, "Peer 1 not found in peer store 0"
                 assert host_0.get_id() in peer_ids_1, "Peer 0 not found in peer store 1"
-
-                # Verify that the peer protocol is set correctly
-                assert (
-                    gsub_0.peer_protocol[host_1.get_id()] == PROTOCOL_ID
-                ), "Incorrect protocol for peer 1 in gossipsub 0"
-                assert (
-                    gsub_1.peer_protocol[host_0.get_id()] == PROTOCOL_ID
-                ), "Incorrect protocol for peer 0 in gossipsub 1"
-
-                # Verify direct peer status
-                assert (
-                    host_0.get_id() in gsub_1.direct_peers
-                ), "Host 0 not marked as direct peer in gsub 1"
-
-                # Verify peer addresses are stored with PERMANENT_ADDR_TTL
-                addrs_0 = peer_store_0.get_addrs(host_1.get_id())
-                addrs_1 = peer_store_1.get_addrs(host_0.get_id())
-
-                print(f"Peer store 0 addresses for peer 1: {addrs_0}")
-                print(f"Peer store 1 addresses for peer 0: {addrs_1}")
-
-                assert (
-                    len(addrs_0) > 0
-                ), "No addresses stored for peer 1 in peer store 0"
-                assert (
-                    len(addrs_1) > 0
-                ), "No addresses stored for peer 0 in peer store 1"
-
-                # Verify addresses are stored with PERMANENT_ADDR_TTL
-                for addr in addrs_0:
-                    ttl = peer_store_0.get_addr_ttl(host_1.get_id(), addr)
-                    assert ttl == PERMANENT_ADDR_TTL, (
-                        f"Address {addr} for peer 1 not stored with "
-                        f"PERMANENT_ADDR_TTL in peer store 0"
-                    )
-
-                for addr in addrs_1:
-                    ttl = peer_store_1.get_addr_ttl(host_0.get_id(), addr)
-                    assert ttl == PERMANENT_ADDR_TTL, (
-                        f"Address {addr} for peer 0 not stored with "
-                        f"PERMANENT_ADDR_TTL in peer store 1"
-                    )
 
             except Exception as e:
                 print(f"Test failed with error: {e}")

--- a/tests/core/pubsub/test_gossipsub_peer_management.py
+++ b/tests/core/pubsub/test_gossipsub_peer_management.py
@@ -1,0 +1,126 @@
+import pytest
+import trio
+from contextlib import asynccontextmanager
+
+from libp2p.pubsub.gossipsub import (
+    PROTOCOL_ID,
+)
+from libp2p.tools.utils import (
+    connect,
+)
+from tests.utils.factories import (
+    PubsubFactory,
+)
+from tests.utils.pubsub.utils import (
+    one_to_all_connect,
+)
+
+
+@asynccontextmanager
+async def create_connected_pubsubs(num_nodes, **kwargs):
+    """Helper context manager to create and connect pubsub nodes."""
+    async with PubsubFactory.create_batch_with_gossipsub(num_nodes, **kwargs) as pubsubs_gsub:
+        gossipsubs = [pubsub.router for pubsub in pubsubs_gsub]
+        hosts = [pubsub.host for pubsub in pubsubs_gsub]
+        
+        # Connect all hosts to each other
+        for i in range(len(hosts)):
+            for j in range(i + 1, len(hosts)):
+                try:
+                    await connect(hosts[i], hosts[j])
+                    # Ensure peer records are stored
+                    hosts[i].get_peerstore().add_protocols(hosts[j].get_id(), [PROTOCOL_ID])
+                    hosts[j].get_peerstore().add_protocols(hosts[i].get_id(), [PROTOCOL_ID])
+                except Exception as e:
+                    print(f"Failed to connect hosts {i} and {j}: {e}")
+                    raise
+        
+        yield pubsubs_gsub, gossipsubs, hosts
+
+
+@pytest.mark.trio
+async def test_attach_peer_records():
+    """Test that attach ensures existence of peer records in peer store."""
+    async with create_connected_pubsubs(2) as (pubsubs_gsub, gossipsubs, hosts):
+        # Wait for heartbeat to allow mesh to connect
+        await trio.sleep(2)
+
+        try:
+            # Verify that peer records exist in peer store
+            peer_store_0 = hosts[0].get_peerstore()
+            peer_store_1 = hosts[1].get_peerstore()
+
+            # Check that each host has the other's peer record
+            peer_ids_0 = peer_store_0.peer_ids()
+            peer_ids_1 = peer_store_1.peer_ids()
+            
+            print(f"Peer store 0 IDs: {peer_ids_0}")
+            print(f"Peer store 1 IDs: {peer_ids_1}")
+            print(f"Host 0 ID: {hosts[0].get_id()}")
+            print(f"Host 1 ID: {hosts[1].get_id()}")
+
+            assert hosts[1].get_id() in peer_ids_0, "Peer 1 not found in peer store 0"
+            assert hosts[0].get_id() in peer_ids_1, "Peer 0 not found in peer store 1"
+
+            # Verify that the peer protocol is set correctly
+            assert gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID, "Incorrect protocol for peer 1 in gossipsub 0"
+            assert gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID, "Incorrect protocol for peer 0 in gossipsub 1"
+        except Exception as e:
+            print(f"Test failed with error: {e}")
+            raise
+
+
+@pytest.mark.trio
+async def test_heartbeat_reconnect():
+    """Test that heartbeat can reconnect with disconnected direct peers gracefully."""
+    async with create_connected_pubsubs(
+        2, 
+        heartbeat_interval=1, 
+        heartbeat_initial_delay=0.1
+    ) as (pubsubs_gsub, gossipsubs, hosts):
+        try:
+            # Wait for initial connection and mesh setup
+            await trio.sleep(2)
+
+            # Verify initial connection
+            assert hosts[1].get_id() in gossipsubs[0].peer_protocol, "Initial connection not established for gossipsub 0"
+            assert hosts[0].get_id() in gossipsubs[1].peer_protocol, "Initial connection not established for gossipsub 1"
+
+            # Simulate disconnection by closing the connection
+            # Create a list of connections to avoid modifying during iteration
+            connections = list(hosts[0].get_network().connections.values())
+            for conn in connections:
+                try:
+                    await conn.close()
+                except Exception as e:
+                    print(f"Error closing connection: {e}")
+                    continue
+
+            # Wait for heartbeat to detect disconnection
+            await trio.sleep(2)
+
+            # Verify that peers are removed from protocol tracking
+            assert hosts[1].get_id() not in gossipsubs[0].peer_protocol, "Peer 1 still in gossipsub 0 after disconnection"
+            assert hosts[0].get_id() not in gossipsubs[1].peer_protocol, "Peer 0 still in gossipsub 1 after disconnection"
+
+            # Reconnect the hosts
+            try:
+                await connect(hosts[0], hosts[1])
+                # Ensure peer records are stored after reconnection
+                hosts[0].get_peerstore().add_protocols(hosts[1].get_id(), [PROTOCOL_ID])
+                hosts[1].get_peerstore().add_protocols(hosts[0].get_id(), [PROTOCOL_ID])
+            except Exception as e:
+                print(f"Error reconnecting hosts: {e}")
+                raise
+
+            # Wait for heartbeat to reestablish connection
+            await trio.sleep(2)
+
+            # Verify that peers are reconnected and protocol tracking is restored
+            assert hosts[1].get_id() in gossipsubs[0].peer_protocol, "Peer 1 not reconnected in gossipsub 0"
+            assert hosts[0].get_id() in gossipsubs[1].peer_protocol, "Peer 0 not reconnected in gossipsub 1"
+            assert gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID, "Incorrect protocol after reconnection for peer 1 in gossipsub 0"
+            assert gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID, "Incorrect protocol after reconnection for peer 0 in gossipsub 1"
+        except Exception as e:
+            print(f"Test failed with error: {e}")
+            raise 

--- a/tests/core/pubsub/test_gossipsub_peer_management.py
+++ b/tests/core/pubsub/test_gossipsub_peer_management.py
@@ -5,6 +5,12 @@ from contextlib import (
 import pytest
 import trio
 
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
+from libp2p.peer.peerstore import (
+    PERMANENT_ADDR_TTL,
+)
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID,
 )
@@ -30,13 +36,6 @@ async def create_connected_pubsubs(num_nodes, **kwargs):
             for j in range(i + 1, len(hosts)):
                 try:
                     await connect(hosts[i], hosts[j])
-                    # Ensure peer records are stored
-                    hosts[i].get_peerstore().add_protocols(
-                        hosts[j].get_id(), [PROTOCOL_ID]
-                    )
-                    hosts[j].get_peerstore().add_protocols(
-                        hosts[i].get_id(), [PROTOCOL_ID]
-                    )
                 except Exception as e:
                     print(f"Failed to connect hosts {i} and {j}: {e}")
                     raise
@@ -47,104 +46,259 @@ async def create_connected_pubsubs(num_nodes, **kwargs):
 @pytest.mark.trio
 async def test_attach_peer_records():
     """Test that attach ensures existence of peer records in peer store."""
-    async with create_connected_pubsubs(2) as (pubsubs_gsub, gossipsubs, hosts):
-        # Wait for heartbeat to allow mesh to connect
-        await trio.sleep(2)
+    # Create first host
+    async with PubsubFactory.create_batch_with_gossipsub(1) as pubsubs_gsub_0:
+        host_0 = pubsubs_gsub_0[0].host
+        gsub_0 = pubsubs_gsub_0[0].router
 
-        try:
-            # Verify that peer records exist in peer store
-            peer_store_0 = hosts[0].get_peerstore()
-            peer_store_1 = hosts[1].get_peerstore()
+        # Create second host with first host as direct peer
+        async with PubsubFactory.create_batch_with_gossipsub(
+            1, direct_peers=[PeerInfo(host_0.get_id(), host_0.get_addrs())]
+        ) as pubsubs_gsub_1:
+            host_1 = pubsubs_gsub_1[0].host
+            gsub_1 = pubsubs_gsub_1[0].router
 
-            # Check that each host has the other's peer record
-            peer_ids_0 = peer_store_0.peer_ids()
-            peer_ids_1 = peer_store_1.peer_ids()
+            # Connect the hosts
+            await connect(host_0, host_1)
 
-            print(f"Peer store 0 IDs: {peer_ids_0}")
-            print(f"Peer store 1 IDs: {peer_ids_1}")
-            print(f"Host 0 ID: {hosts[0].get_id()}")
-            print(f"Host 1 ID: {hosts[1].get_id()}")
+            # Wait for heartbeat to allow mesh to connect
+            await trio.sleep(2)
 
-            assert hosts[1].get_id() in peer_ids_0, "Peer 1 not found in peer store 0"
-            assert hosts[0].get_id() in peer_ids_1, "Peer 0 not found in peer store 1"
+            try:
+                # Verify that peer records exist in peer store
+                peer_store_0 = host_0.get_peerstore()
+                peer_store_1 = host_1.get_peerstore()
 
-            # Verify that the peer protocol is set correctly
-            assert (
-                gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID
-            ), "Incorrect protocol for peer 1 in gossipsub 0"
-            assert (
-                gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID
-            ), "Incorrect protocol for peer 0 in gossipsub 1"
-        except Exception as e:
-            print(f"Test failed with error: {e}")
-            raise
+                # Check that each host has the other's peer record
+                peer_ids_0 = peer_store_0.peer_ids()
+                peer_ids_1 = peer_store_1.peer_ids()
+
+                print(f"Peer store 0 IDs: {peer_ids_0}")
+                print(f"Peer store 1 IDs: {peer_ids_1}")
+                print(f"Host 0 ID: {host_0.get_id()}")
+                print(f"Host 1 ID: {host_1.get_id()}")
+
+                assert host_1.get_id() in peer_ids_0, "Peer 1 not found in peer store 0"
+                assert host_0.get_id() in peer_ids_1, "Peer 0 not found in peer store 1"
+
+                # Verify that the peer protocol is set correctly
+                assert (
+                    gsub_0.peer_protocol[host_1.get_id()] == PROTOCOL_ID
+                ), "Incorrect protocol for peer 1 in gossipsub 0"
+                assert (
+                    gsub_1.peer_protocol[host_0.get_id()] == PROTOCOL_ID
+                ), "Incorrect protocol for peer 0 in gossipsub 1"
+
+                # Verify direct peer status
+                assert (
+                    host_0.get_id() in gsub_1.direct_peers
+                ), "Host 0 not marked as direct peer in gsub 1"
+
+                # Verify peer addresses are stored with PERMANENT_ADDR_TTL
+                addrs_0 = peer_store_0.get_addrs(host_1.get_id())
+                addrs_1 = peer_store_1.get_addrs(host_0.get_id())
+
+                print(f"Peer store 0 addresses for peer 1: {addrs_0}")
+                print(f"Peer store 1 addresses for peer 0: {addrs_1}")
+
+                assert (
+                    len(addrs_0) > 0
+                ), "No addresses stored for peer 1 in peer store 0"
+                assert (
+                    len(addrs_1) > 0
+                ), "No addresses stored for peer 0 in peer store 1"
+
+                # Verify addresses are stored with PERMANENT_ADDR_TTL
+                for addr in addrs_0:
+                    ttl = peer_store_0.get_addr_ttl(host_1.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 1 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 0"
+                    )
+
+                for addr in addrs_1:
+                    ttl = peer_store_1.get_addr_ttl(host_0.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 0 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 1"
+                    )
+
+            except Exception as e:
+                print(f"Test failed with error: {e}")
+                raise
 
 
 @pytest.mark.trio
 async def test_heartbeat_reconnect():
     """Test that heartbeat can reconnect with disconnected direct peers gracefully."""
-    async with create_connected_pubsubs(
-        2, heartbeat_interval=1, heartbeat_initial_delay=0.1
-    ) as (pubsubs_gsub, gossipsubs, hosts):
-        try:
-            # Wait for initial connection and mesh setup
-            await trio.sleep(2)
+    # Create first host
+    async with PubsubFactory.create_batch_with_gossipsub(
+        1, heartbeat_interval=2, heartbeat_initial_delay=1
+    ) as pubsubs_gsub_0:
+        host_0 = pubsubs_gsub_0[0].host
+        gsub_0 = pubsubs_gsub_0[0].router
 
-            # Verify initial connection
-            assert (
-                hosts[1].get_id() in gossipsubs[0].peer_protocol
-            ), "Initial connection not established for gossipsub 0"
-            assert (
-                hosts[0].get_id() in gossipsubs[1].peer_protocol
-            ), "Initial connection not established for gossipsub 1"
+        # Create second host with first host as direct peer
+        async with PubsubFactory.create_batch_with_gossipsub(
+            1,
+            heartbeat_interval=2,
+            heartbeat_initial_delay=1,
+            direct_peers=[PeerInfo(host_0.get_id(), host_0.get_addrs())],
+        ) as pubsubs_gsub_1:
+            host_1 = pubsubs_gsub_1[0].host
+            gsub_1 = pubsubs_gsub_1[0].router
 
-            # Simulate disconnection by closing the connection
-            # Create a list of connections to avoid modifying during iteration
-            connections = list(hosts[0].get_network().connections.values())
-            for conn in connections:
-                try:
-                    await conn.close()
-                except Exception as e:
-                    print(f"Error closing connection: {e}")
-                    continue
+            # Connect the hosts
+            await connect(host_0, host_1)
 
-            # Wait for heartbeat to detect disconnection
-            await trio.sleep(2)
-
-            # Verify that peers are removed from protocol tracking
-            assert (
-                hosts[1].get_id() not in gossipsubs[0].peer_protocol
-            ), "Peer 1 still in gossipsub 0 after disconnection"
-            assert (
-                hosts[0].get_id() not in gossipsubs[1].peer_protocol
-            ), "Peer 0 still in gossipsub 1 after disconnection"
-
-            # Reconnect the hosts
             try:
-                await connect(hosts[0], hosts[1])
-                # Ensure peer records are stored after reconnection
-                hosts[0].get_peerstore().add_protocols(hosts[1].get_id(), [PROTOCOL_ID])
-                hosts[1].get_peerstore().add_protocols(hosts[0].get_id(), [PROTOCOL_ID])
+                # Wait for initial connection and mesh setup
+                await trio.sleep(2)
+
+                # Verify initial connection
+                assert (
+                    host_1.get_id() in gsub_0.peer_protocol
+                ), "Initial connection not established for gossipsub 0"
+                assert (
+                    host_0.get_id() in gsub_1.peer_protocol
+                ), "Initial connection not established for gossipsub 1"
+
+                # Verify direct peer status
+                assert (
+                    host_0.get_id() in gsub_1.direct_peers
+                ), "Host 0 not marked as direct peer in gsub 1"
+
+                # Verify peer addresses are stored with PERMANENT_ADDR_TTL
+                peer_store_0 = host_0.get_peerstore()
+                peer_store_1 = host_1.get_peerstore()
+
+                addrs_0 = peer_store_0.get_addrs(host_1.get_id())
+                addrs_1 = peer_store_1.get_addrs(host_0.get_id())
+
+                assert (
+                    len(addrs_0) > 0
+                ), "No addresses stored for peer 1 in peer store 0"
+                assert (
+                    len(addrs_1) > 0
+                ), "No addresses stored for peer 0 in peer store 1"
+
+                # Verify addresses are stored with PERMANENT_ADDR_TTL
+                for addr in addrs_0:
+                    ttl = peer_store_0.get_addr_ttl(host_1.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 1 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 0"
+                    )
+
+                for addr in addrs_1:
+                    ttl = peer_store_1.get_addr_ttl(host_0.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 0 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 1"
+                    )
+
+                # Simulate disconnection by closing the connection
+                # Create a list of connections to avoid modifying during iteration
+                connections = list(host_0.get_network().connections.values())
+                for conn in connections:
+                    try:
+                        await conn.close()
+                    except Exception as e:
+                        print(f"Error closing connection: {e}")
+                        continue
+
+                # Wait for heartbeat to detect disconnection
+                await trio.sleep(2)
+
+                # Verify that peers are removed from protocol tracking
+                assert (
+                    host_1.get_id() not in gsub_0.peer_protocol
+                ), "Peer 1 still in gossipsub 0 after disconnection"
+                assert (
+                    host_0.get_id() not in gsub_1.peer_protocol
+                ), "Peer 0 still in gossipsub 1 after disconnection"
+
+                # Verify addresses are still stored with
+                # PERMANENT_ADDR_TTL after disconnection
+                addrs_0 = peer_store_0.get_addrs(host_1.get_id())
+                addrs_1 = peer_store_1.get_addrs(host_0.get_id())
+
+                assert (
+                    len(addrs_0) > 0
+                ), "No addresses stored for peer 1 in peer store 0 after disconnection"
+                assert (
+                    len(addrs_1) > 0
+                ), "No addresses stored for peer 0 in peer store 1 after disconnection"
+
+                for addr in addrs_0:
+                    ttl = peer_store_0.get_addr_ttl(host_1.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 1 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 0 after disconnection"
+                    )
+
+                for addr in addrs_1:
+                    ttl = peer_store_1.get_addr_ttl(host_0.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 0 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 1 after disconnection"
+                    )
+
+                # Reconnect the hosts
+                try:
+                    await connect(host_0, host_1)
+                except Exception as e:
+                    print(f"Error reconnecting hosts: {e}")
+                    raise
+
+                # Wait for heartbeat to reestablish connection
+                await trio.sleep(2)
+
+                # Verify that peers are reconnected and protocol tracking is restored
+                assert (
+                    host_1.get_id() in gsub_0.peer_protocol
+                ), "Peer 1 not reconnected in gossipsub 0"
+                assert (
+                    host_0.get_id() in gsub_1.peer_protocol
+                ), "Peer 0 not reconnected in gossipsub 1"
+                assert (
+                    gsub_0.peer_protocol[host_1.get_id()] == PROTOCOL_ID
+                ), "Incorrect protocol after reconnection for peer 1 in gossipsub 0"
+                assert (
+                    gsub_1.peer_protocol[host_0.get_id()] == PROTOCOL_ID
+                ), "Incorrect protocol after reconnection for peer 0 in gossipsub 1"
+
+                # Verify direct peer status is maintained
+                assert (
+                    host_0.get_id() in gsub_1.direct_peers
+                ), "Host 0 not marked as direct peer in gsub 1 after reconnection"
+
+                # Verify addresses are still stored with
+                # PERMANENT_ADDR_TTL after reconnection
+                addrs_0 = peer_store_0.get_addrs(host_1.get_id())
+                addrs_1 = peer_store_1.get_addrs(host_0.get_id())
+
+                assert (
+                    len(addrs_0) > 0
+                ), "No addresses stored for peer 1 in peer store 0 after reconnection"
+                assert (
+                    len(addrs_1) > 0
+                ), "No addresses stored for peer 0 in peer store 1 after reconnection"
+
+                for addr in addrs_0:
+                    ttl = peer_store_0.get_addr_ttl(host_1.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 1 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 0 after reconnection"
+                    )
+
+                for addr in addrs_1:
+                    ttl = peer_store_1.get_addr_ttl(host_0.get_id(), addr)
+                    assert ttl == PERMANENT_ADDR_TTL, (
+                        f"Address {addr} for peer 0 not stored with "
+                        f"PERMANENT_ADDR_TTL in peer store 1 after reconnection"
+                    )
+
             except Exception as e:
-                print(f"Error reconnecting hosts: {e}")
+                print(f"Test failed with error: {e}")
                 raise
-
-            # Wait for heartbeat to reestablish connection
-            await trio.sleep(2)
-
-            # Verify that peers are reconnected and protocol tracking is restored
-            assert (
-                hosts[1].get_id() in gossipsubs[0].peer_protocol
-            ), "Peer 1 not reconnected in gossipsub 0"
-            assert (
-                hosts[0].get_id() in gossipsubs[1].peer_protocol
-            ), "Peer 0 not reconnected in gossipsub 1"
-            assert (
-                gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID
-            ), "Incorrect protocol after reconnection for peer 1 in gossipsub 0"
-            assert (
-                gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID
-            ), "Incorrect protocol after reconnection for peer 0 in gossipsub 1"
-        except Exception as e:
-            print(f"Test failed with error: {e}")
-            raise

--- a/tests/core/pubsub/test_gossipsub_peer_management.py
+++ b/tests/core/pubsub/test_gossipsub_peer_management.py
@@ -1,6 +1,9 @@
+from contextlib import (
+    asynccontextmanager,
+)
+
 import pytest
 import trio
-from contextlib import asynccontextmanager
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID,
@@ -11,30 +14,33 @@ from libp2p.tools.utils import (
 from tests.utils.factories import (
     PubsubFactory,
 )
-from tests.utils.pubsub.utils import (
-    one_to_all_connect,
-)
 
 
 @asynccontextmanager
 async def create_connected_pubsubs(num_nodes, **kwargs):
     """Helper context manager to create and connect pubsub nodes."""
-    async with PubsubFactory.create_batch_with_gossipsub(num_nodes, **kwargs) as pubsubs_gsub:
+    async with PubsubFactory.create_batch_with_gossipsub(
+        num_nodes, **kwargs
+    ) as pubsubs_gsub:
         gossipsubs = [pubsub.router for pubsub in pubsubs_gsub]
         hosts = [pubsub.host for pubsub in pubsubs_gsub]
-        
+
         # Connect all hosts to each other
         for i in range(len(hosts)):
             for j in range(i + 1, len(hosts)):
                 try:
                     await connect(hosts[i], hosts[j])
                     # Ensure peer records are stored
-                    hosts[i].get_peerstore().add_protocols(hosts[j].get_id(), [PROTOCOL_ID])
-                    hosts[j].get_peerstore().add_protocols(hosts[i].get_id(), [PROTOCOL_ID])
+                    hosts[i].get_peerstore().add_protocols(
+                        hosts[j].get_id(), [PROTOCOL_ID]
+                    )
+                    hosts[j].get_peerstore().add_protocols(
+                        hosts[i].get_id(), [PROTOCOL_ID]
+                    )
                 except Exception as e:
                     print(f"Failed to connect hosts {i} and {j}: {e}")
                     raise
-        
+
         yield pubsubs_gsub, gossipsubs, hosts
 
 
@@ -53,7 +59,7 @@ async def test_attach_peer_records():
             # Check that each host has the other's peer record
             peer_ids_0 = peer_store_0.peer_ids()
             peer_ids_1 = peer_store_1.peer_ids()
-            
+
             print(f"Peer store 0 IDs: {peer_ids_0}")
             print(f"Peer store 1 IDs: {peer_ids_1}")
             print(f"Host 0 ID: {hosts[0].get_id()}")
@@ -63,8 +69,12 @@ async def test_attach_peer_records():
             assert hosts[0].get_id() in peer_ids_1, "Peer 0 not found in peer store 1"
 
             # Verify that the peer protocol is set correctly
-            assert gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID, "Incorrect protocol for peer 1 in gossipsub 0"
-            assert gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID, "Incorrect protocol for peer 0 in gossipsub 1"
+            assert (
+                gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID
+            ), "Incorrect protocol for peer 1 in gossipsub 0"
+            assert (
+                gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID
+            ), "Incorrect protocol for peer 0 in gossipsub 1"
         except Exception as e:
             print(f"Test failed with error: {e}")
             raise
@@ -74,17 +84,19 @@ async def test_attach_peer_records():
 async def test_heartbeat_reconnect():
     """Test that heartbeat can reconnect with disconnected direct peers gracefully."""
     async with create_connected_pubsubs(
-        2, 
-        heartbeat_interval=1, 
-        heartbeat_initial_delay=0.1
+        2, heartbeat_interval=1, heartbeat_initial_delay=0.1
     ) as (pubsubs_gsub, gossipsubs, hosts):
         try:
             # Wait for initial connection and mesh setup
             await trio.sleep(2)
 
             # Verify initial connection
-            assert hosts[1].get_id() in gossipsubs[0].peer_protocol, "Initial connection not established for gossipsub 0"
-            assert hosts[0].get_id() in gossipsubs[1].peer_protocol, "Initial connection not established for gossipsub 1"
+            assert (
+                hosts[1].get_id() in gossipsubs[0].peer_protocol
+            ), "Initial connection not established for gossipsub 0"
+            assert (
+                hosts[0].get_id() in gossipsubs[1].peer_protocol
+            ), "Initial connection not established for gossipsub 1"
 
             # Simulate disconnection by closing the connection
             # Create a list of connections to avoid modifying during iteration
@@ -100,8 +112,12 @@ async def test_heartbeat_reconnect():
             await trio.sleep(2)
 
             # Verify that peers are removed from protocol tracking
-            assert hosts[1].get_id() not in gossipsubs[0].peer_protocol, "Peer 1 still in gossipsub 0 after disconnection"
-            assert hosts[0].get_id() not in gossipsubs[1].peer_protocol, "Peer 0 still in gossipsub 1 after disconnection"
+            assert (
+                hosts[1].get_id() not in gossipsubs[0].peer_protocol
+            ), "Peer 1 still in gossipsub 0 after disconnection"
+            assert (
+                hosts[0].get_id() not in gossipsubs[1].peer_protocol
+            ), "Peer 0 still in gossipsub 1 after disconnection"
 
             # Reconnect the hosts
             try:
@@ -117,10 +133,18 @@ async def test_heartbeat_reconnect():
             await trio.sleep(2)
 
             # Verify that peers are reconnected and protocol tracking is restored
-            assert hosts[1].get_id() in gossipsubs[0].peer_protocol, "Peer 1 not reconnected in gossipsub 0"
-            assert hosts[0].get_id() in gossipsubs[1].peer_protocol, "Peer 0 not reconnected in gossipsub 1"
-            assert gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID, "Incorrect protocol after reconnection for peer 1 in gossipsub 0"
-            assert gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID, "Incorrect protocol after reconnection for peer 0 in gossipsub 1"
+            assert (
+                hosts[1].get_id() in gossipsubs[0].peer_protocol
+            ), "Peer 1 not reconnected in gossipsub 0"
+            assert (
+                hosts[0].get_id() in gossipsubs[1].peer_protocol
+            ), "Peer 0 not reconnected in gossipsub 1"
+            assert (
+                gossipsubs[0].peer_protocol[hosts[1].get_id()] == PROTOCOL_ID
+            ), "Incorrect protocol after reconnection for peer 1 in gossipsub 0"
+            assert (
+                gossipsubs[1].peer_protocol[hosts[0].get_id()] == PROTOCOL_ID
+            ), "Incorrect protocol after reconnection for peer 0 in gossipsub 1"
         except Exception as e:
             print(f"Test failed with error: {e}")
-            raise 
+            raise

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -581,8 +581,12 @@ class PubsubFactory(factory.Factory):
                 degree_low=degree_low,
                 degree_high=degree_high,
                 direct_peers=direct_peers,
+                time_to_live=time_to_live,
                 gossip_window=gossip_window,
                 heartbeat_interval=heartbeat_interval,
+                heartbeat_initial_delay=heartbeat_initial_delay,
+                direct_connect_initial_delay=direct_connect_init_delay,
+                direct_connect_interval=direct_connect_interval,
             )
 
         async with cls._create_batch_with_router(

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -427,6 +427,8 @@ class GossipsubFactory(factory.Factory):
     gossip_history = GOSSIPSUB_PARAMS.gossip_history
     heartbeat_initial_delay = GOSSIPSUB_PARAMS.heartbeat_initial_delay
     heartbeat_interval = GOSSIPSUB_PARAMS.heartbeat_interval
+    direct_connect_initial_delay = GOSSIPSUB_PARAMS.direct_connect_init_delay
+    direct_connect_interval = GOSSIPSUB_PARAMS.direct_connect_interval
 
 
 class PubsubFactory(factory.Factory):
@@ -549,6 +551,8 @@ class PubsubFactory(factory.Factory):
         gossip_history: int = GOSSIPSUB_PARAMS.gossip_history,
         heartbeat_interval: float = GOSSIPSUB_PARAMS.heartbeat_interval,
         heartbeat_initial_delay: float = GOSSIPSUB_PARAMS.heartbeat_initial_delay,
+        direct_connect_init_delay: int = GOSSIPSUB_PARAMS.direct_connect_init_delay,
+        direct_connect_interval: int = GOSSIPSUB_PARAMS.direct_connect_interval,
         security_protocol: TProtocol = None,
         muxer_opt: TMuxerOptions = None,
         msg_id_constructor: Callable[
@@ -565,7 +569,11 @@ class PubsubFactory(factory.Factory):
                 direct_peers=direct_peers,
                 time_to_live=time_to_live,
                 gossip_window=gossip_window,
+                gossip_history=gossip_history,
+                heartbeat_initial_delay=heartbeat_initial_delay,
                 heartbeat_interval=heartbeat_interval,
+                direct_connect_initial_delay=direct_connect_init_delay,
+                direct_connect_interval=direct_connect_interval,
             )
         else:
             gossipsubs = GossipsubFactory.create_batch(

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -426,7 +426,7 @@ class GossipsubFactory(factory.Factory):
     gossip_history = GOSSIPSUB_PARAMS.gossip_history
     heartbeat_initial_delay = GOSSIPSUB_PARAMS.heartbeat_initial_delay
     heartbeat_interval = GOSSIPSUB_PARAMS.heartbeat_interval
-    direct_connect_initial_delay = GOSSIPSUB_PARAMS.direct_connect_init_delay
+    direct_connect_initial_delay = GOSSIPSUB_PARAMS.direct_connect_initial_delay
     direct_connect_interval = GOSSIPSUB_PARAMS.direct_connect_interval
 
 
@@ -550,7 +550,7 @@ class PubsubFactory(factory.Factory):
         gossip_history: int = GOSSIPSUB_PARAMS.gossip_history,
         heartbeat_interval: float = GOSSIPSUB_PARAMS.heartbeat_interval,
         heartbeat_initial_delay: float = GOSSIPSUB_PARAMS.heartbeat_initial_delay,
-        direct_connect_init_delay: float = GOSSIPSUB_PARAMS.direct_connect_init_delay,
+        direct_connect_initial_delay: float = GOSSIPSUB_PARAMS.direct_connect_initial_delay,  # noqa: E501
         direct_connect_interval: int = GOSSIPSUB_PARAMS.direct_connect_interval,
         security_protocol: TProtocol = None,
         muxer_opt: TMuxerOptions = None,
@@ -571,7 +571,7 @@ class PubsubFactory(factory.Factory):
                 gossip_history=gossip_history,
                 heartbeat_initial_delay=heartbeat_initial_delay,
                 heartbeat_interval=heartbeat_interval,
-                direct_connect_initial_delay=direct_connect_init_delay,
+                direct_connect_initial_delay=direct_connect_initial_delay,
                 direct_connect_interval=direct_connect_interval,
             )
         else:
@@ -585,7 +585,7 @@ class PubsubFactory(factory.Factory):
                 gossip_window=gossip_window,
                 heartbeat_interval=heartbeat_interval,
                 heartbeat_initial_delay=heartbeat_initial_delay,
-                direct_connect_initial_delay=direct_connect_init_delay,
+                direct_connect_initial_delay=direct_connect_initial_delay,
                 direct_connect_interval=direct_connect_interval,
             )
 

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -1,7 +1,6 @@
 from collections.abc import (
     AsyncIterator,
     Sequence,
-    Set,
 )
 from contextlib import (
     AsyncExitStack,
@@ -545,13 +544,13 @@ class PubsubFactory(factory.Factory):
         degree: int = GOSSIPSUB_PARAMS.degree,
         degree_low: int = GOSSIPSUB_PARAMS.degree_low,
         degree_high: int = GOSSIPSUB_PARAMS.degree_high,
-        direct_peers: Set[PeerInfo] = GOSSIPSUB_PARAMS.direct_peers,
+        direct_peers: Sequence[PeerInfo] = GOSSIPSUB_PARAMS.direct_peers,
         time_to_live: int = GOSSIPSUB_PARAMS.time_to_live,
         gossip_window: int = GOSSIPSUB_PARAMS.gossip_window,
         gossip_history: int = GOSSIPSUB_PARAMS.gossip_history,
         heartbeat_interval: float = GOSSIPSUB_PARAMS.heartbeat_interval,
         heartbeat_initial_delay: float = GOSSIPSUB_PARAMS.heartbeat_initial_delay,
-        direct_connect_init_delay: int = GOSSIPSUB_PARAMS.direct_connect_init_delay,
+        direct_connect_init_delay: float = GOSSIPSUB_PARAMS.direct_connect_init_delay,
         direct_connect_interval: int = GOSSIPSUB_PARAMS.direct_connect_interval,
         security_protocol: TProtocol = None,
         muxer_opt: TMuxerOptions = None,

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -1,6 +1,7 @@
 from collections.abc import (
     AsyncIterator,
     Sequence,
+    Set,
 )
 from contextlib import (
     AsyncExitStack,
@@ -421,6 +422,7 @@ class GossipsubFactory(factory.Factory):
     degree = GOSSIPSUB_PARAMS.degree
     degree_low = GOSSIPSUB_PARAMS.degree_low
     degree_high = GOSSIPSUB_PARAMS.degree_high
+    direct_peers = GOSSIPSUB_PARAMS.direct_peers
     gossip_window = GOSSIPSUB_PARAMS.gossip_window
     gossip_history = GOSSIPSUB_PARAMS.gossip_history
     heartbeat_initial_delay = GOSSIPSUB_PARAMS.heartbeat_initial_delay
@@ -541,6 +543,7 @@ class PubsubFactory(factory.Factory):
         degree: int = GOSSIPSUB_PARAMS.degree,
         degree_low: int = GOSSIPSUB_PARAMS.degree_low,
         degree_high: int = GOSSIPSUB_PARAMS.degree_high,
+        direct_peers: Set[PeerInfo] = GOSSIPSUB_PARAMS.direct_peers,
         time_to_live: int = GOSSIPSUB_PARAMS.time_to_live,
         gossip_window: int = GOSSIPSUB_PARAMS.gossip_window,
         gossip_history: int = GOSSIPSUB_PARAMS.gossip_history,
@@ -559,6 +562,7 @@ class PubsubFactory(factory.Factory):
                 degree=degree,
                 degree_low=degree_low,
                 degree_high=degree_high,
+                direct_peers=direct_peers,
                 time_to_live=time_to_live,
                 gossip_window=gossip_window,
                 heartbeat_interval=heartbeat_interval,
@@ -569,6 +573,7 @@ class PubsubFactory(factory.Factory):
                 degree=degree,
                 degree_low=degree_low,
                 degree_high=degree_high,
+                direct_peers=direct_peers,
                 gossip_window=gossip_window,
                 heartbeat_interval=heartbeat_interval,
             )


### PR DESCRIPTION
## What was wrong?

This PR is part of a long working Gossipsub upgrade process, I have added Direct Peers (AKA Explicit Peers) in this contribution. There are 4 major changes that need to be implemented to introduce the complete functionality of Direct Peering -

- [x] adding direct peers to peerstore while invoking router.attach method
- [x] including direct peers in peers_gen while invoking router.publish method
- [x] rejecting GRAFT requests from direct peers and responding with an appropriate PRUNE msg
- [x] running a direct peer heartbeat which constantly checks for connections with direct peers
- [x] test file to cover all possible cases of Direct Peering

part of #412 

### To-Do

- [X] Clean up commit history
- [ ] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imgs.search.brave.com/nMGA-g1eYFutwVeFVywxeBqGioObCJa73NZ6Z9Zh9Ts/rs:fit:860:0:0:0/g:ce/aHR0cHM6Ly93d3cu/cmQuY29tL3dwLWNv/bnRlbnQvdXBsb2Fk/cy8yMDE4LzA4L2Vt/YmFyYXNzbWVudC1v/Zi1wYW5kYXMuanBn/P3Jlc2l6ZT03MDAs/NDY2)
