### PR TITLE
Reject incomplete byte varints

### DIFF
--- a/libp2p/utils/varint.py
+++ b/libp2p/utils/varint.py
@@ -55,6 +55,8 @@ def decode_uvarint(data: bytes) -> int:
         shift += 7
         if shift >= 64:
             raise ValueError("Varint too long")
+    else:
+        raise ParseError("Unexpected end of data while decoding varint")
 
     return result
 
@@ -92,6 +94,9 @@ def decode_varint_with_size(data: bytes) -> tuple[int, int]:
         Tuple[int, int]: (value, bytes_consumed)
 
     """
+    if not data:
+        raise ParseError("Unexpected end of data")
+
     result = 0
     shift = 0
     bytes_consumed = 0
@@ -104,6 +109,8 @@ def decode_varint_with_size(data: bytes) -> tuple[int, int]:
         shift += 7
         if shift >= 64:
             raise ValueError("Varint too long")
+    else:
+        raise ParseError("Unexpected end of data while decoding varint")
 
     return result, bytes_consumed
 

--- a/newsfragments/1327.bugfix.rst
+++ b/newsfragments/1327.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected truncated byte-buffer varints instead of decoding them as partial values.

--- a/tests/core/utils/test_varint.py
+++ b/tests/core/utils/test_varint.py
@@ -3,7 +3,9 @@ import pytest
 from libp2p.exceptions import ParseError
 from libp2p.io.abc import Reader
 from libp2p.utils.varint import (
+    decode_uvarint,
     decode_varint_from_bytes,
+    decode_varint_with_size,
     encode_uvarint,
     encode_varint_prefixed,
     read_varint_prefixed_bytes,
@@ -77,8 +79,31 @@ def test_decode_varint_from_bytes_invalid():
     with pytest.raises(ParseError, match="Unexpected end of data"):
         decode_varint_from_bytes(b"")
 
-    # Incomplete varint (should not raise, but should handle gracefully)
-    # This depends on the implementation - some might raise, others might return partial
+    # Incomplete varints must not be accepted as partial values.
+    for data in (b"\x80", b"\x81", b"\xff\xff"):
+        with pytest.raises(ParseError, match="Unexpected end of data"):
+            decode_varint_from_bytes(data)
+
+
+def test_decode_varint_with_size_invalid():
+    """Test varint-with-size decoding with invalid data."""
+    with pytest.raises(ParseError, match="Unexpected end of data"):
+        decode_varint_with_size(b"")
+
+    for data in (b"\x80", b"\x81", b"\xff\xff"):
+        with pytest.raises(ParseError, match="Unexpected end of data"):
+            decode_varint_with_size(data)
+
+
+def test_decode_varint_rejects_too_long_values():
+    """Test varint decoding rejects values that exceed 64 bits."""
+    too_long = b"\x80" * 10 + b"\x00"
+
+    with pytest.raises(ValueError, match="Varint too long"):
+        decode_uvarint(too_long)
+
+    with pytest.raises(ValueError, match="Varint too long"):
+        decode_varint_with_size(too_long)
 
 
 def test_encode_varint_prefixed():


### PR DESCRIPTION
## What was wrong?

The byte-buffer varint decoders accepted truncated continuation bytes as if they were complete values. For example, a single `0x80` byte could decode to a partial result instead of failing, which makes callers treat malformed length prefixes as valid input.

## How was it fixed?

`decode_uvarint` and `decode_varint_with_size` now raise `ParseError` when the input ends before a terminating byte is found. I also added unit coverage for empty input, incomplete continuation sequences, and oversized varints so the decoder behavior is explicit.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the release notes
