### PR TITLE
Fix: Make TLS Extensions Non-Critical for Rust Interop

### DIFF
--- a/interop/transport/ping_test.py
+++ b/interop/transport/ping_test.py
@@ -47,7 +47,6 @@ from libp2p.security.noise.transport import (
 )
 from libp2p.security.tls.transport import (
     PROTOCOL_ID as TLS_PROTOCOL_ID,
-    IdentityConfig,
     TLSTransport,
 )
 from libp2p.utils.address_validation import get_available_interfaces
@@ -236,53 +235,11 @@ class PingTest:
             )
             return {NOISE_PROTOCOL_ID: noise_transport}, key_pair
         elif self.security == "tls":
-            # Create TLS transport with custom certificate template for Rust interop
-            # Rust's libp2p-tls only understands the libp2p extension, so we must
-            # set BasicConstraints and KeyUsage as non-critical (critical=False)
-            # to avoid "UnsupportedCriticalExtension" errors.
-            from datetime import timezone
-
-            serial = x509.random_serial_number()
-            not_before = datetime.now(timezone.utc)
-            not_after = not_before + timedelta(hours=24)
-            subject_name = issuer_name = x509.Name(
-                [x509.NameAttribute(NameOID.COMMON_NAME, "libp2p")]
-            )
-
-            # Custom cert template with critical=False for interop compatibility
-            custom_template = (
-                x509.CertificateBuilder()
-                .serial_number(serial)
-                .not_valid_before(not_before)
-                .not_valid_after(not_after)
-                .subject_name(subject_name)
-                .issuer_name(issuer_name)
-                .add_extension(
-                    x509.BasicConstraints(ca=False, path_length=None),
-                    critical=False,  # Must be False for Rust interop
-                )
-                .add_extension(
-                    x509.KeyUsage(
-                        digital_signature=True,
-                        content_commitment=False,
-                        key_encipherment=False,
-                        data_encipherment=False,
-                        key_agreement=False,
-                        key_cert_sign=False,
-                        crl_sign=False,
-                        encipher_only=False,
-                        decipher_only=False,
-                    ),
-                    critical=False,  # Must be False for Rust interop
-                )
-            )
-
-            identity_config = IdentityConfig(cert_template=custom_template)
+            # Use default certificate template (now has critical=False for Rust interop)
             tls_transport = TLSTransport(
                 libp2p_keypair=key_pair,
                 early_data=None,
                 muxers=None,
-                identity_config=identity_config,
             )
             return {TLS_PROTOCOL_ID: tls_transport}, key_pair
         elif self.security == "plaintext":

--- a/libp2p/security/tls/certificate.py
+++ b/libp2p/security/tls/certificate.py
@@ -179,18 +179,18 @@ def create_cert_template() -> x509.CertificateBuilder:
         .issuer_name(issuer_name)
     )
 
+    # Both extensions are set to critical=False for cross-implementation compatibility.
+    # Rust libp2p-tls doesn't understand these extensions, so they must be non-critical
+    # per spec: "Implementations MUST ignore non-critical extensions with unknown OIDs.
+    # Endpoints MUST abort the connection attempt if the certificate contains critical
+    # extensions that the endpoint does not understand."
+
     # Add Basic Constraints extension - not a CA
-    # Note: critical=False for cross-implementation compatibility.
-    # Rust libp2p-tls doesn't understand this extension, so it must be non-critical
-    # per spec: "Implementations MUST ignore non-critical extensions with unknown OIDs"
     builder = builder.add_extension(
         x509.BasicConstraints(ca=False, path_length=None), critical=False
     )
 
     # Add Key Usage - digital signature only
