### PR TITLE
Polish contributor setup docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing
 
 Thank you for your interest in contributing! We welcome all contributions no matter
 their size. Please read along to learn how to get started. If you get stuck, feel free
-to ask for help in `Libp2p Discover Server <https://discord.gg/GK8TxRNh2s>`_.
+to ask for help in the `libp2p Discord server <https://discord.gg/GK8TxRNh2s>`_.
 
 Setting the stage
 ~~~~~~~~~~~~~~~~~
@@ -21,7 +21,8 @@ Python's built-in ``venv`` module. Instructions vary by platform:
 
 .. note::
 
-    py-libp2p contributor setup is currently supported on Python versions ``<= 3.13``.
+    py-libp2p contributor setup is currently supported on Python versions
+    ``3.10`` through ``3.13``.
 
 Linux Setup
 ^^^^^^^^^^^
@@ -247,8 +248,8 @@ Setup Steps
 
    .. code:: powershell
 
-        python -m venv venv
-        .\venv\Scripts\activate
+        python -m venv .venv
+        .\.venv\Scripts\Activate.ps1
 
 3. **Install Dependencies**
 

--- a/newsfragments/1325.docs.rst
+++ b/newsfragments/1325.docs.rst
@@ -1,0 +1,1 @@
+Polished contributor setup documentation for Discord support, Python version support, and Windows virtual environment activation.


### PR DESCRIPTION
## Summary
- fix the libp2p Discord server wording in the contributing guide
- clarify the supported Python version range for contributors
- keep the Windows virtual environment path consistent with the rest of the docs

## Test
- python -m pytest tests\examples\attack_simulation\utils\test_attack_metrics.py