### PR TITLE
Configurable TTL Values in py-libp2p 

### DIFF
--- a/libp2p/config/ttl.py
+++ b/libp2p/config/ttl.py
@@ -1,0 +1,57 @@
+# libp2p/config/ttl.py
+from dataclasses import dataclass, field
+from typing import Any
+
+import trio
+
+
+@dataclass
+class TTLConfig:
+    """Configurable TTL values for different libp2p components."""
+
+    # Peer address TTLs
+    peer_addr_ttl: int = 7200  # 2 hours
+    temp_addr_ttl: int = 600  # 10 minutes
+    permanent_addr_ttl: int = 315360000  # 10 years
+
+    # DHT TTLs
+    dht_provider_ttl: int = 86400  # 24 hours
+    dht_record_ttl: int = 79200  # 22 hours
+
+    # PubSub TTLs
+    pubsub_message_ttl: int = 7200  # 2 hours
+
+    # Identify TTLs
+    identify_timeout: int = 30  # 30 seconds
+
+    # Trio-specific: Cleanup tasks for proper resource management
+    _cleanup_tasks: list[trio.CancelScope] = field(
+        default_factory=list, init=False, repr=False
+    )
+
+    @classmethod
+    def from_dict(cls, config: dict[str, Any]) -> "TTLConfig":
+        """Create TTLConfig from dictionary."""
+        return cls(**{k: v for k, v in config.items() if k in cls.__annotations__})
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "peer_addr_ttl": self.peer_addr_ttl,
+            "temp_addr_ttl": self.temp_addr_ttl,
+            "permanent_addr_ttl": self.permanent_addr_ttl,
+            "dht_provider_ttl": self.dht_provider_ttl,
+            "dht_record_ttl": self.dht_record_ttl,
+            "pubsub_message_ttl": self.pubsub_message_ttl,
+            "identify_timeout": self.identify_timeout,
+        }
+
+    async def cleanup(self) -> None:
+        """Clean up TTL-related resources when cancelled."""
+        for task in self._cleanup_tasks:
+            task.cancel()
+        self._cleanup_tasks.clear()
+
+    def add_cleanup_task(self, task: trio.CancelScope) -> None:
+        """Add a cleanup task for proper resource management."""
+        self._cleanup_tasks.append(task)  # type: ignore


### PR DESCRIPTION
## What was wrong?
The current py-libp2p implementation uses hardcoded TTL (Time To Live) values throughout the codebase. This PR(WIP) implements a configurable TTL system across Identify, PubSub, DHT, Host modules, following golibp2p's approach.

Implements discussion  #967 

## How was it fixed?
As the discussed in #967, this PR focuses on phase 1 and 2 of the implementation roadmap.

Phase 1: Core Infrastructure

- Create TTLConfig dataclass

- Add configuration validation

- Create default TTL values based on Go libp2p

Phase 2: Component Updates

-    Update IdentifyPush to use configurable TTL

-    Update PubSub utilities

-    Update DHT utilities

-   Update Host class to accept TTL config



### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture


<img width="246" height="148" alt="image" src="https://github.com/user-attachments/assets/48042419-ad1e-44a1-85b7-50eacb329986" />

