### PR TITLE
fix: Resolved type-checking error in PubSub example test.

### DIFF
--- a/tests/core/examples/test_examples.py
+++ b/tests/core/examples/test_examples.py
@@ -209,8 +209,8 @@ async def ping_demo(host_a, host_b):
 
 
 async def pubsub_demo(host_a, host_b):
-    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 0.1, 1)
-    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 0.1, 1)
+    gossipsub_a = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 1, 1)
+    gossipsub_b = GossipSub([GOSSIPSUB_PROTOCOL_ID], 3, 2, 4, None, 1, 1)
     pubsub_a = Pubsub(host_a, gossipsub_a)
     pubsub_b = Pubsub(host_b, gossipsub_b)
     message_a_to_b = "Hello from A to B"


### PR DESCRIPTION
## What was wrong?

There was a type check error in the test file of the pubsub example—a float value was passed where an integer was expected when creating a Gossipsub object.

## How was it fixed?

The float value was replaced with an integer to satisfy the type check requirements during the creation of the Gossipsub object in the test file.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<https://www.shutterstock.com/shutterstock/photos/2282926633/display_1500/stock-photo-portrait-of-a-cat-with-the-fashionable-dressing-wearing-sunglasses-2282926633.jpg>)
