### PR TITLE
Fix PytestUnknownMarkWarning and RuntimeWarning in CI (#1228)

### DIFF
--- a/newsfragments/1228.bugfix.rst
+++ b/newsfragments/1228.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed PytestUnknownMarkWarning for the ``integration`` mark and RuntimeWarning from an unawaited coroutine in stream muxer tests, so CI runs without these warnings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ markers = [
     "slow: mark test as slow",
     "flaky: mark test as flaky (may fail intermittently)",
     "benchmark: performance/sanity benchmarks (deselect with -m 'not benchmark')",
+    "integration: mark test as integration (requires external service or proxy)",
 ]
 xfail_strict = true
 trio_mode = true

--- a/tests/core/stream_muxer/test_muxer_multistream.py
+++ b/tests/core/stream_muxer/test_muxer_multistream.py
@@ -54,7 +54,6 @@ async def test_new_conn_passes_timeout_to_multistream_client():
     mock_conn = MagicMock()
     mock_conn.is_initiator = True
     mock_peer_id = ID(b"test_peer")
-    mock_communicator = MagicMock()
 
     # Mock MultistreamClient and transports
     muxer = MuxerMultistream({}, negotiate_timeout=30)
@@ -65,9 +64,8 @@ async def test_new_conn_passes_timeout_to_multistream_client():
     await muxer.new_conn(mock_conn, mock_peer_id)
 
     # Verify that select_one_of was called with the correct timeout
-    muxer.multistream_client.select_one_of(
-        tuple(muxer.transports.keys()), mock_communicator, 30
-    )
+    muxer.multistream_client.select_one_of.assert_called_once()
+    assert muxer.multistream_client.select_one_of.call_args[0][2] == 30
 
 
 @pytest.mark.trio


### PR DESCRIPTION
Fixes #1228

- Register `integration` pytest mark in pyproject.toml
- Fix unawaited coroutine in `test_new_conn_passes_timeout_to_multistream_client` by using `assert_called_once()` and `call_args` instead of calling the AsyncMock again
- Add newsfragment 1228.bugfix.rst

Made with [Cursor](https://cursor.com)