### PR TITLE
Refresh user and contributor documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing
 
 Thank you for your interest in contributing! We welcome all contributions no matter
 their size. Please read along to learn how to get started. If you get stuck, feel free
-to ask for help in `Libp2p Discover Server <https://discord.gg/GK8TxRNh2s>`_.
+to ask for help in the `libp2p Discord server <https://discord.gg/GK8TxRNh2s>`_.
 
 Setting the stage
 ~~~~~~~~~~~~~~~~~
@@ -21,7 +21,8 @@ Python's built-in ``venv`` module. Instructions vary by platform:
 
 .. note::
 
-    py-libp2p contributor setup is currently supported on Python versions ``<= 3.13``.
+    py-libp2p contributor setup is currently supported on Python versions
+    ``3.10`` through ``3.13``.
 
 Linux Setup
 ^^^^^^^^^^^
@@ -247,8 +248,8 @@ Setup Steps
 
    .. code:: powershell
 
-        python -m venv venv
-        .\venv\Scripts\activate
+        python -m venv .venv
+        .\.venv\Scripts\Activate.ps1
 
 3. **Install Dependencies**
 
@@ -312,7 +313,13 @@ Running the tests
 
 A great way to explore the code base is to run the tests.
 
-We can run all tests with:
+For a quick feedback loop, run the smallest test target that covers your change:
+
+.. code:: sh
+
+    pytest tests/core/tools/test_bind_address_config.py
+
+Run the full test suite before larger changes:
 
 .. code:: sh
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,7 +1,7 @@
 Getting Started
 ===============
 
-Welcome to py-libp2p! This guide will walk you through setting up a fully functional libp2p node in Python 🚀
+Welcome to py-libp2p! This guide will walk you through setting up a fully functional libp2p node in Python.
 
 Install
 -------
@@ -71,7 +71,7 @@ For Python, we can use mplex as our multiplexer:
 .. literalinclude:: ../examples/doc-examples/example_multiplexer.py
    :language: python
 
-Running Libp2p
+Running libp2p
 ^^^^^^^^^^^^^^
 
 Now that you have configured a **Transport**, **Crypto** and **Stream Multiplexer** module, you can start your libp2p node:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,19 +1,20 @@
 Install
 ================
 
-Follow the steps below to install `py-libp2p` on your platform.
+Follow the steps below to install ``py-libp2p`` on your platform.
 
 .. note::
 
