### PR TITLE
Remove FIXME about 32 bytes prefix in noise

### DIFF
--- a/libp2p/security/noise/io.py
+++ b/libp2p/security/noise/io.py
@@ -41,7 +41,8 @@ class BaseNoiseMsgReadWriter(EncryptedMsgReadWriter):
     read_writer: NoisePacketReadWriter
     noise_state: NoiseState
 
-    # FIXME: This prefix is added in msg#3 in Go. Check whether it's a desired behavior.
+    # NOTE: This prefix is added in msg#3 in Go.
+    #       Support in py-libp2p is available but not used
     prefix: bytes = b"\x00" * 32
 
     def __init__(self, conn: IRawConnection, noise_state: NoiseState) -> None:

--- a/newsfragments/592.internal.rst
+++ b/newsfragments/592.internal.rst
@@ -1,0 +1,1 @@
+remove FIXME comment since it's obsolete and 32-byte prefix support is there but not enabled by default


### PR DESCRIPTION
## What was wrong?

Issue  https://github.com/libp2p/py-libp2p/issues/592 about 32 bytes prefix FIXME

## How was it fixed?

Implemented but not used by default

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/5a04f32e-d228-4c08-8b6a-f0ba6a71481b" />

