### PR TITLE
docs: update README.md with module status and source links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ ______________________________________________________________________
 | -------------------------------------- | :--------: | :---------------------------------------------------------------------------------: |
 | **`libp2p-tcp`**                       |     ✅     | [source](https://github.com/libp2p/py-libp2p/blob/main/libp2p/transport/tcp/tcp.py) |
 | **`libp2p-quic`**                      |     🌱     |                                                                                     |
-| **`libp2p-websocket`**                 |     ❌     |                                                                                     |
-| **`libp2p-webrtc-browser-to-server`**  |     ❌     |                                                                                     |
-| **`libp2p-webrtc-private-to-private`** |     ❌     |                                                                                     |
+| **`libp2p-websocket`**                 |     🌱     |                                                                                     |
+| **`libp2p-webrtc-browser-to-server`**  |     🌱     |                                                                                     |
+| **`libp2p-webrtc-private-to-private`** |     🌱     |                                                                                     |
 
 ______________________________________________________________________
 
 ### NAT Traversal
 
-| **NAT Traversal**             | **Status** |
-| ----------------------------- | :--------: |
-| **`libp2p-circuit-relay-v2`** |     ❌     |
-| **`libp2p-autonat`**          |     ❌     |
-| **`libp2p-hole-punching`**    |     ❌     |
+| **NAT Traversal**             | **Status** |                                   **Source**                                    |
+| ----------------------------- | :--------: | :-----------------------------------------------------------------------------: |
+| **`libp2p-circuit-relay-v2`** |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/relay/circuit_v2) |
+| **`libp2p-autonat`**          |     ✅     |   [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/host/autonat)   |
+| **`libp2p-hole-punching`**    |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/relay/circuit_v2) |
 
 ______________________________________________________________________
 
@@ -54,27 +54,27 @@ ______________________________________________________________________
 
 | **Secure Communication** | **Status** |                                  **Source**                                   |
 | ------------------------ | :--------: | :---------------------------------------------------------------------------: |
-| **`libp2p-noise`**       |     🌱     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/security/noise) |
-| **`libp2p-tls`**         |     ❌     |                                                                               |
+| **`libp2p-noise`**       |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/security/noise) |
+| **`libp2p-tls`**         |     🌱     |                                                                               |
 
 ______________________________________________________________________
 
 ### Discovery
 
-| **Discovery**        | **Status** |
-| -------------------- | :--------: |
-| **`bootstrap`**      |     ❌     |
-| **`random-walk`**    |     ❌     |
-| **`mdns-discovery`** |     ❌     |
-| **`rendezvous`**     |     ❌     |
+| **Discovery**        | **Status** |                                     **Source**                                     |
+| -------------------- | :--------: | :--------------------------------------------------------------------------------: |
+| **`bootstrap`**      |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/discovery/bootstrap) |
+| **`random-walk`**    |     🌱     |                                                                                    |
+| **`mdns-discovery`** |     ✅     |   [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/discovery/mdns)    |
+| **`rendezvous`**     |     🌱     |                                                                                    |
 
 ______________________________________________________________________
 
 ### Peer Routing
 
-| **Peer Routing**     | **Status** |
-| -------------------- | :--------: |
-| **`libp2p-kad-dht`** |     ❌     |
+| **Peer Routing**     | **Status** |                               **Source**                               |
+| -------------------- | :--------: | :--------------------------------------------------------------------: |
+| **`libp2p-kad-dht`** |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/kad_dht) |
 
 ______________________________________________________________________
 
@@ -89,10 +89,10 @@ ______________________________________________________________________
 
 ### Stream Muxers
 
-| **Stream Muxers**  | **Status** |                                         **Status**                                         |
-| ------------------ | :--------: | :----------------------------------------------------------------------------------------: |
-| **`libp2p-yamux`** |     🌱     |                                                                                            |
-| **`libp2p-mplex`** |     🛠️     | [source](https://github.com/libp2p/py-libp2p/blob/main/libp2p/stream_muxer/mplex/mplex.py) |
+| **Stream Muxers**  | **Status** |                                    **Source**                                     |
+| ------------------ | :--------: | :-------------------------------------------------------------------------------: |
+| **`libp2p-yamux`** |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/stream_muxer/yamux) |
+| **`libp2p-mplex`** |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/stream_muxer/mplex) |
 
 ______________________________________________________________________
 
@@ -100,7 +100,7 @@ ______________________________________________________________________
 
 | **Storage**         | **Status** |
 | ------------------- | :--------: |
-| **`libp2p-record`** |     ❌     |
+| **`libp2p-record`** |     🌱     |
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## What was wrong?

The README.md file contained outdated status information that didn't reflect the current state of py-libp2p module implementations. Many completed modules were marked as missing (❌), and several modules in development weren't properly categorized according to the status documented in [GitHub discussion #800](https://github.com/libp2p/py-libp2p/discussions/800).

## How was it fixed?

Updated the README.md status table to align with the current implementation state:

**Transports**: Updated websocket and webrtc modules from ❌ to 🌱 (prototype)
**NAT Traversal**: Updated circuit-relay-v2, autonat, and hole-punching from ❌ to ✅ (completed) with source links
**Secure Communication**: Updated libp2p-noise from 🌱 to ✅ and libp2p-tls from ❌ to 🌱
**Discovery**: Updated rendezvous from ❌ to 🌱 (prototype)
**Stream Muxers**: Updated yamux from 🌱 to ✅ and mplex from 🛠️ to ✅, both with proper source directory links

All changes were based on actual module presence in the codebase and the community-maintained status in discussion #800.

### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Happy cat celebrating updated documentation](https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif)