### PR TITLE
Added tests for identify push concurrency cap under high peer load

### DIFF
--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -176,10 +176,7 @@ async def push_identify_to_peers(
     host: IHost,
     peer_ids: set[ID] | None = None,
     observed_multiaddr: Multiaddr | None = None,
-    counter: dict[str, int] | None = None,
-    lock: trio.Lock | None = None,
-    limit: int = CONCURRENCY_LIMIT,
-) -> int:  # <-- return the max concurrency
+) -> None:
     """
     Push an identify message to multiple peers in parallel.
 
@@ -193,6 +190,4 @@ async def push_identify_to_peers(
     # limiting concurrent connections to 10
     async with trio.open_nursery() as nursery:
         for peer_id in peer_ids:
-            nursery.start_soon(limited_push, peer_id)
-
-    return counter["max"] if counter else 0
+            nursery.start_soon(push_identify_to_peer, host, peer_id, observed_multiaddr)

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -190,4 +190,4 @@ async def push_identify_to_peers(
     # limiting concurrent connections to 10
     async with trio.open_nursery() as nursery:
         for peer_id in peer_ids:
-            nursery.start_soon(push_identify_to_peer, host, peer_id, observed_multiaddr)
+            nursery.start_soon(limited_push, peer_id)

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -176,7 +176,9 @@ async def push_identify_to_peers(
     host: IHost,
     peer_ids: set[ID] | None = None,
     observed_multiaddr: Multiaddr | None = None,
-) -> None:
+    counter: dict[str, int] | None = None,
+    lock: trio.Lock | None = None,
+) -> int:  # <-- return the max concurrency
     """
     Push an identify message to multiple peers in parallel.
 
