### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "grpcio>=1.41.0",
     "lru-dict>=1.1.6",
     # "multiaddr (>=0.0.9,<0.0.10)",
-    "multiaddr @ git+https://github.com/multiformats/py-multiaddr.git@db8124e2321f316d3b7d2733c7df11d6ad9c03e6",
+    "multiaddr @ git+https://github.com/multiformats/py-multiaddr.git@3ea7f866fda9268ee92506edf9d8e975274bf941",
     "mypy-protobuf>=3.0.0",
     "noiseprotocol>=0.3.0",
     "protobuf>=4.25.0,<5.0.0",


### PR DESCRIPTION
## What was wrong?

Update pyproject.toml with the correct destination path of py-multiaddr. Temporary fix while we resolve release mgmt. at pypi.

Issue #

CI/CD broken because of incorrect destination path of py-multiaddr.

## How was it fixed?

Updated the requisite path

Summary of approach.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
