### PR TITLE
Remove completed TODO task comments in Peerstore

### DIFF
--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -39,8 +39,6 @@ from .peerinfo import (
 PERMANENT_ADDR_TTL = 0
 
 
-# TODO: Set up an async task for periodic peer-store cleanup
-# for expired addresses and records.
 class PeerRecordState:
     envelope: Envelope
     seq: int
@@ -217,7 +215,6 @@ class PeerStore(IPeerStore):
 
     # -----CERT-ADDR-BOOK-----
 
-    # TODO: Make proper use of this function
     def maybe_delete_peer_record(self, peer_id: ID) -> None:
         """
         Delete the signed peer record for a peer if it has no know

--- a/newsfragments/819.internal.rst
+++ b/newsfragments/819.internal.rst
@@ -1,0 +1,3 @@
+Remove the already completed TODO tasks in Peerstore:
+TODO: Set up an async task for periodic peer-store cleanup for expired addresses and records.
+TODO: Make proper use of this function


### PR DESCRIPTION
Removed completed TODO task comments in the Peerstore module. 
1. TODO: Set up an async task for periodic peer-store cleanup for expired addresses and records.
2. TODO: Make proper use of this function