### PR TITLE
chore(kad_dht): centralize shared values in common.py file

### DIFF
--- a/libp2p/kad_dht/common.py
+++ b/libp2p/kad_dht/common.py
@@ -1,0 +1,10 @@
+from libp2p.custom_types import (
+    TProtocol,
+)
+
+# Constants for the Kademlia algorithm
+ALPHA = 3  # Concurrency parameter
+PROTOCOL_ID = TProtocol("/ipfs/kad/1.0.0")
+QUERY_TIMEOUT = 10
+
+TTL = DEFAULT_TTL = 24 * 60 * 60 # 24 hours in seconds

--- a/libp2p/kad_dht/kad_dht.py
+++ b/libp2p/kad_dht/kad_dht.py
@@ -49,16 +49,16 @@ from .routing_table import (
 from .value_store import (
     ValueStore,
 )
+from .common import (
+    PROTOCOL_ID,
+    ALPHA,
+    QUERY_TIMEOUT
+)
 
 logger = logging.getLogger("kademlia-example.kad_dht")
 # logger = logging.getLogger("libp2p.kademlia")
 # Default parameters
-PROTOCOL_ID = TProtocol("/ipfs/kad/1.0.0")
-ROUTING_TABLE_REFRESH_INTERVAL = 1 * 60  # 1 min in seconds for testing
-TTL = 24 * 60 * 60  # 24 hours in seconds
-ALPHA = 3
-QUERY_TIMEOUT = 10  # seconds
-
+ROUTING_TABLE_REFRESH_INTERVAL = 60  # 1 min in seconds for testing
 
 class DHTMode(Enum):
     """DHT operation modes."""

--- a/libp2p/kad_dht/peer_routing.py
+++ b/libp2p/kad_dht/peer_routing.py
@@ -25,11 +25,16 @@ from libp2p.peer.peerinfo import (
     PeerInfo,
 )
 
+
 from .pb.kademlia_pb2 import (
     Message,
 )
 from .routing_table import (
     RoutingTable,
+)
+from .common import (
+    PROTOCOL_ID,
+    ALPHA
 )
 from .utils import (
     sort_peer_ids_by_distance,
@@ -38,10 +43,7 @@ from .utils import (
 # logger = logging.getLogger("libp2p.kademlia.peer_routing")
 logger = logging.getLogger("kademlia-example.peer_routing")
 
-# Constants for the Kademlia algorithm
-ALPHA = 3  # Concurrency parameter
 MAX_PEER_LOOKUP_ROUNDS = 20  # Maximum number of rounds in peer lookup
-PROTOCOL_ID = TProtocol("/ipfs/kad/1.0.0")
 
 
 class PeerRouting(IPeerRouting):

--- a/libp2p/kad_dht/peer_routing.py
+++ b/libp2p/kad_dht/peer_routing.py
@@ -15,9 +15,6 @@ from libp2p.abc import (
     INetStream,
     IPeerRouting,
 )
-from libp2p.custom_types import (
-    TProtocol,
-)
 from libp2p.peer.id import (
     ID,
 )

--- a/libp2p/kad_dht/provider_store.py
+++ b/libp2p/kad_dht/provider_store.py
@@ -33,6 +33,12 @@ from .pb.kademlia_pb2 import (
     Message,
 )
 
+from .common import (
+    PROTOCOL_ID,
+    ALPHA,
+    QUERY_TIMEOUT
+)
+
 # logger = logging.getLogger("libp2p.kademlia.provider_store")
 logger = logging.getLogger("kademlia-example.provider_store")
 
@@ -40,9 +46,6 @@ logger = logging.getLogger("kademlia-example.provider_store")
 PROVIDER_RECORD_REPUBLISH_INTERVAL = 22 * 60 * 60  # 22 hours in seconds
 PROVIDER_RECORD_EXPIRATION_INTERVAL = 48 * 60 * 60  # 48 hours in seconds
 PROVIDER_ADDRESS_TTL = 30 * 60  # 30 minutes in seconds
-PROTOCOL_ID = TProtocol("/ipfs/kad/1.0.0")
-ALPHA = 3  # Number of parallel queries/advertisements
-QUERY_TIMEOUT = 10  # Timeout for each query in seconds
 
 
 class ProviderRecord:

--- a/libp2p/kad_dht/value_store.py
+++ b/libp2p/kad_dht/value_store.py
@@ -23,13 +23,13 @@ from .pb.kademlia_pb2 import (
     Message,
 )
 
+from .common import (
+    PROTOCOL_ID,
+    DEFAULT_TTL
+)
+
 # logger = logging.getLogger("libp2p.kademlia.value_store")
 logger = logging.getLogger("kademlia-example.value_store")
-
-# Default time to live for values in seconds (24 hours)
-DEFAULT_TTL = 24 * 60 * 60
-PROTOCOL_ID = TProtocol("/ipfs/kad/1.0.0")
-
 
 class ValueStore:
     """


### PR DESCRIPTION
### What was wrong?

The kad_dht module contained repeated definitions of commonly used variables, leading to redundancy and reduced maintainability.

### How was it fixed?

A new common.py file was introduced to centralize shared default values and constants, promoting reuse and improving code clarity.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://github.com/user-attachments/assets/8a0015e7-f910-4546-b556-38026fe7b851)
