### PR TITLE
fix: GossipSub peer propagation to include FloodSub peers

### DIFF
--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -293,7 +293,7 @@ class GossipSub(IPubsubRouter, Service):
             floodsub_peers: set[ID] = {
                 peer_id
                 for peer_id in self.pubsub.peer_topics[topic]
-                if self.peer_protocol[peer_id] == floodsub.PROTOCOL_ID
+                if peer_id in self.peer_protocol and self.peer_protocol[peer_id] == floodsub.PROTOCOL_ID
             }
             send_to.update(floodsub_peers)
 


### PR DESCRIPTION
## What was wrong?

When a node publishes a message immediately after connecting to a peer, py-libp2p sometimes crashes with:

```
KeyError: <PeerID>
```

This happens in pubsub/gossipsub.py, where `self.peer_protocol[peer_id`] is accessed before the identify handshake has finished. The handshake is asynchronous, so peer_protocol may not yet contain the connected peer.

Issue #887

## How was it fixed?

- Guarded against missing entries in `peer_protocol`
- Optionally, queue publishes until identify completes.

Summary of approach.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://t3.ftcdn.net/jpg/02/36/99/22/360_F_236992283_sNOxCVQeFLd5pdqaKGh8DRGMZy7P4XKm.jpg)
