### PR TITLE
chore(deps): deduplicate repeated dependency specs

### DIFF
--- a/newsfragments/1255.internal.rst
+++ b/newsfragments/1255.internal.rst
@@ -1,0 +1,1 @@
+Deduplicated repeated `requests` and `types-requests` entries in project dependencies to keep dependency metadata consistent and reduce false duplicate signals in observability reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,10 @@ dependencies = [
     "py-multicodec>=1.0.0",
     "py-cid>=0.5.0",
     "pynacl>=1.3.0",
-    "requests>=2.25.0",
     "rpcudp>=3.0.0",
     "trio-typing>=0.0.4",
     "trio-websocket>=0.11.0",
     "trio>=0.26.0",
-    "types-requests",
     "zeroconf (>=0.147.0,<0.148.0)",
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- remove duplicate `requests` and `types-requests` entries from `[project.dependencies]`
- keep the newer `requests>=2.28.0` constraint and a single `types-requests` entry
- add required newsfragment for issue #1255

## Test plan
- [x] `make lint`
- [x] verify `pyproject.toml` no longer contains duplicate dependency declarations

Fixes #1255

Made with [Cursor](https://cursor.com)