### PR TITLE
remove references to removed setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ validate-newsfragments:
 check-docs: build-docs validate-newsfragments
 
 build-docs:
-	sphinx-apidoc -o docs/ . setup.py "*conftest*" tests/
+	sphinx-apidoc -o docs/ . "*conftest*" tests/
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,12 +221,7 @@ values = ["alpha", "beta", "stable"]
 [tool.bumpversion.part.devnum]
 
 [[tool.bumpversion.files]]
-filename = "setup.py"
-search = "version=\"{current_version}\""
-replace = "version=\"{new_version}\""
-
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"              # Keep pyproject.toml version in sync
+filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
 


### PR DESCRIPTION
## What was wrong?

A couple references to `setup.py` were not removed, blocking release.

## How was it fixed?

Removed refs

### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/907ef92b-349a-4275-bf02-67bb6a1a9d7a)
