### PR TITLE
Updated transport module status in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ ______________________________________________________________________
 | **Transport**                          | **Status** |                                     **Source**                                      |
 | -------------------------------------- | :--------: | :---------------------------------------------------------------------------------: |
 | **`libp2p-tcp`**                       |     ✅     | [source](https://github.com/libp2p/py-libp2p/blob/main/libp2p/transport/tcp/tcp.py) |
-| **`libp2p-quic`**                      |     🌱     |                                                                                     |
-| **`libp2p-websocket`**                 |     🌱     |                                                                                     |
+| **`libp2p-quic`**                      |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/transport/quic) |
+| **`libp2p-websocket`**                 |     ✅     | [source](https://github.com/libp2p/py-libp2p/tree/main/libp2p/transport/websocket) |
 | **`libp2p-webrtc-browser-to-server`**  |     🌱     |                                                                                     |
 | **`libp2p-webrtc-private-to-private`** |     🌱     |                                                                                     |
 


### PR DESCRIPTION
## What was wrong?

The Status of transport modules are not updated in readme file.

## How was it fixed?

The status of Quic and Websocket are updated in Readme file.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
