### PR TITLE
remove deprecated IK pattern TODO

### DIFF
--- a/libp2p/security/noise/transport.py
+++ b/libp2p/security/noise/transport.py
@@ -29,11 +29,6 @@ class Transport(ISecureTransport):
     early_data: bytes | None
     with_noise_pipes: bool
 
-    # NOTE: Implementations that support Noise Pipes must decide whether to use
-    #   an XX or IK handshake based on whether they possess a cached static
-    #   Noise key for the remote peer.
-    # TODO: A storage of seen noise static keys for pattern IK?
-
     def __init__(
         self,
         libp2p_keypair: KeyPair,

--- a/newsfragments/816.internal.rst
+++ b/newsfragments/816.internal.rst
@@ -1,0 +1,1 @@
+The TODO IK patterns in Noise has been deprecated in specs: https://github.com/libp2p/specs/tree/master/noise#handshake-pattern


### PR DESCRIPTION
## What was wrong?

Issue # https://github.com/libp2p/py-libp2p/issues/816

## How was it fixed?

Removed TODO since IK patten was deprecated in specs 
https://github.com/libp2p/specs/tree/master/noise#handshake-pattern

`noise-libp2p` supports the [XX handshake pattern](#xx), which provides mutual
authentication and encryption of static keys and handshake payloads and is
resistant to replay attacks.

Prior revisions of this spec included a compound protocol involving the `IK` and
`XXfallback `patterns, but this was [removed](#why-the-xx-handshake-pattern) due
to the benefits not justifying the considerable additional complexity.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)



<img width="216" height="233" alt="image" src="https://github.com/user-attachments/assets/49e6930d-f34e-413e-a3e5-960a8762457c" />

