### PR TITLE
fix_gossipsub_mid_type

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -775,12 +775,12 @@ class GossipSub(IPubsubRouter, Service):
         # Get list of all seen (seqnos, from) from the (seqno, from) tuples in
         # seen_messages cache
         seen_seqnos_and_peers = [
-            str(seqno_and_from) for seqno_and_from in self.pubsub.seen_messages.cache.keys()
+            str(seqno_and_from)
+            for seqno_and_from in self.pubsub.seen_messages.cache.keys()
         ]
 
         # Add all unknown message ids (ids that appear in ihave_msg but not in
         # seen_seqnos) to list of messages we want to request
-        # FIXME: Update type of message ID
         msg_ids_wanted: list[str] = [
             msg_id
             for msg_id in ihave_msg.messageIDs

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -597,9 +597,7 @@ class GossipSub(IPubsubRouter, Service):
                 peers_to_emit_ihave_to = self._get_in_topic_gossipsub_peers_from_minus(
                     topic, self.degree, current_peers, True
                 )
-                msg_id_strs = [
-                    msg_id[0].decode() + msg_id[1].decode() for msg_id in msg_ids
-                ]
+                msg_id_strs = [str(msg_id) for msg_id in msg_ids]
                 for peer in peers_to_emit_ihave_to:
                     peers_to_gossip[peer][topic] = msg_id_strs
 

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -775,16 +775,16 @@ class GossipSub(IPubsubRouter, Service):
         # Get list of all seen (seqnos, from) from the (seqno, from) tuples in
         # seen_messages cache
         seen_seqnos_and_peers = [
-            seqno_and_from for seqno_and_from in self.pubsub.seen_messages.cache.keys()
+            str(seqno_and_from) for seqno_and_from in self.pubsub.seen_messages.cache.keys()
         ]
 
         # Add all unknown message ids (ids that appear in ihave_msg but not in
         # seen_seqnos) to list of messages we want to request
         # FIXME: Update type of message ID
-        msg_ids_wanted: list[Any] = [
+        msg_ids_wanted: list[str] = [
             msg_id
             for msg_id in ihave_msg.messageIDs
-            if literal_eval(msg_id) not in seen_seqnos_and_peers
+            if msg_id not in seen_seqnos_and_peers
         ]
 
         # Request messages with IWANT message

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -597,7 +597,9 @@ class GossipSub(IPubsubRouter, Service):
                 peers_to_emit_ihave_to = self._get_in_topic_gossipsub_peers_from_minus(
                     topic, self.degree, current_peers, True
                 )
-                msg_id_strs = [str(msg_id) for msg_id in msg_ids]
+                msg_id_strs = [
+                    msg_id[0].decode() + msg_id[1].decode() for msg_id in msg_ids
+                ]
                 for peer in peers_to_emit_ihave_to:
                     peers_to_gossip[peer][topic] = msg_id_strs
 

--- a/newsfragments/859.feature.rst
+++ b/newsfragments/859.feature.rst
@@ -1,0 +1,1 @@
+Fix type for gossipsub_message_id for consistency and security


### PR DESCRIPTION
## What was wrong?
Fix Issue 2 mentioned in discussion: https://github.com/libp2p/py-libp2p/discussions/719
Issue # https://github.com/libp2p/py-libp2p/issues/858

## How was it fixed?
Fixed the type of msg_id and changed from literal_eval() to string comparison for security,

Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
