### PR TITLE
Fix: signer identity validation for signed PeerRecords

### DIFF
--- a/libp2p/peer/peerstore.py
+++ b/libp2p/peer/peerstore.py
@@ -5,6 +5,7 @@ from collections.abc import (
     AsyncIterable,
     Sequence,
 )
+import logging
 
 from multiaddr import (
     Multiaddr,
@@ -39,6 +40,23 @@ from .peerinfo import (
 )
 
 PERMANENT_ADDR_TTL = 0
+
+logger = logging.getLogger(__name__)
+
+
+def _peer_record_signer_matches(envelope: Envelope) -> bool:
+    """Return True if envelope signer identity matches record.peer_id."""
+    try:
+        record = envelope.record()
+        if ID.from_pubkey(envelope.public_key) != record.peer_id:
+            logger.debug(
+                "Rejected peer record: signer identity does not match record peer_id"
+            )
+            return False
+        return True
+    except Exception:
+        logger.debug("Rejected peer record: failed to validate signer identity")
+        return False
 
 
 def create_signed_peer_record(
@@ -327,6 +345,7 @@ class PeerStore(IPeerStore):
 
         This function:
         - Extracts the peer ID and sequence number from the envelope
+        - Rejects the record if the signer identity does not match record.peer_id
         - Rejects the record if it's older (lower seq)
         - Updates the stored peer record and replaces associated addresses if accepted
 
@@ -334,6 +353,9 @@ class PeerStore(IPeerStore):
         :param ttl: Time-to-live for the included multiaddrs (in seconds).
         :return: True if the record was accepted and stored; False if it was rejected.
         """
+        if not _peer_record_signer_matches(envelope):
+            return False
+
         record = envelope.record()
         peer_id = record.peer_id
 

--- a/libp2p/peer/persistent/async_/peerstore.py
+++ b/libp2p/peer/persistent/async_/peerstore.py
@@ -22,7 +22,11 @@ from libp2p.peer.envelope import Envelope
 from libp2p.peer.id import ID
 from libp2p.peer.peerdata import PeerData, PeerDataError
 from libp2p.peer.peerinfo import PeerInfo
-from libp2p.peer.peerstore import PeerRecordState, PeerStoreError
+from libp2p.peer.peerstore import (
+    PeerRecordState,
+    PeerStoreError,
+    _peer_record_signer_matches,
+)
 
 from ..datastore.base import IDatastore
 from ..serialization import (
@@ -607,6 +611,9 @@ class AsyncPersistentPeerStore(IAsyncPeerStore):
         Accept and store a signed PeerRecord, unless it's older than
         the one already stored.
         """
+        if not _peer_record_signer_matches(envelope):
+            return False
+
         record = envelope.record()
         peer_id = record.peer_id
 

--- a/libp2p/peer/persistent/sync/peerstore.py
+++ b/libp2p/peer/persistent/sync/peerstore.py
@@ -21,7 +21,11 @@ from libp2p.peer.envelope import Envelope
 from libp2p.peer.id import ID
 from libp2p.peer.peerdata import PeerData, PeerDataError
 from libp2p.peer.peerinfo import PeerInfo
-from libp2p.peer.peerstore import PeerRecordState, PeerStoreError
+from libp2p.peer.peerstore import (
+    PeerRecordState,
+    PeerStoreError,
+    _peer_record_signer_matches,
+)
 
 from ..datastore.base_sync import IDatastoreSync
 from ..serialization import (
@@ -573,6 +577,9 @@ class SyncPersistentPeerStore(IPeerStore):
         Accept and store a signed PeerRecord, unless it's older than
         the one already stored.
         """
+        if not _peer_record_signer_matches(envelope):
+            return False
+
         record = envelope.record()
         peer_id = record.peer_id
 

--- a/newsfragments/1338.bugfix.rst
+++ b/newsfragments/1338.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed peer record validation to ensure signed ``PeerRecord``s have matching signer identity and peer ID, preventing certified address book poisoning for arbitrary peer IDs.

--- a/tests/core/peer/test_peer_record_signer_binding.py
+++ b/tests/core/peer/test_peer_record_signer_binding.py
@@ -1,0 +1,86 @@
+"""
+Regression tests for libp2p/py-libp2p#1338.
+
+A signed ``PeerRecord`` must only be accepted when the envelope's signer
+identity matches the ``peer_id`` claimed inside the record.
+"""
+
+from __future__ import annotations
+
+import pytest
+from multiaddr import Multiaddr
+
+from libp2p.crypto.ed25519 import create_new_key_pair
+from libp2p.peer.envelope import Envelope, seal_record
+from libp2p.peer.id import ID
+from libp2p.peer.peer_record import PeerRecord
+from libp2p.peer.peerstore import PeerStore
+from libp2p.peer.persistent import (
+    create_async_memory_peerstore,
+    create_sync_memory_peerstore,
+)
+
+_ATTACKER_ADDR = Multiaddr("/ip4/10.0.0.1/tcp/4001")
+_OWNER_ADDR = Multiaddr("/ip4/127.0.0.1/tcp/4001")
+_TTL = 7200
+
+
+def _forged_envelope() -> tuple[ID, Envelope]:
+    victim = create_new_key_pair()
+    attacker = create_new_key_pair()
+    victim_id = ID.from_pubkey(victim.public_key)
+    record = PeerRecord(victim_id, [_ATTACKER_ADDR])
+    forged = seal_record(record, attacker.private_key)
+    return victim_id, forged
+
+
+def _self_signed_envelope() -> tuple[ID, Envelope]:
+    owner = create_new_key_pair()
+    owner_id = ID.from_pubkey(owner.public_key)
+    record = PeerRecord(owner_id, [_OWNER_ADDR])
+    envelope = seal_record(record, owner.private_key)
+    return owner_id, envelope
+
+
+@pytest.mark.parametrize(
+    "store_factory",
+    [PeerStore, create_sync_memory_peerstore],
+    ids=["in_memory", "sync_persistent"],
+)
+def test_rejects_forged_peer_record(store_factory) -> None:
+    store = store_factory()
+    victim_id, forged = _forged_envelope()
+
+    assert store.consume_peer_record(forged, _TTL) is False
+    assert store.get_peer_record(victim_id) is None
+
+
+@pytest.mark.parametrize(
+    "store_factory",
+    [PeerStore, create_sync_memory_peerstore],
+    ids=["in_memory", "sync_persistent"],
+)
+def test_accepts_self_signed_peer_record(store_factory) -> None:
+    store = store_factory()
+    owner_id, envelope = _self_signed_envelope()
+
+    assert store.consume_peer_record(envelope, _TTL) is True
+    assert set(store.addrs(owner_id)) == {_OWNER_ADDR}
+
+
+@pytest.mark.trio
+async def test_rejects_forged_peer_record_async() -> None:
+    store = create_async_memory_peerstore()
+    victim_id, forged = _forged_envelope()
+
+    assert await store.consume_peer_record_async(forged, _TTL) is False
+    assert await store.get_peer_record_async(victim_id) is None
+
+
+@pytest.mark.trio
+async def test_accepts_self_signed_peer_record_async() -> None:
+    store = create_async_memory_peerstore()
+    owner_id, envelope = _self_signed_envelope()
+
+    assert await store.consume_peer_record_async(envelope, _TTL) is True
+    assert set(await store.addrs_async(owner_id)) == {_OWNER_ADDR}


### PR DESCRIPTION
## What was wrong?

Fixes #1338

KadDHT accepted signed PeerRecords where the signer identity did not match record.peer_id.

Although the envelope signature was valid, the signer public key embedded in the envelope could derive to a different peer ID than the one claimed in the record payload.

This allowed authenticated but incorrectly bound peer records to poison the certified address book for arbitrary peer IDs.

## How was it fixed?

Added signer identity binding validation before accepting signed peer records.

The fix enforces:

`signer_peer_id = ID.from_pubkey(envelope.public_key)`

Records with mismatched signer identities are now rejected before they can update certified peer addresses.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the release notes

#### Cute Animal Picture