### PR TITLE
Add timeouts to CI/CD pipeline to prevent hanging tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ defaults:
 jobs:
   tox:
     runs-on: ubuntu-latest
+    timeout-minutes: 60  # 1 hour timeout
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
@@ -82,6 +83,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    timeout-minutes: 60  # 1 hour timeout
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ typecheck:
 	pre-commit run mypy-local --all-files && pre-commit run pyrefly-local --all-files
 
 test:
-	python -m pytest tests -n auto
+	python -m pytest tests -n auto --timeout=1200
 
 pr: clean fix lint typecheck test
 

--- a/newsfragments/977.internal.rst
+++ b/newsfragments/977.internal.rst
@@ -1,0 +1,6 @@
+Added timeouts to CI/CD pipeline to prevent hanging tests.
+
+- Added 60-minute job timeout to GitHub Actions workflow
+- Added 20-minute pytest timeouts to tox.ini for all test environments
+- Updated Makefile test command with 20-minute timeout
+- Prevents tests from hanging indefinitely in CI/CD

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,10 @@ max_issue_threshold=1
 [testenv]
 usedevelop=True
 commands=
-    core: pytest -n auto {posargs:tests/core}
-    interop: pytest -n auto {posargs:tests/interop}
+    core: pytest -n auto --timeout=1200 {posargs:tests/core}
+    interop: pytest -n auto --timeout=1200 {posargs:tests/interop}
     docs: make check-docs-ci
-    demos: pytest -n auto {posargs:tests/core/examples/test_examples.py}
+    demos: pytest -n auto --timeout=1200 {posargs:tests/core/examples/test_examples.py}
 basepython=
     docs: python
     windows-wheel: python


### PR DESCRIPTION
- Add 60-minute job timeout to GitHub Actions workflow
- Add 20-minute pytest timeouts to tox.ini for all test environments
- Update Makefile test command with 20-minute timeout
- Prevents tests from hanging indefinitely in CI/CD

Fixes #977



<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/539da0e4-3420-4d5e-ad10-8016d1eb16e9" />

