### PR TITLE
TODO: throttle on async validators

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -692,12 +692,7 @@ class Pubsub(Service, IPubsub):
 
         if len(async_topic_validators) > 0:
             # Appends to lists are thread safe in CPython
-            results = []
-
-            async def run_async_validator(func: AsyncValidatorFn) -> None:
-                async with self._validator_semaphore:
-                    result = await func(msg_forwarder, msg)
-                    results.append(result)
+            results: list[bool] = []
 
             async with trio.open_nursery() as nursery:
                 for async_validator in async_topic_validators:

--- a/newsfragments/755.performance.rst
+++ b/newsfragments/755.performance.rst
@@ -1,0 +1,2 @@
+Added throttling for async topic validators in validate_msg, enforcing a
+concurrency limit to prevent resource exhaustion under heavy load.


### PR DESCRIPTION
Fixed a `TODO: Implement throttle on async validators` in `libp2p/pubsub/pubsub.py::validate_msg()`.

Used semaphores to limit concurrency while running concurrent async_validators:

```py
semaphore = trio.Semaphore(MAX_CONCURRENT_VALIDATORS)

async def run_async_validator(func: AsyncValidatorFn) -> None:
    async with semaphore:
        result = await func(msg_forwarder, msg)
        results.append(result)

async with trio.open_nursery() as nursery:
    for async_validator in async_topic_validators:
        nursery.start_soon(run_async_validator, async_validator)
```