### PR TITLE
fix(yamux): add concurrency lock to YamuxStream to prevent data corruption

### DIFF
--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -132,8 +132,20 @@ class BasicHost(IHost):
 
     def get_mux(self) -> Multiselect:
         """
-        :return: mux instance of host
+        Retrieve the muxer instance for the host.
+
+        Returns
+        -------
+        Multiselect
+            The muxer instance of the host. Never returns None.
+
+        Raises
+        ------
+        RuntimeError
+            If the multiselect instance is not initialized.
         """
+        if not hasattr(self, "multiselect") or self.multiselect is None:
+            raise RuntimeError("Multiselect instance not initialized")
         return self.multiselect
 
     def get_addrs(self) -> list[multiaddr.Multiaddr]:

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -101,6 +101,17 @@ class Multiselect(IMultiselectMuxer):
         except trio.TooSlowError:
             raise MultiselectError("handshake read timeout")
 
+    def get_protocols(self) -> tuple[TProtocol, ...]:
+        """
+        Retrieve the protocols for which handlers have been registered.
+
+        Returns
+        -------
+        tuple[TProtocol, ...]
+            A tuple of registered protocol names, excluding None values.
+        """
+        return tuple(p for p in self.handlers.keys() if p is not None)
+
     async def handshake(self, communicator: IMultiselectCommunicator) -> None:
         """
         Perform handshake to agree on multiselect protocol.


### PR DESCRIPTION
### Description

This pull request introduces a critical enhancement to the concurrency model of the Yamux stream muxer in `py-libp2p`. The update addresses a race condition where concurrent read and write operations on the same `YamuxStream` instance could interleave, resulting in data corruption and unpredictable protocol behavior.

#### Summary of Changes

- Introduced a dedicated asynchronous read/write lock (`self.rw_lock`) to the `YamuxStream` class.
- Both the `read` and `write` methods are now protected by this lock, ensuring that only one coroutine can access these methods at a time for a given stream.
- This approach aligns the concurrency safety of Yamux with the existing pattern used in the Mplex stream muxer.


#### Impact

- Prevents data races and corruption in Yamux streams.
- Improves the stability and reliability of all protocols built on top of the stream muxer.
- Brings the concurrency model of Yamux in line with best practices and other muxer implementations.

