### PR TITLE
fix: replace complex logic with decapsulate

### DIFF
--- a/newsfragments/684.misc.rst
+++ b/newsfragments/684.misc.rst
@@ -1,0 +1,1 @@
+Uses the `decapsulate` method of the `Multiaddr` class to clean up the observed address.

--- a/tests/core/identity/identify/test_identify.py
+++ b/tests/core/identity/identify/test_identify.py
@@ -56,16 +56,9 @@ async def test_identify_protocol(security_protocol):
         )
 
         # Check observed address
-        # TODO: use decapsulateCode(protocols('p2p').code)
-        # when the Multiaddr class will implement it
         host_b_addr = host_b.get_addrs()[0]
-        cleaned_addr = Multiaddr.join(
-            *(
-                host_b_addr.split()[:-1]
-                if str(host_b_addr.split()[-1]).startswith("/p2p/")
-                else host_b_addr.split()
-            )
-        )
+        host_b_peer_id = host_b.get_id()
+        cleaned_addr = host_b_addr.decapsulate(Multiaddr(f"/p2p/{host_b_peer_id}"))
 
         logger.debug("observed_addr: %s", Multiaddr(identify_response.observed_addr))
         logger.debug("host_b.get_addrs()[0]: %s", host_b.get_addrs()[0])


### PR DESCRIPTION
## What was wrong?

This pr replaces the complex logic and uses the decapsulate method in Multiaddr

## How was it fixed?

delete the complex logic and use decapsulate method
### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

cc: @seetadev 