### PR TITLE
Implemented multi-error handling in MultiError() class

### DIFF
--- a/libp2p/exceptions.py
+++ b/libp2p/exceptions.py
@@ -1,5 +1,5 @@
-from typing import (
-    Any,
+from collections.abc import (
+    Sequence,
 )
 
 
@@ -16,9 +16,33 @@ class ParseError(BaseLibp2pError):
 
 
 class MultiError(BaseLibp2pError):
-    """Raised with multiple exceptions."""
+    """
+    A combined error that wraps multiple exceptions into a single error object.
+    This error is raised when multiple exceptions need to be reported together,
+    typically in scenarios where parallel operations or multiple validations fail.
 
-    def __init__(self, errors: list[Any]) -> None:
+    Example:
+    -------
+        >>> errors = [
+        ...     ValueError("Invalid input"),
+        ...     TypeError("Wrong type"),
+        ...     RuntimeError("Operation failed")
+        ... ]
+        >>> multi_error = MultiError(errors)
+        >>> print(multi_error)
+        Error 1: Invalid input
+        Error 2: Wrong type
+        Error 3: Operation failed
+
+    Note:
+    ----
+        The string representation of this error will number and list all contained
+        errors sequentially, making it easier to identify individual issues in
+        complex error scenarios.
+
+    """
+
+    def __init__(self, errors: Sequence[Exception]) -> None:
         super().__init__(errors)
         self.errors = errors  # Storing list of errors
 

--- a/libp2p/exceptions.py
+++ b/libp2p/exceptions.py
@@ -16,13 +16,14 @@ class ParseError(BaseLibp2pError):
 
 
 class MultiError(BaseLibp2pError):
-    """
+    r"""
     A combined error that wraps multiple exceptions into a single error object.
     This error is raised when multiple exceptions need to be reported together,
     typically in scenarios where parallel operations or multiple validations fail.
 
-    Example:
-    -------
+    Example\:
+    ---------
+        >>> from libp2p.exceptions import MultiError
         >>> errors = [
         ...     ValueError("Invalid input"),
         ...     TypeError("Wrong type"),
@@ -34,8 +35,8 @@ class MultiError(BaseLibp2pError):
         Error 2: Wrong type
         Error 3: Operation failed
 
-    Note:
-    ----
+    Note\:
+    ------
         The string representation of this error will number and list all contained
         errors sequentially, making it easier to identify individual issues in
         complex error scenarios.

--- a/libp2p/exceptions.py
+++ b/libp2p/exceptions.py
@@ -1,3 +1,8 @@
+from typing import (
+    Any,
+)
+
+
 class BaseLibp2pError(Exception):
     pass
 
@@ -13,4 +18,11 @@ class ParseError(BaseLibp2pError):
 class MultiError(BaseLibp2pError):
     """Raised with multiple exceptions."""
 
-    # todo: find some way for this to fancy-print all encapsulated errors
+    def __init__(self, errors: list[Any]) -> None:
+        super().__init__(errors)
+        self.errors = errors  # Storing list of errors
+
+    def __str__(self) -> str:
+        return "\n".join(
+            f"Error {i + 1}: {error}" for i, error in enumerate(self.errors)
+        )

--- a/newsfragments/613.feature.rst
+++ b/newsfragments/613.feature.rst
@@ -1,0 +1,1 @@
+Added support for multiple-error formatting in the `MultiError` class.

--- a/tests/exceptions/test_exceptions.py
+++ b/tests/exceptions/test_exceptions.py
@@ -1,0 +1,13 @@
+from libp2p.exceptions import (
+    MultiError,
+)
+
+
+def test_multierror_str_and_storage():
+    errors = [ValueError("bad value"), KeyError("missing key"), "custom error"]
+    multi_error = MultiError(errors)
+    # Check for storage
+    assert multi_error.errors == errors
+    # Check for representation
+    expected = "Error 1: bad value\n" "Error 2: 'missing key'\n" "Error 3: custom error"
+    assert str(multi_error) == expected


### PR DESCRIPTION
## What was wrong?
Issue #613 

## How was it fixed?
This pull request enhances error handling in the `libp2p/exceptions.py` file by improving the `MultiError` class to provide better error representation and adding type annotations for clarity.

### Error handling improvements:

* [`libp2p/exceptions.py`](diffhunk://#diff-c8448095566bd3d3635fec680d89f4c78c3113d85029e0841a471866fce06ecbL16-R28): Updated the `MultiError` class to include an `__init__` method for storing a list of errors and a `__str__` method for formatted error representation. This allows the class to print all encapsulated errors in a user-friendly format.

### Code clarity:

* [`libp2p/exceptions.py`](diffhunk://#diff-c8448095566bd3d3635fec680d89f4c78c3113d85029e0841a471866fce06ecbL16-R28): Added type annotations to the `MultiError` class, specifying that the `errors` parameter is a list of `Any` type. This improves code readability and ensures better type checking.
* [`libp2p/exceptions.py`](diffhunk://#diff-c8448095566bd3d3635fec680d89f4c78c3113d85029e0841a471866fce06ecbR1-R5): Imported `Any` from the `typing` module to support the new type annotations.
Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![cute animal image](https://compote.slate.com/images/73f0857e-2a1a-4fea-b97a-bd4c241c01f5.jpg)
