### PR TITLE
Use uv as the recommended install method in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,43 +1,65 @@
-Install
+ Install
 ================
 
-Follow the steps below to install `py-libp2p` on your platform.
+ Follow the steps below to install `py-libp2p` on your platform.
 
-**Linux / macOS / Windows**
+ **Recommended (using ``uv``, same as CI)**
 
-1. Create a Python virtual environment:
+ 1. Install ``uv`` (if you don't have it yet):
 
-   .. code:: sh
+    .. code:: sh
 
-       python -m venv venv
+        curl -LsSf https://astral.sh/uv/install.sh | sh
 
-2. Activate the virtual environment:
+ 2. Create a Python virtual environment:
 
-   - **Linux / macOS**
+    .. code:: sh
 
-     .. code:: sh
+        uv venv venv
 
-         source venv/bin/activate
+ 3. Activate the virtual environment:
 
-   - **Windows (cmd)**
+    - **Linux / macOS**
 
-     .. code:: batch
+      .. code:: sh
 
-         venv\Scripts\activate.bat
+          source venv/bin/activate
 
-   - **Windows (PowerShell)**
+    - **Windows (cmd)**
 
-     .. code:: powershell
+      .. code:: batch
 
-         venv\Scripts\Activate.ps1
+          venv\Scripts\activate.bat
 
-3. Install `py-libp2p`:
+    - **Windows (PowerShell)**
 
-   .. code:: sh
+      .. code:: powershell
 
-       python -m pip install libp2p
+          venv\Scripts\Activate.ps1
 
-Usage
+ 4. Install `py-libp2p` from PyPI:
+
+    .. code:: sh
+
+        uv pip install libp2p
+
+ **Alternative: using standard ``pip``**
+
+ If you prefer not to use ``uv``, you can instead:
+
+ 1. Create a Python virtual environment:
+
+    .. code:: sh
+
+        python -m venv venv
+
+ 2. Activate the virtual environment (as shown above) and install:
+
+    .. code:: sh
+
+        python -m pip install libp2p
+
+ Usage
 -----
 Configuration
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
## What was wrong?

The install documentation recommended using standard `pip` only (`python -m pip install libp2p`), while the contributing guide and CI/CD use `uv` as the default tool.

This mismatch was confusing for contributors and users trying to mirror the CI environment and follow the recommended workflow.

## How was it fixed?

- Updated [docs/install.rst](cci:7://file:///home/lynndabel/py-libp2p/docs/install.rst:0:0-0:0) to recommend **`uv` as the primary installation method**, aligned with the contributing guide and CI.
- Added explicit `uv`-based steps:
  - Install `uv` via the official installer.
  - Create a virtual environment with `uv venv venv`.
  - Install from PyPI with `uv pip install libp2p`.
- Kept the previous `pip`-only flow as an **“Alternative: using standard `pip`”** section so users without `uv` can still install the package in the old way.
- No code or packaging logic was changed; this PR only updates documentation.

### To-Do

- [ ] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://placekitten.com/400/300)

closes #1175