### PR TITLE
[910] Pubsub service crashes on protocol negotiation failures

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -501,8 +501,10 @@ class Pubsub(Service, IPubsub):
         async with self.peer_receive_channel:
             self.event_handle_peer_queue_started.set()
             async for peer_id in self.peer_receive_channel:
-                # Add Peer
-                self.manager.run_task(self._handle_new_peer, peer_id)
+                try:
+                    self.manager.run_task(self._handle_new_peer, peer_id)
+                except Exception as e:
+                    logger.info(f"Protocol negotiation failed for peer {peer_id}: {e}")
 
     async def handle_dead_peer_queue(self) -> None:
         """


### PR DESCRIPTION
## What was wrong?

Issue #910 

## How was it fixed?

**Technical Approach**

1. Minimal Invasive Fix:

- Added only a try-except block around the problematic line
- No changes to the existing API or method signatures
- Preserved all existing functionality

2. Service Continuity:

- The pubsub service now continues running even when individual peer negotiations fail
- TCP connections are maintained even if PubSub protocol negotiation fails
- Future peer connections can still be processed


### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="435" height="774" alt="image" src="https://github.com/user-attachments/assets/45811ad0-3977-4ba6-a7de-9b8d70ff76d2" />