### PR TITLE
Fix type annotation inconsistency in negotiate() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ env.bak/
 #lockfiles
 uv.lock
 poetry.lock
+
+# Temporary upload files
+.tmp.driveupload/

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -48,12 +48,11 @@ class Multiselect(IMultiselectMuxer):
         """
         self.handlers[protocol] = handler
 
-    # FIXME: Make TProtocol Optional[TProtocol] to keep types consistent
     async def negotiate(
         self,
         communicator: IMultiselectCommunicator,
         negotiate_timeout: int = DEFAULT_NEGOTIATE_TIMEOUT,
-    ) -> tuple[TProtocol, StreamHandlerFn | None]:
+    ) -> tuple[TProtocol | None, StreamHandlerFn | None]:
         """
         Negotiate performs protocol selection.
 


### PR DESCRIPTION
Title: Fix type inconsistency in multiselect negotiate method and add temporary files to gitignore

Description:

Problem
This PR addresses a type inconsistency between the abstract interface and its implementation in the multiselect protocol negotiation:

•  The IProtocolMuxer.negotiate() method in libp2p/abc.py has return type Optional[TProtocol] (allowing None)
•  The implementation in libp2p/protocol_muxer/multiselect.py had return type TProtocol (not allowing None)
•  There was a FIXME comment in the code acknowledging this mismatch

This inconsistency could cause type checking errors and potential runtime issues when the method legitimately returns None during failed negotiations.

Changes Made
1. Fixed type annotation: Updated the negotiate method's return type in multiselect.py from TProtocol to Optional[TProtocol] to match the abstract interface
2. Improved gitignore: Added .tmp.driveupload/ pattern to exclude temporary upload files from version control

Benefits
•  ✅ Resolves type checking inconsistencies
•  ✅ Aligns implementation with abstract interface contract
•  ✅ Prevents accidental commits of temporary files
•  ✅ Improves code maintainability and type safety

Testing
•  Verified type annotations are consistent between interface and implementation
•  Confirmed gitignore pattern correctly excludes temporary files
•  No functional changes to existing behavior

Checklist
Code changes implemented
Type consistency verified
Gitignore updated





