### PR TITLE
fix towncrier config and correct links in release_notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ ifndef bump
 endif
 
 check-git:
-	# require that upstream is configured for ethereum/py-libp2p
+	# require that upstream is configured for libp2p/py-libp2p
 	@if ! git remote -v | grep "upstream[[:space:]]git@github.com:libp2p/py-libp2p.git (push)\|upstream[[:space:]]https://github.com/libp2p/py-libp2p (push)"; then \
 		echo "Error: You must have a remote named 'upstream' that points to 'py-libp2p'"; \
 		exit 1; \

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,21 +9,21 @@ py-libp2p v0.2.5 (2025-04-14)
 Bugfixes
 ~~~~~~~~
 
-- Fixed flaky test_simple_last_seen_cache by adding a retry loop for reliable expiry detection across platforms. (`#558 <https://github.com/ethereum/py-libp2p/issues/558>`__)
+- Fixed flaky test_simple_last_seen_cache by adding a retry loop for reliable expiry detection across platforms. (`#558 <https://github.com/libp2p/py-libp2p/issues/558>`__)
 
 
 Improved Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- Added install and getting started documentation. (`#559 <https://github.com/ethereum/py-libp2p/issues/559>`__)
+- Added install and getting started documentation. (`#559 <https://github.com/libp2p/py-libp2p/issues/559>`__)
 
 
 Features
 ~~~~~~~~
 
-- Added a ``pub-sub`` example having ``gossipsub`` as the router to demonstrate how to use the pub-sub module in py-libp2p. (`#515 <https://github.com/ethereum/py-libp2p/issues/515>`__)
-- Added documentation on how to add examples to the libp2p package. (`#550 <https://github.com/ethereum/py-libp2p/issues/550>`__)
-- Added Windows-specific development setup instructions to `docs/contributing.rst`. (`#559 <https://github.com/ethereum/py-libp2p/issues/559>`__)
+- Added a ``pub-sub`` example having ``gossipsub`` as the router to demonstrate how to use the pub-sub module in py-libp2p. (`#515 <https://github.com/libp2p/py-libp2p/issues/515>`__)
+- Added documentation on how to add examples to the libp2p package. (`#550 <https://github.com/libp2p/py-libp2p/issues/550>`__)
+- Added Windows-specific development setup instructions to `docs/contributing.rst`. (`#559 <https://github.com/libp2p/py-libp2p/issues/559>`__)
 
 
 py-libp2p v0.2.4 (2025-03-27)
@@ -32,7 +32,7 @@ py-libp2p v0.2.4 (2025-03-27)
 Bugfixes
 ~~~~~~~~
 
-- Added Windows compatibility by using coincurve instead of fastecdsa on Windows platforms (`#507 <https://github.com/ethereum/py-libp2p/issues/507>`__)
+- Added Windows compatibility by using coincurve instead of fastecdsa on Windows platforms (`#507 <https://github.com/libp2p/py-libp2p/issues/507>`__)
 
 
 py-libp2p v0.2.3 (2025-03-27)
@@ -41,36 +41,36 @@ py-libp2p v0.2.3 (2025-03-27)
 Bugfixes
 ~~~~~~~~
 
-- Fixed import path in the examples to use updated `net_stream` module path, resolving ModuleNotFoundError when running the examples. (`#513 <https://github.com/ethereum/py-libp2p/issues/513>`__)
+- Fixed import path in the examples to use updated `net_stream` module path, resolving ModuleNotFoundError when running the examples. (`#513 <https://github.com/libp2p/py-libp2p/issues/513>`__)
 
 
 Improved Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- Updates ``Feature Breakdown`` in ``README`` to more closely match the list of standard modules. (`#498 <https://github.com/ethereum/py-libp2p/issues/498>`__)
-- Adds detailed Sphinx-style docstrings to ``abc.py``. (`#535 <https://github.com/ethereum/py-libp2p/issues/535>`__)
+- Updates ``Feature Breakdown`` in ``README`` to more closely match the list of standard modules. (`#498 <https://github.com/libp2p/py-libp2p/issues/498>`__)
+- Adds detailed Sphinx-style docstrings to ``abc.py``. (`#535 <https://github.com/libp2p/py-libp2p/issues/535>`__)
 
 
 Features
 ~~~~~~~~
 
