### PR TITLE
replace ethereum author with current maintainers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,10 @@ readme = "README.md"
 requires-python = ">=3.10, <4.0"
 license = { text = "MIT AND Apache-2.0" }
 keywords = ["libp2p", "p2p"]
-authors = [
-    { name = "The Ethereum Foundation", email = "snakecharmers@ethereum.org" },
+maintainers = [
+    { name = "Paul Robinson", email = "pacrob@protonmail.com" },
+    { name = "Manu Sheel Gupta", email = "manu@seeta.in" },
+    { name = "Dave Grantham", email = "dave@aviation.community" },
 ]
 dependencies = [
     "base58>=1.0.3",


### PR DESCRIPTION
## What was wrong?

`authors` email still pointed to an Ethereum email.

## How was it fixed?

Replaced `authors` with `maintainers` and added current maintainers.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/24dcd37b-d23e-44fe-b30b-ae8ebf4bfcf5" />