### PR TITLE
feat: implement AsyncContextManager for IMuxedStream to support async…

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -8,10 +8,14 @@ from collections.abc import (
     KeysView,
     Sequence,
 )
+from types import (
+    TracebackType,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
     AsyncContextManager,
+    Optional,
 )
 
 from multiaddr import (
@@ -215,7 +219,7 @@ class IMuxedConn(ABC):
         """
 
 
-class IMuxedStream(ReadWriteCloser):
+class IMuxedStream(ReadWriteCloser, AsyncContextManager["IMuxedStream"]):
     """
     Interface for a multiplexed stream.
 
@@ -248,6 +252,20 @@ class IMuxedStream(ReadWriteCloser):
         :return: True if the deadline was set successfully,
             otherwise False.
         """
+
+    @abstractmethod
+    async def __aenter__(self) -> "IMuxedStream":
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Exit the async context manager and close the stream."""
+        await self.close()
 
 
 # -------------------------- net_stream interface.py --------------------------

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -1,3 +1,6 @@
+from types import (
+    TracebackType,
+)
 from typing import (
     TYPE_CHECKING,
     Optional,
@@ -257,3 +260,16 @@ class MplexStream(IMuxedStream):
     def get_remote_address(self) -> Optional[tuple[str, int]]:
         """Delegate to the parent Mplex connection."""
         return self.muxed_conn.get_remote_address()
+
+    async def __aenter__(self) -> "MplexStream":
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Exit the async context manager and close the stream."""
+        await self.close()

--- a/libp2p/stream_muxer/yamux/yamux.py
+++ b/libp2p/stream_muxer/yamux/yamux.py
@@ -9,6 +9,9 @@ from collections.abc import (
 import inspect
 import logging
 import struct
+from types import (
+    TracebackType,
+)
 from typing import (
     Callable,
     Optional,
@@ -73,6 +76,19 @@ class YamuxStream(IMuxedStream):
         self.send_window = DEFAULT_WINDOW_SIZE
         self.recv_window = DEFAULT_WINDOW_SIZE
         self.window_lock = trio.Lock()
+
+    async def __aenter__(self) -> "YamuxStream":
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """Exit the async context manager and close the stream."""
+        await self.close()
 
     async def write(self, data: bytes) -> None:
         if self.send_closed:

--- a/tests/stream_muxer/test_async_context_manager.py
+++ b/tests/stream_muxer/test_async_context_manager.py
@@ -1,0 +1,127 @@
+import pytest
+import trio
+
+from libp2p.stream_muxer.exceptions import (
+    MuxedStreamClosed,
+    MuxedStreamError,
+)
+from libp2p.stream_muxer.mplex.datastructures import (
+    StreamID,
+)
+from libp2p.stream_muxer.mplex.mplex_stream import (
+    MplexStream,
+)
+from libp2p.stream_muxer.yamux.yamux import (
+    YamuxStream,
+)
+
+
+class DummySecuredConn:
+    async def write(self, data):
+        pass
+
+
+class MockMuxedConn:
+    def __init__(self):
+        self.streams = {}
+        self.streams_lock = trio.Lock()
+        self.event_shutting_down = trio.Event()
+        self.event_closed = trio.Event()
+        self.event_started = trio.Event()
+        self.secured_conn = DummySecuredConn()  # For YamuxStream
+
+    async def send_message(self, flag, data, stream_id):
+        pass
+
+    def get_remote_address(self):
+        return None
+
+
+@pytest.mark.trio
+async def test_mplex_stream_async_context_manager():
+    muxed_conn = MockMuxedConn()
+    stream_id = StreamID(1, True)  # Use real StreamID
+    stream = MplexStream(
+        name="test_stream",
+        stream_id=stream_id,
+        muxed_conn=muxed_conn,
+        incoming_data_channel=trio.open_memory_channel(8)[1],
+    )
+    async with stream as s:
+        assert s is stream
+        assert not stream.event_local_closed.is_set()
+        assert not stream.event_remote_closed.is_set()
+        assert not stream.event_reset.is_set()
+    assert stream.event_local_closed.is_set()
+
+
+@pytest.mark.trio
+async def test_yamux_stream_async_context_manager():
+    muxed_conn = MockMuxedConn()
+    stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
+    async with stream as s:
+        assert s is stream
+        assert not stream.closed
+        assert not stream.send_closed
+        assert not stream.recv_closed
+    assert stream.send_closed
+
+
+@pytest.mark.trio
+async def test_mplex_stream_async_context_manager_with_error():
+    muxed_conn = MockMuxedConn()
+    stream_id = StreamID(1, True)
+    stream = MplexStream(
+        name="test_stream",
+        stream_id=stream_id,
+        muxed_conn=muxed_conn,
+        incoming_data_channel=trio.open_memory_channel(8)[1],
+    )
+    with pytest.raises(ValueError):
+        async with stream as s:
+            assert s is stream
+            assert not stream.event_local_closed.is_set()
+            assert not stream.event_remote_closed.is_set()
+            assert not stream.event_reset.is_set()
+            raise ValueError("Test error")
+    assert stream.event_local_closed.is_set()
+
+
+@pytest.mark.trio
+async def test_yamux_stream_async_context_manager_with_error():
+    muxed_conn = MockMuxedConn()
+    stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
+    with pytest.raises(ValueError):
+        async with stream as s:
+            assert s is stream
+            assert not stream.closed
+            assert not stream.send_closed
+            assert not stream.recv_closed
+            raise ValueError("Test error")
+    assert stream.send_closed
+
+
+@pytest.mark.trio
+async def test_mplex_stream_async_context_manager_write_after_close():
+    muxed_conn = MockMuxedConn()
+    stream_id = StreamID(1, True)
+    stream = MplexStream(
+        name="test_stream",
+        stream_id=stream_id,
+        muxed_conn=muxed_conn,
+        incoming_data_channel=trio.open_memory_channel(8)[1],
+    )
+    async with stream as s:
+        assert s is stream
+    with pytest.raises(MuxedStreamClosed):
+        await stream.write(b"test data")
+
+
+@pytest.mark.trio
+async def test_yamux_stream_async_context_manager_write_after_close():
+    muxed_conn = MockMuxedConn()
+    stream = YamuxStream(stream_id=1, conn=muxed_conn, is_initiator=True)
+    async with stream as s:
+        assert s is stream
+    with pytest.raises(MuxedStreamError):
+        await stream.write(b"test data")


### PR DESCRIPTION
# Async Context Manager for IMuxedStream

## Issue Overview

[Issue #414](https://github.com/libp2p/py-libp2p/issues/414) proposed implementing the `AsyncContextManager` protocol for `IMuxedStream` to improve stream handling ergonomics. The goal was to allow automatic closure of streams when the consumer is finished, similar to how file handles are managed in Python.

## Implementation Details

### Interface Changes

The `IMuxedStream` interface in `libp2p/abc.py` was updated to implement `AsyncContextManager`:

```python
class IMuxedStream(ReadWriteCloser, AsyncContextManager["IMuxedStream"]):
    muxed_conn: IMuxedConn

    async def __aenter__(self) -> "IMuxedStream":
        """Enter the async context manager."""
        return self

    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
        """Exit the async context manager and close the stream."""
        await self.close()
```

### Implementation in Stream Classes

Both `MplexStream` and `YamuxStream` implement the async context manager methods:

```python
# In MplexStream
async def __aenter__(self) -> "MplexStream":
    """Enter the async context manager."""
    return self

async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
    """Exit the async context manager and close the stream."""
    await self.close()

# In YamuxStream
async def __aenter__(self) -> "YamuxStream":
    """Enter the async context manager."""
    return self

async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
    """Exit the async context manager and close the stream."""
    await self.close()
```

## Testing

The implementation is thoroughly tested in `tests/stream_muxer/test_async_context_manager.py`. The test suite covers:

1. **Basic Context Manager Usage**
   - Verifies that streams can be used with `async with`
   - Ensures streams are properly closed after context exit

2. **Error Handling**
   - Tests that streams are closed even when exceptions occur
   - Verifies that writing to a closed stream raises the correct exception

3. **Stream Types**
   - Tests both `MplexStream` and `YamuxStream` implementations
   - Uses proper mocks to simulate real connection behavior

## Usage Examples

### Basic Usage

```python
async with await muxed_conn.open_stream() as stream:
    # Write data to the stream
    await stream.write(b"Hello, World!")
    # Read data from the stream
    data = await stream.read(1024)
# Stream is automatically closed here
```

### Error Handling

```python
try:
    async with await muxed_conn.open_stream() as stream:
        await stream.write(b"Hello")
        raise Exception("Something went wrong")
except Exception:
    # Stream is automatically closed, even though an exception occurred
    pass
```

### Multiple Streams

```python
async with await muxed_conn.open_stream() as stream1:
    async with await muxed_conn.open_stream() as stream2:
        await stream1.write(b"Hello from stream 1")
        await stream2.write(b"Hello from stream 2")
# Both streams are automatically closed
```

## Benefits

1. **Resource Management**: Streams are automatically closed when no longer needed
2. **Clean Code**: Reduces boilerplate code for stream management
3. **Error Safety**: Ensures streams are closed even when exceptions occur
4. **Consistency**: Follows Python's async context manager protocol
5. **Compatibility**: Maintains backward compatibility with existing code

## Implementation Notes

- The implementation is minimal and focused on adding async context manager support
- Existing stream behavior remains unchanged
- Both `MplexStream` and `YamuxStream` implementations are consistent
- The feature is fully tested and ready for production use

## Future Considerations

1. **Integration Testing**: Add tests with real network connections
2. **Performance Monitoring**: Track stream closure and resource cleanup
3. **Documentation**: Add more examples and use cases
4. **Error Handling**: Consider adding more specific error types for stream operations 
