### PR TITLE
Revert 'Update py-multihash to 3.0.0 from PyPI'

### DIFF
--- a/newsfragments/1097.internal.rst
+++ b/newsfragments/1097.internal.rst
@@ -1,1 +1,0 @@
-Updated py-multihash dependency to use version 3.0.0 from PyPI instead of a git dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "noiseprotocol>=0.3.0",
     "protobuf>=4.25.0,<7.0.0",
     "pycryptodome>=3.9.2",
-    "py-multihash>=3.0.0",
+    "py-multihash @ git+https://github.com/sumanjeet0012/py-multihash.git@cb23eaa3c66d977ae7f4ce777cad5c2566a7c3de",
     "pynacl>=1.3.0",
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",


### PR DESCRIPTION
This PR reverts PR #1098 which updated py-multihash to 3.0.0 from PyPI.

## Reason for Revert

According to the release plan in discussion #1089, py-libp2p should wait for:
- py-multicodec 1.0.0 (step 3)
- py-cid 0.4.0 (step 4)

before updating to py-multihash 3.0.0 (step 5).

The premature update could cause dependency conflicts since:
- py-cid 0.3.1 still uses the old `pymultihash` package
- Both `pymultihash` and `py-multihash` provide the `multihash` module
- This creates a potential module name conflict

## Changes

- Reverts py-multihash dependency back to git dependency
- Removes newsfragment 1097.internal.rst

## Related

- Reverts #1098
- Related to discussion #1089