-    # Note: critical=False for cross-implementation compatibility.
-    # Rust libp2p-tls doesn't understand this extension, so it must be non-critical
-    # per spec: "Implementations MUST ignore non-critical extensions with unknown OIDs"
     builder = builder.add_extension(
         x509.KeyUsage(
             digital_signature=True,

--- a/libp2p/security/tls/certificate.py
+++ b/libp2p/security/tls/certificate.py
@@ -180,11 +180,17 @@ def create_cert_template() -> x509.CertificateBuilder:
     )
 
     # Add Basic Constraints extension - not a CA
+    # Note: critical=False for cross-implementation compatibility.
+    # Rust libp2p-tls doesn't understand this extension, so it must be non-critical
+    # per spec: "Implementations MUST ignore non-critical extensions with unknown OIDs"
     builder = builder.add_extension(
-        x509.BasicConstraints(ca=False, path_length=None), critical=True
+        x509.BasicConstraints(ca=False, path_length=None), critical=False
     )
 
     # Add Key Usage - digital signature only
+    # Note: critical=False for cross-implementation compatibility.
+    # Rust libp2p-tls doesn't understand this extension, so it must be non-critical
+    # per spec: "Implementations MUST ignore non-critical extensions with unknown OIDs"
     builder = builder.add_extension(
         x509.KeyUsage(
             digital_signature=True,
@@ -197,7 +203,7 @@ def create_cert_template() -> x509.CertificateBuilder:
             encipher_only=False,
             decipher_only=False,
         ),
-        critical=True,
+        critical=False,
     )
     return builder
 

--- a/newsfragments/1159.bugfix.rst
+++ b/newsfragments/1159.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed TLS certificate interoperability with Rust libp2p by setting BasicConstraints and KeyUsage X.509 extensions to non-critical, allowing cross-implementation compatibility per libp2p TLS spec.

--- a/tests/core/security/tls/test_certificate.py
+++ b/tests/core/security/tls/test_certificate.py
@@ -33,6 +33,33 @@ def test_generate_certificate_has_libp2p_extension_noncritical():
     assert found, "libp2p extension missing"
 
 
+def test_certificate_extensions_are_noncritical():
+    """Verify BasicConstraints and KeyUsage are non-critical for Rust interop."""
+    keypair = create_secp256k1()
+    tmpl = certmod.create_cert_template()
+    cert_pem, _ = certmod.generate_certificate(keypair.private_key, tmpl)
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+
+    # Find and verify BasicConstraints and KeyUsage
+    basic_constraints_found = False
+    key_usage_found = False
+
+    for ext in cert.extensions:
+        if isinstance(ext.value, x509.BasicConstraints):
+            basic_constraints_found = True
+            assert ext.critical is False, (
+                "BasicConstraints must be non-critical for Rust interop"
+            )
+        elif isinstance(ext.value, x509.KeyUsage):
+            key_usage_found = True
+            assert ext.critical is False, (
+                "KeyUsage must be non-critical for Rust interop"
+            )
+
+    assert basic_constraints_found, "BasicConstraints extension missing"
+    assert key_usage_found, "KeyUsage extension missing"
+
+
 def test_verify_certificate_chain_extracts_host_public_key():
     # Generate cert for a new host key
     keypair = create_secp256k1()


### PR DESCRIPTION
This PR changes the `critical` flag for `BasicConstraints` and `KeyUsage` X.509 extensions from `True` to `False` in `libp2p/security/tls/certificate.py`. This change is needed for TLS certificate interoperability with Rust libp2p nodes, which (correctly per spec) abort if they encounter critical extensions they do not recognize.

### Issue:- #1159

## Context

- See [libp2p/specs/tls.md](https://github.com/libp2p/specs/blob/master/tls/tls.md): Non-critical (critical=False) is required for unrecognized or optional extensions.
- Previously both extensions were marked `critical=True`. This caused Rust libp2p (`rust-libp2p-tls`) to abort TLS connections from Python, breaking interoperability.
- The fix is to set `critical=False` on both, so Rust (and any other implementations) will ignore rather than reject the extensions.

## Changes

- **libp2p/security/tls/certificate.py**
  - Set `critical=False` for `BasicConstraints`
  - Set `critical=False` for `KeyUsage`
- No changes to other extensions or WSS self-signed certificate routines.

## Rationale

- Aligns with the TLS interoperability spec (see quote below).
- Restores working cross-language communication (Python <-> Rust).
- Harmless for Python-only operation: all Python checks still apply.

> Implementations MUST ignore non-critical extensions with unknown OIDs. Endpoints MUST abort the connection attempt if the certificate contains critical extensions that the endpoint does not understand.

---

@acul71 @seetadev The fix is in place and should resolve the Rust interop failures.