### PR TITLE
fix: Added multiselect type inconsistency in ```negotiate```  method

### DIFF
--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -288,6 +288,9 @@ class BasicHost(IHost):
             protocol, handler = await self.multiselect.negotiate(
                 MultiselectCommunicator(net_stream), self.negotiate_timeout
             )
+            if protocol is None:
+                await net_stream.reset()
+                raise StreamFailure("No protocol selected")
         except MultiselectError as error:
             peer_id = net_stream.muxed_conn.peer_id
             logger.debug(

--- a/libp2p/protocol_muxer/multiselect.py
+++ b/libp2p/protocol_muxer/multiselect.py
@@ -53,7 +53,7 @@ class Multiselect(IMultiselectMuxer):
         self,
         communicator: IMultiselectCommunicator,
         negotiate_timeout: int = DEFAULT_NEGOTIATE_TIMEOUT,
-    ) -> tuple[TProtocol, StreamHandlerFn | None]:
+    ) -> tuple[TProtocol | None, StreamHandlerFn | None]:
         """
         Negotiate performs protocol selection.
 

--- a/libp2p/security/security_multistream.py
+++ b/libp2p/security/security_multistream.py
@@ -26,6 +26,9 @@ from libp2p.protocol_muxer.multiselect_client import (
 from libp2p.protocol_muxer.multiselect_communicator import (
     MultiselectCommunicator,
 )
+from libp2p.transport.exceptions import (
+    SecurityUpgradeFailure,
+)
 
 """
 Represents a secured connection object, which includes a connection and details about
@@ -104,7 +107,7 @@ class SecurityMultistream(ABC):
         :param is_initiator: true if we are the initiator, false otherwise
         :return: selected secure transport
         """
-        protocol: TProtocol
+        protocol: TProtocol | None
         communicator = MultiselectCommunicator(conn)
         if is_initiator:
             # Select protocol if initiator
@@ -114,5 +117,7 @@ class SecurityMultistream(ABC):
         else:
             # Select protocol if non-initiator
             protocol, _ = await self.multiselect.negotiate(communicator)
+            if protocol is None:
+                raise SecurityUpgradeFailure("No protocol selected")
         # Return transport from protocol
         return self.transports[protocol]


### PR DESCRIPTION
## What was wrong?
The multiselect type was inconsistent

## How was it fixed?
Set the return type to None and handled the places where the ```negotiate``` function is used.

Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