-- Improved the implementation of the identify protocol and enhanced test coverage to ensure proper functionality and network layer address delegation. (`#358 <https://github.com/ethereum/py-libp2p/issues/358>`__)
-- Adds the ability to check connection status of a peer in the peerstore. (`#420 <https://github.com/ethereum/py-libp2p/issues/420>`__)
-- implemented ``timed_cache`` module which will allow to implement ``seen_ttl`` configurable param for pubsub and protocols extending it. (`#518 <https://github.com/ethereum/py-libp2p/issues/518>`__)
+- Improved the implementation of the identify protocol and enhanced test coverage to ensure proper functionality and network layer address delegation. (`#358 <https://github.com/libp2p/py-libp2p/issues/358>`__)
+- Adds the ability to check connection status of a peer in the peerstore. (`#420 <https://github.com/libp2p/py-libp2p/issues/420>`__)
+- implemented ``timed_cache`` module which will allow to implement ``seen_ttl`` configurable param for pubsub and protocols extending it. (`#518 <https://github.com/libp2p/py-libp2p/issues/518>`__)
 - Added a maximum RSA key size limit of 4096 bits to prevent resource exhaustion attacks.Consolidated validation logic to use a single error message source and
-  added tests to catch invalid key sizes (including negative values). (`#523 <https://github.com/ethereum/py-libp2p/issues/523>`__)
-- Added automated testing of ``demo`` applications as part of CI to prevent demos from breaking silently. Tests are located in `tests/core/examples/test_examples.py`. (`#524 <https://github.com/ethereum/py-libp2p/issues/524>`__)
-- Added an example implementation of the identify protocol to demonstrate its usage and help users understand how to properly integrate it into their libp2p applications. (`#536 <https://github.com/ethereum/py-libp2p/issues/536>`__)
+  added tests to catch invalid key sizes (including negative values). (`#523 <https://github.com/libp2p/py-libp2p/issues/523>`__)
+- Added automated testing of ``demo`` applications as part of CI to prevent demos from breaking silently. Tests are located in `tests/core/examples/test_examples.py`. (`#524 <https://github.com/libp2p/py-libp2p/issues/524>`__)
+- Added an example implementation of the identify protocol to demonstrate its usage and help users understand how to properly integrate it into their libp2p applications. (`#536 <https://github.com/libp2p/py-libp2p/issues/536>`__)
 
 
 Internal Changes - for py-libp2p Contributors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- moved all interfaces to ``libp2p.abc`` along with all libp2p custom types to ``libp2p.custom_types``. (`#228 <https://github.com/ethereum/py-libp2p/issues/228>`__)
-- moved ``libp2p/tools/factories`` to ``tests``. (`#503 <https://github.com/ethereum/py-libp2p/issues/503>`__)
-- Fixes broken CI lint run, bumps ``pre-commit-hooks`` version to ``5.0.0`` and ``mdformat`` to ``0.7.22``. (`#522 <https://github.com/ethereum/py-libp2p/issues/522>`__)
-- Rebuilds protobufs with ``protoc v30.1``. (`#542 <https://github.com/ethereum/py-libp2p/issues/542>`__)
-- Moves ``pubsub`` testing tools from ``libp2p.tools`` and ``factories`` from ``tests`` to ``tests.utils``. (`#543 <https://github.com/ethereum/py-libp2p/issues/543>`__)
+- moved all interfaces to ``libp2p.abc`` along with all libp2p custom types to ``libp2p.custom_types``. (`#228 <https://github.com/libp2p/py-libp2p/issues/228>`__)
+- moved ``libp2p/tools/factories`` to ``tests``. (`#503 <https://github.com/libp2p/py-libp2p/issues/503>`__)
+- Fixes broken CI lint run, bumps ``pre-commit-hooks`` version to ``5.0.0`` and ``mdformat`` to ``0.7.22``. (`#522 <https://github.com/libp2p/py-libp2p/issues/522>`__)
+- Rebuilds protobufs with ``protoc v30.1``. (`#542 <https://github.com/libp2p/py-libp2p/issues/542>`__)
+- Moves ``pubsub`` testing tools from ``libp2p.tools`` and ``factories`` from ``tests`` to ``tests.utils``. (`#543 <https://github.com/libp2p/py-libp2p/issues/543>`__)
 
 
 py-libp2p v0.2.2 (2025-02-20)
@@ -79,21 +79,21 @@ py-libp2p v0.2.2 (2025-02-20)
 Bugfixes
 ~~~~~~~~
 
-- - This fix issue #492 adding a missing break statement that lowers GIL usage from 99% to 0%-2%. (`#492 <https://github.com/ethereum/py-libp2p/issues/492>`__)
+- - This fix issue #492 adding a missing break statement that lowers GIL usage from 99% to 0%-2%. (`#492 <https://github.com/libp2p/py-libp2p/issues/492>`__)
 
 
 Features
 ~~~~~~~~
 
