### PR TITLE
Update py-multihash to 3.0.0 from PyPI

### DIFF
--- a/newsfragments/1097.internal.rst
+++ b/newsfragments/1097.internal.rst
@@ -1,0 +1,1 @@
+Updated py-multihash dependency to use version 3.0.0 from PyPI instead of a git dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "noiseprotocol>=0.3.0",
     "protobuf>=4.25.0,<7.0.0",
     "pycryptodome>=3.9.2",
-    "py-multihash @ git+https://github.com/sumanjeet0012/py-multihash.git@cb23eaa3c66d977ae7f4ce777cad5c2566a7c3de",
+    "py-multihash>=3.0.0",
     "pynacl>=1.3.0",
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",


### PR DESCRIPTION
This PR updates the py-multihash dependency from a git dependency to version 3.0.0 from PyPI.

## Changes
- Replace git dependency with PyPI package version 3.0.0
- Update dependency constraint to use `>=3.0.0`
- Add newsfragment for issue #1097

## Related Issue
Closes #1097

## Testing
- All tests pass (`make pr`)
- Linting and type checking pass
- No breaking changes expected