### PR TITLE
Update py-multihash dependency to latest PyPI version

### DIFF
--- a/newsfragments/1102.internal.rst
+++ b/newsfragments/1102.internal.rst
@@ -1,0 +1,1 @@
+Updated py-multihash dependency from git repository to PyPI version 3.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "noiseprotocol>=0.3.0",
     "protobuf>=4.25.0,<7.0.0",
     "pycryptodome>=3.9.2",
-    "py-multihash @ git+https://github.com/sumanjeet0012/py-multihash.git@cb23eaa3c66d977ae7f4ce777cad5c2566a7c3de",
+    "py-multihash>=3.0.0",
     "pynacl>=1.3.0",
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",


### PR DESCRIPTION
This PR updates the `py-multihash` dependency from a git repository to PyPI version 3.0.0 as specified in issue #1102.

## Changes
- Updated `pyproject.toml` to change from git dependency to PyPI version: `py-multihash>=3.0.0`
- Added news fragment for release notes

## Testing
- ✅ Verified API compatibility with existing code
- ✅ All multihash functions work correctly (digest, decode, FuncReg)
- ✅ All imports work across affected modules
- ✅ All tests pass (1807 passed, 13 skipped)
- ✅ Documentation builds successfully
- ✅ Pre-commit hooks pass

## Verification
The following modules using multihash were tested and verified:
- `libp2p/kad_dht/utils.py`
- `libp2p/peer/id.py`
- `libp2p/security/secio/transport.py`
- `libp2p/records/pubkey.py`
- `libp2p/kad_dht/routing_table.py`

Fixes #1102