-- Create entry points for demos to be run directly from installed package (`#490 <https://github.com/ethereum/py-libp2p/issues/490>`__)
-- Merge template, adding python 3.13 to CI checks. (`#496 <https://github.com/ethereum/py-libp2p/issues/496>`__)
+- Create entry points for demos to be run directly from installed package (`#490 <https://github.com/libp2p/py-libp2p/issues/490>`__)
+- Merge template, adding python 3.13 to CI checks. (`#496 <https://github.com/libp2p/py-libp2p/issues/496>`__)
 
 
 Internal Changes - for py-libp2p Contributors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Drop CI runs for python 3.8, run ``pyupgrade`` to bring code up to python 3.9. (`#497 <https://github.com/ethereum/py-libp2p/issues/497>`__)
-- Rename ``typing.py`` to ``custom_types.py`` for clarity. (`#500 <https://github.com/ethereum/py-libp2p/issues/500>`__)
+- Drop CI runs for python 3.8, run ``pyupgrade`` to bring code up to python 3.9. (`#497 <https://github.com/libp2p/py-libp2p/issues/497>`__)
+- Rename ``typing.py`` to ``custom_types.py`` for clarity. (`#500 <https://github.com/libp2p/py-libp2p/issues/500>`__)
 
 
 py-libp2p v0.2.1 (2024-12-20)
@@ -102,28 +102,28 @@ py-libp2p v0.2.1 (2024-12-20)
 Bugfixes
 ~~~~~~~~
 
-- Added missing check to reject messages claiming to be from ourselves but not locally published in pubsub's ``push_msg`` function (`#413 <https://github.com/ethereum/py-libp2p/issues/413>`__)
-- Added missing check in ``add_addrs`` function for duplicate addresses in ``peerdata`` (`#485 <https://github.com/ethereum/py-libp2p/issues/485>`__)
+- Added missing check to reject messages claiming to be from ourselves but not locally published in pubsub's ``push_msg`` function (`#413 <https://github.com/libp2p/py-libp2p/issues/413>`__)
+- Added missing check in ``add_addrs`` function for duplicate addresses in ``peerdata`` (`#485 <https://github.com/libp2p/py-libp2p/issues/485>`__)
 
 
 Improved Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- added missing details of params in ``IPubsubRouter`` (`#486 <https://github.com/ethereum/py-libp2p/issues/486>`__)
+- added missing details of params in ``IPubsubRouter`` (`#486 <https://github.com/libp2p/py-libp2p/issues/486>`__)
 
 
 Features
 ~~~~~~~~
 
-- Added ``PingService`` class in ``host/ping.py`` which can be used to initiate ping requests to peers and added tests for the same (`#344 <https://github.com/ethereum/py-libp2p/issues/344>`__)
-- Added ``get_connected_peers`` method in class ``IHost`` which can be used to get a list of peer ids of currently connected peers (`#419 <https://github.com/ethereum/py-libp2p/issues/419>`__)
+- Added ``PingService`` class in ``host/ping.py`` which can be used to initiate ping requests to peers and added tests for the same (`#344 <https://github.com/libp2p/py-libp2p/issues/344>`__)
+- Added ``get_connected_peers`` method in class ``IHost`` which can be used to get a list of peer ids of currently connected peers (`#419 <https://github.com/libp2p/py-libp2p/issues/419>`__)
 
 
 Internal Changes - for py-libp2p Contributors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Update ``sphinx_rtd_theme`` options and drop pdf build of docs (`#481 <https://github.com/ethereum/py-libp2p/issues/481>`__)
-- Update ``trio`` package version dependency (`#482 <https://github.com/ethereum/py-libp2p/issues/482>`__)
+- Update ``sphinx_rtd_theme`` options and drop pdf build of docs (`#481 <https://github.com/libp2p/py-libp2p/issues/481>`__)
+- Update ``trio`` package version dependency (`#482 <https://github.com/libp2p/py-libp2p/issues/482>`__)
 
 
 py-libp2p v0.2.0 (2024-07-09)
@@ -132,38 +132,38 @@ py-libp2p v0.2.0 (2024-07-09)
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-- Drop support for ``python<3.8`` (`#447 <https://github.com/ethereum/py-libp2p/issues/447>`__)
-- Drop dep for unmaintained ``async-service`` and copy relevant functions into a local tool of the same name (`#467 <https://github.com/ethereum/py-libp2p/issues/467>`__)
+- Drop support for ``python<3.8`` (`#447 <https://github.com/libp2p/py-libp2p/issues/447>`__)
+- Drop dep for unmaintained ``async-service`` and copy relevant functions into a local tool of the same name (`#467 <https://github.com/libp2p/py-libp2p/issues/467>`__)
 
 
 Improved Documentation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- Move contributing and history info from README to docs (`#454 <https://github.com/ethereum/py-libp2p/issues/454>`__)
-- Display example usage and full code in docs (`#466 <https://github.com/ethereum/py-libp2p/issues/466>`__)
+- Move contributing and history info from README to docs (`#454 <https://github.com/libp2p/py-libp2p/issues/454>`__)
+- Display example usage and full code in docs (`#466 <https://github.com/libp2p/py-libp2p/issues/466>`__)
 
 
 Features
 ~~~~~~~~
 