@@ -191,3 +193,5 @@ async def push_identify_to_peers(
     async with trio.open_nursery() as nursery:
         for peer_id in peer_ids:
             nursery.start_soon(limited_push, peer_id)
+
+    return counter["max"] if counter else 0

--- a/libp2p/identity/identify_push/identify_push.py
+++ b/libp2p/identity/identify_push/identify_push.py
@@ -178,6 +178,7 @@ async def push_identify_to_peers(
     observed_multiaddr: Multiaddr | None = None,
     counter: dict[str, int] | None = None,
     lock: trio.Lock | None = None,
+    limit: int = CONCURRENCY_LIMIT,
 ) -> int:  # <-- return the max concurrency
     """
     Push an identify message to multiple peers in parallel.

--- a/newsfragments/708.performance.rst
+++ b/newsfragments/708.performance.rst
@@ -1,0 +1,2 @@
+Limit concurrency in `push_identify_to_peers` to prevent resource exhaustion under high peer counts.
+This makes peer communication more stable and efficient, especially at scale.

--- a/newsfragments/708.performance.rst
+++ b/newsfragments/708.performance.rst
@@ -1,2 +1,1 @@
-Limit concurrency in `push_identify_to_peers` to prevent resource exhaustion under high peer counts.
-This makes peer communication more stable and efficient, especially at scale.
+Added extra tests for identify push concurrency cap under high peer load

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -10,7 +10,6 @@ import trio
 from libp2p import (
     new_host,
 )
-from libp2p.abc import IHost
 from libp2p.crypto.secp256k1 import (
     create_new_key_pair,
 )
@@ -36,6 +35,8 @@ from tests.utils.factories import (
 )
 from tests.utils.utils import (
     create_mock_connections,
+    run_host_forever,
+    wait_until_listening,
 )
 
 logger = logging.getLogger("libp2p.identity.identify-push-test")
@@ -504,3 +505,91 @@ async def test_push_identify_to_peers_respects_concurrency_limit():
     assert state["max_observed"] <= CONCURRENCY_LIMIT, (
         f"Max concurrency observed: {state['max_observed']}"
     )
+
+
+@pytest.mark.trio
+async def test_all_peers_receive_identify_push_with_semaphore(security_protocol):
+    dummy_peers = []
+
+    async with host_pair_factory(security_protocol=security_protocol) as (host_a, _):
+        # Create dummy peers
+        for _ in range(50):
+            key_pair = create_new_key_pair()
+            dummy_host = new_host(key_pair=key_pair)
+            dummy_host.set_stream_handler(
+                ID_PUSH, identify_push_handler_for(dummy_host)
+            )
+            listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+            dummy_peers.append((dummy_host, listen_addr))
+
+        async with trio.open_nursery() as nursery:
+            # Start all dummy hosts
+            for host, listen_addr in dummy_peers:
+                nursery.start_soon(run_host_forever, host, listen_addr)
+
+            # Wait for all hosts to finish setting up listeners
+            for host, _ in dummy_peers:
+                await wait_until_listening(host)
+
+            # Now connect host_a → dummy peers
+            for host, _ in dummy_peers:
+                await host_a.connect(info_from_p2p_addr(host.get_addrs()[0]))
+
+            await push_identify_to_peers(
+                host_a,
+            )
+
+            await trio.sleep(0.5)
+
+            peer_id_a = host_a.get_id()
+            for host, _ in dummy_peers:
+                dummy_peerstore = host.get_peerstore()
+                assert peer_id_a in dummy_peerstore.peer_ids()
+
+            nursery.cancel_scope.cancel()
+
+
+@pytest.mark.trio
+async def test_all_peers_receive_identify_push_with_semaphore_under_high_peer_load(
+    security_protocol,
+):
+    dummy_peers = []
+
+    async with host_pair_factory(security_protocol=security_protocol) as (host_a, _):
+        # Create dummy peers
+        # Breaking with more than 500 peers
+        # Trio have a async tasks limit of 1000
+        for _ in range(499):
+            key_pair = create_new_key_pair()
+            dummy_host = new_host(key_pair=key_pair)
+            dummy_host.set_stream_handler(
+                ID_PUSH, identify_push_handler_for(dummy_host)
+            )
+            listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+            dummy_peers.append((dummy_host, listen_addr))
+
+        async with trio.open_nursery() as nursery:
+            # Start all dummy hosts
+            for host, listen_addr in dummy_peers:
+                nursery.start_soon(run_host_forever, host, listen_addr)
+
+            # Wait for all hosts to finish setting up listeners
+            for host, _ in dummy_peers:
+                await wait_until_listening(host)
+
+            # Now connect host_a → dummy peers
+            for host, _ in dummy_peers:
+                await host_a.connect(info_from_p2p_addr(host.get_addrs()[0]))
+
+            await push_identify_to_peers(
+                host_a,
+            )
+
+            await trio.sleep(0.5)
+
+            peer_id_a = host_a.get_id()
+            for host, _ in dummy_peers:
+                dummy_peerstore = host.get_peerstore()
+                assert peer_id_a in dummy_peerstore.peer_ids()
+
+            nursery.cancel_scope.cancel()

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -10,6 +10,7 @@ import trio
 from libp2p import (
     new_host,
 )
+from libp2p.abc import IHost
 from libp2p.crypto.secp256k1 import (
     create_new_key_pair,
 )

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -2,13 +2,30 @@ from unittest.mock import (
     MagicMock,
 )
 
+import trio
 
-def create_mock_connections() -> dict:
+from libp2p.abc import IHost
+
+
+def create_mock_connections(count: int = 50) -> dict:
     connections = {}
 
-    for i in range(1, 31):
+    for i in range(1, count):
         peer_id = f"peer-{i}"
         mock_conn = MagicMock(name=f"INetConn-{i}")
         connections[peer_id] = mock_conn
 
     return connections
+
+
+async def run_host_forever(host: IHost, addr):
+    async with host.run([addr]):
+        await trio.sleep_forever()
+
+
+async def wait_until_listening(host, timeout=3):
+    with trio.move_on_after(timeout):
+        while not host.get_addrs():
+            await trio.sleep(0.05)
+        return
+    raise RuntimeError("Timed out waiting for host to get an address")


### PR DESCRIPTION
Implements a ``TODO: Consider using a bounded nursery to limit concurrency and avoid overwhelming the network.``

### Problem: 
Right now, ``push_identify_to_peers`` uses an unbounded ``trio.open_nursery()`` to spawn one task per peer — meaning if you’re connected to 500 or 1000 peers, it tries to push identify info to all of them at once. This might work okay for a few peers, but at scale it causes trouble:

* Too many concurrent network connections
* "Too many open files" errors from exhausting file descriptors
* High CPU load from context switching between too many tasks
* The event loop gets bogged down, slowing everything else down

There’s no throttle — it just fires everything off as fast as it can.

### Solution:
This PR adds a simple fix: we use a ``trio.Semaphore`` to limit how many identify pushes happen at the same time. The limit is set to 10 by default, so only 10 peer pushes run concurrently — the rest wait their turn.

This keeps the system from getting overwhelmed, and makes behavior a lot more stable and predictable when you’re dealing with large peer sets. It’s a small change but helps a lot when scaling.
