### PR TITLE
chore: clarify newline requirement in newsfragments README.md

### DIFF
--- a/newsfragments/775.docs.rst
+++ b/newsfragments/775.docs.rst
@@ -1,0 +1,1 @@
+Clarified the requirement for a trailing newline in newsfragments to pass lint checks.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -18,12 +18,19 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 - `performance`
 - `removal`
 
-So for example: `123.feature.rst`, `456.bugfix.rst`
+So for example: `1024.feature.rst`
+
+**Important**: Ensure the file ends with a newline character (``\n``) to pass GitHub tox linting checks.
+
+```
+Added support for Ed25519 key generation in libp2p peer identity creation.
+
+```
 
 If the PR fixes an issue, use that number here. If there is no issue,
 then open up the PR first and use the PR number for the newsfragment.
 
-Note that the `towncrier` tool will automatically
+**Note** that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
 `towncrier build --draft` to get a preview of what the release notes entry
 will look like in the final release notes.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -20,7 +20,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 
 So for example: `1024.feature.rst`
 
-**Important**: Ensure the file ends with a newline character (``\n``) to pass GitHub tox linting checks.
+**Important**: Ensure the file ends with a newline character (`\n`) to pass GitHub tox linting checks.
 
 ```
 Added support for Ed25519 key generation in libp2p peer identity creation.


### PR DESCRIPTION
## What was wrong?
While working on the release note for #772, I encountered a CI ``tox lint`` failure due to a missing newline at the end of the file. Although this seems minor, documenting this requirement will help contributors avoid unexpected GitHub Actions errors for contributors who are unaware of this constraint.

## How was it fixed?
Added a note to the newsfragments README.md explaining that files must end with a newline character (\n) to pass GitHub CI linting checks. This prevents contributors from encountering unexpected CI failures when creating release notes.

### To-Do
- [x] Clean up commit history
- [x] Add or update documentation related to these changes
~~- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)~~

#### Cute Animal Picture
![cute_cat_0](https://github.com/user-attachments/assets/40885776-a3e4-4b36-a9b4-e09794e2861f)