-- Add basic support for ``python3.8, 3.9, 3.10, 3.11, 3.12`` (`#447 <https://github.com/ethereum/py-libp2p/issues/447>`__)
+- Add basic support for ``python3.8, 3.9, 3.10, 3.11, 3.12`` (`#447 <https://github.com/libp2p/py-libp2p/issues/447>`__)
 
 
 Internal Changes - for py-libp2p Contributors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Merge updates from ethereum python project template, including using ``pre-commit`` for linting, change name of ``master`` branch to ``main``, lots of linting changes (`#447 <https://github.com/ethereum/py-libp2p/issues/447>`__)
-- Fix docs CI, drop ``bumpversion`` for ``bump-my-version``, reorg tests (`#454 <https://github.com/ethereum/py-libp2p/issues/454>`__)
-- Turn ``mypy`` checks on and remove ``async_generator`` dependency (`#464 <https://github.com/ethereum/py-libp2p/issues/464>`__)
-- Convert ``KeyType`` enum to use ``protobuf.KeyType`` options rather than ints, rebuild protobufs to include ``ECC_P256`` (`#465 <https://github.com/ethereum/py-libp2p/issues/465>`__)
-- Bump to ``mypy==1.10.0``, run ``pre-commit`` local hook instead of ``mirrors-mypy`` (`#472 <https://github.com/ethereum/py-libp2p/issues/472>`__)
-- Bump ``protobufs`` dep to ``>=5.27.2`` and rebuild protobuf definition with ``protoc==27.2`` (`#473 <https://github.com/ethereum/py-libp2p/issues/473>`__)
+- Merge updates from ethereum python project template, including using ``pre-commit`` for linting, change name of ``master`` branch to ``main``, lots of linting changes (`#447 <https://github.com/libp2p/py-libp2p/issues/447>`__)
+- Fix docs CI, drop ``bumpversion`` for ``bump-my-version``, reorg tests (`#454 <https://github.com/libp2p/py-libp2p/issues/454>`__)
+- Turn ``mypy`` checks on and remove ``async_generator`` dependency (`#464 <https://github.com/libp2p/py-libp2p/issues/464>`__)
+- Convert ``KeyType`` enum to use ``protobuf.KeyType`` options rather than ints, rebuild protobufs to include ``ECC_P256`` (`#465 <https://github.com/libp2p/py-libp2p/issues/465>`__)
+- Bump to ``mypy==1.10.0``, run ``pre-commit`` local hook instead of ``mirrors-mypy`` (`#472 <https://github.com/libp2p/py-libp2p/issues/472>`__)
+- Bump ``protobufs`` dep to ``>=5.27.2`` and rebuild protobuf definition with ``protoc==27.2`` (`#473 <https://github.com/libp2p/py-libp2p/issues/473>`__)
 
 
 Removals
 ~~~~~~~~
 
-- Drop ``async-exit-stack`` dep, as of py37 can import ``AsyncExitStack`` from contextlib, also open ``pynacl`` dep to bottom pin only (`#468 <https://github.com/ethereum/py-libp2p/issues/468>`__)
+- Drop ``async-exit-stack`` dep, as of py37 can import ``AsyncExitStack`` from contextlib, also open ``pynacl`` dep to bottom pin only (`#468 <https://github.com/libp2p/py-libp2p/issues/468>`__)
 
 
 libp2p v0.1.5 (2020-03-25)

--- a/newsfragments/561.feature.rst
+++ b/newsfragments/561.feature.rst
@@ -1,0 +1,1 @@
+Added AutoNAT protocol

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,10 @@ markers = ["slow: mark test as slow"]
 xfail_strict = true
 
 [tool.towncrier]
-# Read https://github.com/ethereum/py-libp2p/blob/main/newsfragments/README.md for instructions
+# Read https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md for instructions
 directory = "newsfragments"
 filename = "docs/release_notes.rst"
-issue_format = "`#{issue} <https://github.com/ethereum/py-libp2p/issues/{issue}>`__"
+issue_format = "`#{issue} <https://github.com/libp2p/py-libp2p/issues/{issue}>`__"
 package = "libp2p"
 title_format = "py-libp2p v{version} ({project_date})"
 underlines = ["-", "~", "^"]


### PR DESCRIPTION
## What was wrong?

Towncrier config used `ethereum` instead of `libp2p` in its generated links, making them all broken.

## How was it fixed?

Fixed towncrier config in `pyproject.toml` and updated all broken links in `release_notes`.
Added a missing newsfragment for adding AutoNAT - #561 

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/6e0ab427-ecc8-4ac9-a92d-4750b781de17)
