### PR TITLE
doc: fix broken newsfragment link in contributing

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -294,7 +294,7 @@ do not pass the CI build yet won't get reviewed unless explicitly requested.
 
 If the pull request introduces changes that should be reflected in the release notes,
 please add a newsfragment file as explained
-`here <https://github.com/ethereum/py-libp2p/blob/main/newsfragments/README.md>`_.
+`here <https://github.com/libp2p/py-libp2p/tree/main/newsfragments>`_.
 
 If possible, the change to the release notes file should be included in the commit that
 introduces the feature or bugfix.


### PR DESCRIPTION
## What was wrong?

Issue #595 Doc: Link in doc broken about news fragment in contributing
In [https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests](https://py-libp2p.readthedocs.io/en/latest/contributing.html#pull-requests)
`If the pull request introduces changes that should be reflected in the release notes, please add a newsfragment file as explained` [here](https://github.com/ethereum/py-libp2p/blob/main/newsfragments/README.md).
The here link is broken.

## How was it fixed?

fix the broken link with a working one.

![image](https://github.com/user-attachments/assets/af0b638f-fe81-4c18-9a8d-3927b85fcf85)
