### PR TITLE
fix typo: recieved -> received

### DIFF
--- a/libp2p/security/insecure/transport.py
+++ b/libp2p/security/insecure/transport.py
@@ -148,7 +148,7 @@ async def run_handshake(
 
     # Verify that `remote_peer_id` isn't `None`
     # That is the only condition that `remote_peer_id` would not need to be checked
-    # against the `recieved_peer_id` gotten from the outbound/recieved `msg`.
+    # against the `received_peer_id` gotten from the outbound/received `msg`.
     # The check against `received_peer_id` happens in the next if-block
     if is_initiator and remote_peer_id is None:
         raise HandshakeFailure(


### PR DESCRIPTION
## What was wrong?

'recieved' -> 'received' typo in a comment inside `libp2p/security/insecure/transport.py`.

## How was it fixed?

Single-character comment fix; no behavioral change.

### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

Release note not needed for a comment-only typo fix.
