### PR TITLE
remove duplicate entry of fastecdsa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",
     "trio>=0.26.0",
-    "fastecdsa==2.3.2; sys_platform != 'win32'",
     "trio-websocket>=0.11.0",
     "zeroconf (>=0.147.0,<0.148.0)",
 ]


### PR DESCRIPTION
## What was wrong?

`dependencies` in `pyproject.toml` had 2 entries for `fastecdsa`. This removes one of them.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1200" height="759" alt="image" src="https://github.com/user-attachments/assets/df5bc617-795e-4070-abb7-23d82823e7e0" />
