### PR TITLE
add make pr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "package-test - build package and install it in a venv for manual testing"
 	@echo "notes - consume towncrier newsfragments and update release notes in docs - requires bump to be set"
 	@echo "release - package and upload a release (does not run notes target) - requires bump to be set"
+	@echo "pr - run clean, fix, lint, typecheck, and test i.e basically everything you need to do before creating a PR"
 
 clean-build:
 	rm -fr build/
@@ -46,6 +47,8 @@ typecheck:
 
 test:
 	python -m pytest tests -n auto
+
+pr: clean fix lint typecheck test
 
 # protobufs management
 


### PR DESCRIPTION
## What was wrong?

This PR introduces a convenience target for preparing pull requests. Previously, developers had to manually run multiple separate commands (make clean, make fix, make lint, make typecheck, make test) before creating a PR, which was tedious and easy to forget steps.

## How was it fixed?

Added a new make pr target that combines all the necessary pre-PR checks into a single command. 

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
