### PR TITLE
fixme/correct-type

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -50,6 +50,11 @@ if TYPE_CHECKING:
         Pubsub,
     )
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from libp2p.protocol_muxer.multiselect import Multiselect
+
 from libp2p.pubsub.pb import (
     rpc_pb2,
 )
@@ -1545,9 +1550,8 @@ class IHost(ABC):
 
         """
 
-    # FIXME: Replace with correct return type
     @abstractmethod
-    def get_mux(self) -> Any:
+    def get_mux(self) -> "Multiselect":
         """
         Retrieve the muxer instance for the host.
 
@@ -2158,6 +2162,7 @@ class IMultiselectMuxer(ABC):
 
         """
 
+    @abstractmethod
     def get_protocols(self) -> tuple[TProtocol | None, ...]:
         """
         Retrieve the protocols for which handlers have been registered.
@@ -2168,7 +2173,6 @@ class IMultiselectMuxer(ABC):
             A tuple of registered protocol names.
 
         """
-        return tuple(self.handlers.keys())
 
     @abstractmethod
     async def negotiate(

--- a/libp2p/identity/identify/identify.py
+++ b/libp2p/identity/identify/identify.py
@@ -59,7 +59,7 @@ def _mk_identify_protobuf(
 ) -> Identify:
     public_key = host.get_public_key()
     laddrs = host.get_addrs()
-    protocols = host.get_mux().get_protocols()
+    protocols = tuple(str(p) for p in host.get_mux().get_protocols() if p is not None)
 
     observed_addr = observed_multiaddr.to_bytes() if observed_multiaddr else b""
     return Identify(

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -101,6 +101,18 @@ class Multiselect(IMultiselectMuxer):
         except trio.TooSlowError:
             raise MultiselectError("handshake read timeout")
 
+    def get_protocols(self) -> tuple[TProtocol | None, ...]:
+        """
+        Retrieve the protocols for which handlers have been registered.
+
+        Returns
+        -------
+        tuple[TProtocol, ...]
+            A tuple of registered protocol names.
+
+        """
+        return tuple(self.handlers.keys())
+
     async def handshake(self, communicator: IMultiselectCommunicator) -> None:
         """
         Perform handshake to agree on multiselect protocol.

--- a/libp2p/relay/circuit_v2/discovery.py
+++ b/libp2p/relay/circuit_v2/discovery.py
@@ -293,7 +293,9 @@ class RelayDiscovery(Service):
                 # Get protocols with proper typing
                 mux_protocols = mux.get_protocols()
                 if isinstance(mux_protocols, (list, tuple)):
-                    available_protocols = list(mux_protocols)
+                    available_protocols = [
+                        p for p in mux.get_protocols() if p is not None
+                    ]
 
             for protocol in available_protocols:
                 try:
@@ -313,7 +315,7 @@ class RelayDiscovery(Service):
 
             self._protocol_cache[peer_id] = peer_protocols
             protocol_str = str(PROTOCOL_ID)
-            for protocol in peer_protocols:
+            for protocol in map(TProtocol, peer_protocols):
                 if protocol == protocol_str:
                     return True
             return False


### PR DESCRIPTION
## What was wrong?

Refers to "FIXME:  Replace with correct return type" in libp2p/abc.py

Issue #
The main issue was that the return type of `get_mux()` was not correctly specified — it returned `Any`, which made type checking and linting difficult. After updating the return type to `"Multiselect"`, related code using `get_mux().get_protocols()` in `identify.py` and `discovery.py` started showing linting issues due to potential `None` values in the returned tuple.

## How was it fixed?

- Updated `get_mux()` return type from `Any` to `"Multiselect"`.
- Implemented the `get_protocols()` method inside `Multiselect` to return a properly typed tuple of registered protocols.
- Updated `identify.py` to filter out `None` values from `get_protocols()` when converting protocols to strings.
- Updated `discovery.py` to:
  - Safely filter `None` values from `get_protocols()`
  - Convert string protocol values back to `TProtocol` instances for comparison.

These changes ensure better type safety and fix linter warnings/errors that arose due to stricter type expectations.
Please look into this @seetadev 
