### PR TITLE
Remove piggyback TODO from gossipsub

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -251,7 +251,6 @@ class GossipSub(IPubsubRouter, Service):
             stream = self.pubsub.peers[peer_id]
             # FIXME: We should add a `WriteMsg` similar to write delimited messages.
             #   Ref: https://github.com/libp2p/go-libp2p-pubsub/blob/master/comm.go#L107
-            # TODO: Go use `sendRPC`, which possibly piggybacks gossip/control messages.
             try:
                 await stream.write(encode_varint_prefixed(rpc_msg.SerializeToString()))
             except StreamClosed:
@@ -459,8 +458,8 @@ class GossipSub(IPubsubRouter, Service):
             self.fanout_heartbeat()
             # Get the peers to send IHAVE to
             peers_to_gossip = self.gossip_heartbeat()
-            # Pack GRAFT, PRUNE and IHAVE for the same peer into one control message and
-            # send it
+            # Pack(piggyback) GRAFT, PRUNE and IHAVE for the same peer into
+            # one control message and send it
             await self._emit_control_msgs(
                 peers_to_graft, peers_to_prune, peers_to_gossip
             )


### PR DESCRIPTION
## What was wrong?
This issue was intended to fix the `TODO` in the gossipsub module to implement piggybacking. But later found out the code is already there.  

Issue #https://github.com/libp2p/py-libp2p/issues/692

## How was it fixed?
Removed the `TODO` tag from the module and added a comment pointing to piggyback implementation.

Summary of approach.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://mystickermania.com/cdn/stickers/cute/cute-penguin-knife-512x512.png)
