### PR TITLE
TODO: Handle `ls` command in `multiselect.py`

### DIFF
--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -60,8 +60,14 @@ class Multiselect(IMultiselectMuxer):
                 raise MultiselectError() from error
 
             if command == "ls":
-                # TODO: handle ls command
-                pass
+                supported_protocols = list(self.handlers.keys())
+                response = "\n".join(supported_protocols) + "\n"
+
+                try:
+                    await communicator.write(response)
+                except MultiselectCommunicatorError as error:
+                    raise MultiselectError() from error
+
             else:
                 protocol = TProtocol(command)
                 if protocol in self.handlers:

--- a/newsfragments/622.feature.rst
+++ b/newsfragments/622.feature.rst
@@ -1,0 +1,2 @@
+Feature: Support for sending `ls` command over `multistream-select` to list supported protocols from remote peer.
+This allows inspecting which protocol handlers a peer supports at runtime.


### PR DESCRIPTION
Added utility functions for handling `ls` command in `libp2p/protocol_muxer/multiselect.py` here: [TODO: handle ls command](https://github.com/libp2p/py-libp2p/blob/18c6f529c688e9b02a8323e9b9d7a1daa9a60052/libp2p/protocol_muxer/multiselect.py#L62C1-L65C9), to send the list of all supported protocols by the listener to dialer. 

@seetadev @pacrob @acul71 