-    py-libp2p installation is currently supported on Python versions ``<= 3.13``.
+    py-libp2p installation is currently supported on Python versions ``3.10``
+    through ``3.13``.
 
 Using uv (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~
 
-`uv <https://docs.astral.sh/uv/>`_ is a fast Python package manager.
-It is used in py-libp2p's CI/CD pipeline and is the recommended way to install.
+`uv <https://docs.astral.sh/uv/>`_ is a fast Python package manager. It is used
+in py-libp2p's CI/CD pipeline and is the recommended way to install.
 
-1. Install `uv` if you haven't already:
+1. Install ``uv`` if you haven't already:
 
    .. code:: sh
 
@@ -25,7 +26,7 @@ It is used in py-libp2p's CI/CD pipeline and is the recommended way to install.
 
        pip install uv
 
-2. Create a virtual environment and install `py-libp2p`:
+2. Create a virtual environment and install ``py-libp2p``:
 
    .. code:: sh
 
@@ -49,7 +50,7 @@ It is used in py-libp2p's CI/CD pipeline and is the recommended way to install.
 Using pip
 ~~~~~~~~~
 
-If you prefer pip, you can install `py-libp2p` the traditional way:
+If you prefer pip, you can install ``py-libp2p`` the traditional way:
 
 1. Create a Python virtual environment:
 
@@ -99,16 +100,23 @@ Usage
 -----
 Configuration
 ~~~~~~~~~~~~~~
-For all the information on how you can configure `py-libp2p`, TODO.
+For a guided walkthrough of the required transport, security, and stream
+multiplexer configuration, see :doc:`getting_started`. That guide also covers
+listen address environment variables such as ``LIBP2P_BIND`` and
+``LIBP2P_BIND_V6``.
 
 Limits
 ~~~~~~~~~~~~~~
-For help configuring your node to resist malicious network peers, TODO.
+For help configuring your node to resist malicious network peers, start with the
+resource management section in :doc:`getting_started`. The resource manager API
+reference is available at :doc:`libp2p.rcmgr`.
 
 Getting started
 ~~~~~~~~~~~~~~~~
-If you are starting your journey with `py-libp2p`, read the :doc:`getting_started` guide.
+If you are starting your journey with ``py-libp2p``, read the
+:doc:`getting_started` guide.
 
 Tutorials and Examples
 ~~~~~~~~~~~~~~~~~~~~~~~
-You can find multiple examples in the :doc:`examples` guide that will help you understand how to use `py-libp2p` for various scenarios.
+You can find multiple examples in the :doc:`examples` guide that will help you
+understand how to use ``py-libp2p`` for various scenarios.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,26 +1,32 @@
 Introduction
 ============
 
-What is Py-libp2p?
+What is py-libp2p?
 ------------------
 
-Py-libp2p is the Python implementation of the libp2p networking stack, a modular peer-to-peer networking framework. It provides a robust foundation for building decentralized applications and protocols in Python, enabling developers to create resilient, secure, and efficient peer-to-peer networks.
+py-libp2p is the Python implementation of the libp2p networking stack, a
+modular peer-to-peer networking framework. It provides a foundation for building
+decentralized applications and protocols in Python, enabling developers to
+create resilient, secure, and efficient peer-to-peer networks.
 
-The Libp2p Ecosystem
+The libp2p Ecosystem
 --------------------
 
-Libp2p is a collection of networking protocols and specifications that form the foundation of many decentralized systems. Py-libp2p is part of this broader ecosystem, which includes implementations in various languages:
+libp2p is a collection of networking protocols and specifications that form the
+foundation of many decentralized systems. py-libp2p is part of this broader
+ecosystem, which includes implementations in various languages:
 
 * `js-libp2p <https://github.com/libp2p/js-libp2p>`_ - JavaScript implementation
 * `go-libp2p <https://github.com/libp2p/go-libp2p>`_ - Go implementation
 * `rust-libp2p <https://github.com/libp2p/rust-libp2p>`_ - Rust implementation
 
-While each implementation has its strengths, Py-libp2p offers unique advantages for Python developers and researchers.
+While each implementation has its strengths, py-libp2p offers familiar tools and
+workflows for Python developers and researchers.
 
-Why Choose Py-libp2p?
+Why Choose py-libp2p?
 ---------------------
 
-Py-libp2p is particularly well-suited for:
+py-libp2p is particularly well-suited for:
 
 * **Protocol Research and Development**: Python's simplicity and readability make it ideal for experimenting with new protocols and network topologies.
 * **Rapid Prototyping**: Quickly build and test peer-to-peer applications with Python's extensive ecosystem.
@@ -30,29 +36,28 @@ Py-libp2p is particularly well-suited for:
 Current Capabilities
 --------------------
 
-Py-libp2p currently supports these core libp2p features:
+py-libp2p currently supports these core libp2p features:
 
-* **Transports**: TCP, QUIC (near completion, in final testing phase)
-* **Protocols**: Gossipsub v1.1 and v1.2, Identify, Ping
-* **Security**: Noise protocol framework
-* **Connection Management**: Connection multiplexing
+* **Transports**: TCP, QUIC, and WebSocket
+* **Protocols**: Gossipsub, FloodSub, Identify, Identify Push, Ping, Bitswap,
+  and Kademlia DHT
+* **Security**: Noise, TLS, SECIO, and private network support
+* **Connection Management**: Stream multiplexing with Yamux and mplex, plus
+  resource management for connections and streams
+* **Discovery**: Bootstrap, mDNS, random-walk, and rendezvous discovery
+* **NAT traversal**: AutoNAT, Circuit Relay v2, and DCUtR support
 
 Features in Development
 -----------------------
 
-Several important features are currently being actively developed:
-
-* **NAT Traversal**: AutoNAT and relay-based hole punching under development
-* **WebSocket Transport**: Design and scoping discussions underway
-* **Peer Discovery**:
-
-  * **mDNS**: Implementation planned for upcoming sprints
-  * **Bootstrap**: Modular bootstrap system planned after mDNS implementation
+Several areas continue to evolve, including protocol interoperability, transport
+coverage, Filecoin-focused compatibility work, and production-hardening for
+larger deployments.
 
 Use Cases
 ---------
 
-Py-libp2p can be used to build various decentralized applications:
+py-libp2p can be used to build various decentralized applications:
 
 * Distributed file storage systems
 * Decentralized social networks
@@ -64,7 +69,10 @@ Py-libp2p can be used to build various decentralized applications:
 Getting Started
 ---------------
 
-Ready to start building with Py-libp2p? Check out our :doc:`getting_started` guide to begin your journey. For more detailed information about specific features and APIs, explore our :doc:`examples` and :doc:`API documentation <libp2p>`.
+Ready to start building with py-libp2p? Check out our :doc:`getting_started`
+guide to begin your journey. For more detailed information about specific
+features and APIs, explore our :doc:`examples` and
+:doc:`API documentation <libp2p>`.
 
 Contributing
 ------------

--- a/newsfragments/1324.docs.rst
+++ b/newsfragments/1324.docs.rst
@@ -1,0 +1,1 @@
+Improved the user-facing documentation for installation, getting started, contribution setup, and the current feature overview.


### PR DESCRIPTION
## Summary
- refresh the introduction feature summary so it reflects current py-libp2p capabilities
- replace install guide TODO placeholders with links to existing configuration and resource manager docs
- clarify supported Python versions and tighten install-guide formatting
- improve contributor setup guidance, including the Windows virtualenv path and focused-test workflow
- add the release newsfragment for this documentation update

## Test
- python -m pytest tests\examples\attack_simulation\utils\test_attack_metrics.py