### PR TITLE
fix: removed dummy ID(b) from upgrade_security for inbound connections

### DIFF
--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -257,7 +257,6 @@ class Swarm(Service, INetworkService):
                 # Per, https://discuss.libp2p.io/t/multistream-security/130, we first
                 # secure the conn and then mux the conn
                 try:
-                    # FIXME: This dummy `ID(b"")` for the remote peer is useless.
                     secured_conn = await self.upgrader.upgrade_security(raw_conn, False)
                 except SecurityUpgradeFailure as error:
                     logger.debug("failed to upgrade security for peer at %s", maddr)

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -187,7 +187,7 @@ class Swarm(Service, INetworkService):
         # Per, https://discuss.libp2p.io/t/multistream-security/130, we first secure
         # the conn and then mux the conn
         try:
-            secured_conn = await self.upgrader.upgrade_security(raw_conn, peer_id, True)
+            secured_conn = await self.upgrader.upgrade_security(raw_conn, True, peer_id)
         except SecurityUpgradeFailure as error:
             logger.debug("failed to upgrade security for peer %s", peer_id)
             await raw_conn.close()
@@ -258,9 +258,7 @@ class Swarm(Service, INetworkService):
                 # secure the conn and then mux the conn
                 try:
                     # FIXME: This dummy `ID(b"")` for the remote peer is useless.
-                    secured_conn = await self.upgrader.upgrade_security(
-                        raw_conn, ID(b""), False
-                    )
+                    secured_conn = await self.upgrader.upgrade_security(raw_conn, False)
                 except SecurityUpgradeFailure as error:
                     logger.debug("failed to upgrade security for peer at %s", maddr)
                     await raw_conn.close()

--- a/libp2p/transport/upgrader.py
+++ b/libp2p/transport/upgrader.py
@@ -48,11 +48,16 @@ class TransportUpgrader:
         # TODO: Figure out what to do with this function.
 
     async def upgrade_security(
-        self, raw_conn: IRawConnection, peer_id: ID, is_initiator: bool
+        self,
+        raw_conn: IRawConnection,
+        is_initiator: bool,
+        peer_id: ID | None = None,
     ) -> ISecureConn:
         """Upgrade conn to a secured connection."""
         try:
             if is_initiator:
+                if peer_id is None:
+                    raise ValueError("peer_id must be provided for outbout connection")
                 return await self.security_multistream.secure_outbound(
                     raw_conn, peer_id
                 )

--- a/newsfragments/681.breaking.rst
+++ b/newsfragments/681.breaking.rst
@@ -1,0 +1,2 @@
+Reordered the arguments to `upgrade_security` to place `is_initiator` before `peer_id`, and made `peer_id` optional.
+This allows the method to reflect the fact that peer identity is not required for inbound connections.

--- a/newsfragments/681.internal.rst
+++ b/newsfragments/681.internal.rst
@@ -1,0 +1,1 @@
+removed dummy ID(b"") from upgrade_security for inbound connections

--- a/newsfragments/681.internal.rst
+++ b/newsfragments/681.internal.rst
@@ -1,1 +1,0 @@
-removed dummy ID(b"") from upgrade_security for inbound connections


### PR DESCRIPTION
### Resolved: FIXME: This dummy `ID(b"")` for the remote peer is useless.
Updated peer_id from `ID` to `Optional[ID] = None` in `transport/upgrader.py:upgrade_security()`.

@seetadev 