### PR TITLE
Update multiaddr and p2pclient version

### DIFF
--- a/docs/dependency_graph/dependencies.md
+++ b/docs/dependency_graph/dependencies.md
@@ -8,15 +8,17 @@
 Total: 28 dependencies
 
 - **aioquic** (>=1.2.0)
+- **anyio** (>=4.0)
 - **base58** (>=1.0.3)
+- **cbor2** (>=5.4.0)
 - **coincurve** (==21.0.0)
 - **exceptiongroup** (>=1.2.0) [python_version < '3.11']
 - **fastecdsa** (==2.3.2) [sys_platform != 'win32']
 - **grpcio** (>=1.41.0)
 - **httpx** (>=0.25.0)
 - **lru-dict** (>=1.1.6)
-- **miniupnpc** (>=2.3)
-- **multiaddr** (==0.0.11)
+- **miniupnpc** (>=2.3,\<3.0)
+- **multiaddr** (>=0.2.0)
 - **mypy-protobuf** (>=3.0.0)
 - **noiseprotocol** (>=0.3.0)
 - **protobuf** (>=4.25.0,\<7.0.0)
@@ -27,13 +29,15 @@ Total: 28 dependencies
 - **pycryptodome** (>=3.9.2)
 - **pynacl** (>=1.3.0)
 - **requests** (>=2.28.0)
-- **requests** (>=2.25.0)
 - **rpcudp** (>=3.0.0)
 - **trio** (>=0.26.0)
 - **trio-typing** (>=0.0.4)
 - **trio-websocket** (>=0.11.0)
 - **types-requests**
-- **types-requests**
 - **zeroconf** (>=0.147.0,\<0.148.0)
 
 ## Optional Dependencies
+
+### Webrtc (1 dependencies)
+
+- **aiortc** (>=1.5.0,\<2.0)

--- a/libp2p/transport/webrtc/multiaddr_utils.py
+++ b/libp2p/transport/webrtc/multiaddr_utils.py
@@ -16,156 +16,18 @@ Spec: https://github.com/libp2p/specs/blob/master/webrtc/webrtc-direct.md
 
 from __future__ import annotations
 
-import logging
-import threading
+from multiaddr import Multiaddr
+from multiaddr.exceptions import ProtocolLookupError
 
-from multiaddr import (
-    Multiaddr,
-    protocols as _mp,
-)
-
-from .constants import (
-    CERTHASH_PROTOCOL_CODE,
-    WEBRTC_DIRECT_PROTOCOL_CODE,
-    WEBRTC_PROTOCOL_CODE,
-)
 from .exceptions import WebRTCMultiaddrError
 
-logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Register WebRTC protocol codes with py-multiaddr.
-#
-# py-multiaddr 0.0.11 ships with the old p2p-webrtc-direct (0x0114) but NOT
-# the current spec protocols.  We register them at import time so that
-# Multiaddr("/ip4/.../udp/.../webrtc-direct") construction works.
-#
-# certhash (0x01D2) takes a string value but py-multiaddr's binary codec
-# system doesn't handle it correctly, so we parse certhash from the string
-# representation instead of relying on protocols().
-# ---------------------------------------------------------------------------
-_PROTOCOLS_TO_REGISTER = [
-    _mp.Protocol(code=WEBRTC_DIRECT_PROTOCOL_CODE, name="webrtc-direct", codec=None),
-    _mp.Protocol(code=WEBRTC_PROTOCOL_CODE, name="webrtc", codec=None),
-    _mp.Protocol(code=CERTHASH_PROTOCOL_CODE, name="certhash", codec="utf8"),
-]
-
-_registered = False
-_registration_lock = threading.Lock()
-
-
-def _ensure_protocols_registered() -> None:
-    """
-    Register WebRTC multiaddr protocols (idempotent, thread-safe).
-
-    py-multiaddr normally locks its protocol registry after initial setup.
-    We have to temporarily unlock it to add the WebRTC protocol codes that
-    ship on the spec but not in the library yet.  We use the public
-    ``REGISTRY.add`` API for the insertion itself; the unlock / relock
-    step touches ``REGISTRY._locked`` because no public equivalent is
-    exposed.  The call is guarded with ``hasattr`` so that if py-multiaddr
-    ever changes the internal attribute name, registration fails gracefully
-    (logged, skipped) instead of raising on import.
-    """
-    global _registered
-    if _registered:
-        return
-    with _registration_lock:
-        if _registered:  # double-checked locking
-            return
-
-        registry = _mp.REGISTRY
-        was_locked = getattr(registry, "locked", False)
-
-        if was_locked and not hasattr(registry, "_locked"):
-            logger.warning(
-                "py-multiaddr REGISTRY is locked but has no `_locked` attribute "
-                "we can toggle; skipping WebRTC multiaddr protocol registration. "
-                "Install a compatible py-multiaddr version or register the "
-                "protocols manually."
-            )
-            _registered = True  # don't retry on every call
-            return
-
-        if was_locked:
-            registry._locked = False  # type: ignore[attr-defined]
-        try:
-            for proto in _PROTOCOLS_TO_REGISTER:
-                try:
-                    registry.add(proto)
-                except Exception as e:
-                    logger.debug(
-                        "WebRTC multiaddr protocol %s not registered: %s",
-                        proto.name,
-                        e,
-                    )
-        finally:
-            if was_locked:
-                registry._locked = True  # type: ignore[attr-defined]
-        _registered = True
-        logger.debug("Registered WebRTC multiaddr protocols")
-
-
-# Register on import
-_ensure_protocols_registered()
-
-# Protocol name strings
 _WEBRTC_DIRECT_NAME = "webrtc-direct"
 _WEBRTC_NAME = "webrtc"
 _CERTHASH_NAME = "certhash"
 
-# All known multiaddr protocol names.  Used by _parse_multiaddr_string to
-# distinguish protocol names from protocol values.  If the next path segment
-# is in this set it starts a new protocol; otherwise it is the current
-# protocol's value (e.g. "127.0.0.1" for ip4, "uEi..." for certhash).
-_KNOWN_PROTOCOL_NAMES = frozenset(
-    {
-        "ip4",
-        "ip6",
-        "tcp",
-        "udp",
-        _WEBRTC_DIRECT_NAME,
-        _WEBRTC_NAME,
-        _CERTHASH_NAME,
-        "p2p",
-        "p2p-circuit",
-        "quic",
-        "quic-v1",
-        "tls",
-        "noise",
-        "http",
-        "https",
-        "ws",
-        "wss",
-        "dns",
-        "dns4",
-        "dns6",
-        "dnsaddr",
-    }
-)
 
-
-def _parse_multiaddr_string(maddr_str: str) -> list[tuple[str, str]]:
-    """
-    Parse a multiaddr string into ``(protocol_name, value)`` pairs.
-
-    Handles certhash and other value-bearing protocols correctly by treating
-    the string as a sequence of ``/protocol[/value]`` segments where known
-    protocol names delimit the segments.
-    """
-    parts = maddr_str.split("/")
-    result: list[tuple[str, str]] = []
-    i = 1  # skip leading empty string
-    while i < len(parts):
-        proto = parts[i]
-        # Next element is a value if it's NOT a known protocol name
-        if i + 1 < len(parts) and parts[i + 1] not in _KNOWN_PROTOCOL_NAMES:
-            result.append((proto, parts[i + 1]))
-            i += 2
-        else:
-            result.append((proto, ""))
-            i += 1
-    return result
+def _protocol_names(maddr: Multiaddr) -> list[str]:
+    return [protocol.name for protocol in maddr.protocols()]
 
 
 def is_webrtc_direct_multiaddr(maddr: Multiaddr) -> bool:
@@ -176,8 +38,7 @@ def is_webrtc_direct_multiaddr(maddr: Multiaddr) -> bool:
     :returns: True if the address contains ``/webrtc-direct``.
     """
     try:
-        parts = _parse_multiaddr_string(str(maddr))
-        names = [p for p, _ in parts]
+        names = _protocol_names(maddr)
         if _WEBRTC_DIRECT_NAME not in names:
             return False
         idx = names.index(_WEBRTC_DIRECT_NAME)
@@ -193,14 +54,20 @@ def is_webrtc_multiaddr(maddr: Multiaddr) -> bool:
     A valid address contains ``/p2p-circuit/webrtc/``.
     """
     try:
-        parts = _parse_multiaddr_string(str(maddr))
-        names = [p for p, _ in parts]
+        names = _protocol_names(maddr)
         if _WEBRTC_NAME not in names:
             return False
         idx = names.index(_WEBRTC_NAME)
         return idx > 0 and names[idx - 1] == "p2p-circuit"
     except Exception:
         return False
+
+
+def _value_for_protocol(maddr: Multiaddr, protocol: str) -> str | None:
+    try:
+        return maddr.value_for_protocol(protocol)
+    except ProtocolLookupError:
+        return None
 
 
 def parse_webrtc_direct_multiaddr(
@@ -218,19 +85,17 @@ def parse_webrtc_direct_multiaddr(
         raise WebRTCMultiaddrError(f"Not a valid /webrtc-direct multiaddr: {maddr}")
 
     try:
-        parts_dict = dict(_parse_multiaddr_string(str(maddr)))
-
-        host = parts_dict.get("ip4") or parts_dict.get("ip6")
+        host = _value_for_protocol(maddr, "ip4") or _value_for_protocol(maddr, "ip6")
         if not host:
             raise WebRTCMultiaddrError(f"No IP address in multiaddr: {maddr}")
 
-        port_str = parts_dict.get("udp")
+        port_str = _value_for_protocol(maddr, "udp")
         if not port_str:
             raise WebRTCMultiaddrError(f"No UDP port in multiaddr: {maddr}")
         port = int(port_str)
 
-        certhash = parts_dict.get(_CERTHASH_NAME) or None
-        peer_id = parts_dict.get("p2p") or None
+        certhash = _value_for_protocol(maddr, _CERTHASH_NAME)
+        peer_id = _value_for_protocol(maddr, "p2p")
 
         return (host, port, certhash, peer_id)
 

--- a/newsfragments/1356.misc.rst
+++ b/newsfragments/1356.misc.rst
@@ -1,0 +1,1 @@
+Bumped ``p2pclient`` to ``>=0.3.0`` and ``multiaddr`` to ``>=0.2.0`` to enable proper WebRTC multiaddr support. WebRTC multiaddrs now use native py-multiaddr parsing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "miniupnpc>=2.3,<3.0",
     "requests>=2.28.0",
     "types-requests",
-    "multiaddr==0.0.11",
+    "multiaddr>=0.2.0",
     "mypy-protobuf>=3.0.0",
     "noiseprotocol>=0.3.0",
     "protobuf>=4.25.0,<7.0.0",
@@ -111,7 +111,7 @@ docs = [
 ]
 test = [
     "factory-boy>=2.12.0,<3.0.0",
-    "p2pclient>=0.2.1",
+    "p2pclient>=0.3.0",
     "pytest>=7.0.0",
     "pytest-timeout>=2.4.0",
     "pytest-trio>=0.5.2",

--- a/tests/core/transport/webrtc/test_multiaddr_utils.py
+++ b/tests/core/transport/webrtc/test_multiaddr_utils.py
@@ -18,6 +18,12 @@ from libp2p.transport.webrtc.multiaddr_utils import (
 class TestIsWebrtcDirectMultiaddr:
     """Test WebRTC Direct multiaddr detection."""
 
+    def test_native_certhash_protocol_parsing(self):
+        cert = WebRTCCertificate.generate()
+        certhash = cert.fingerprint_to_multibase()
+        maddr = Multiaddr(f"/ip4/127.0.0.1/udp/9090/webrtc-direct/certhash/{certhash}")
+        assert maddr.value_for_protocol("certhash") == certhash
+
     def test_valid_ipv4_webrtc_direct(self):
         maddr = Multiaddr("/ip4/127.0.0.1/udp/9090/webrtc-direct")
         assert is_webrtc_direct_multiaddr(maddr)

--- a/tests/interop/perf/test_perf_test_helpers.py
+++ b/tests/interop/perf/test_perf_test_helpers.py
@@ -9,6 +9,8 @@ import sys
 import pytest
 import multiaddr
 
+pytest.importorskip("redis")
+
 try:
     ExceptionGroup  # noqa: B018
 except NameError:


### PR DESCRIPTION
## What was wrong?

Closes #1356

Bump the py-multiaddr dependency to >=0.2.0 by removing the version constraint imposed by p2pclient.
This unblocks the dependency upgrade requested in #1356 and allows py-libp2p to use newer versions of py-multiaddr.

## How was it fixed?

* Bump `multiaddr` to `>=0.2.0` and `p2pclient` to `>=0.3.0` (p2pclient 0.3.0 relaxes the multiaddr upper bound and fixes the `anyio.abc.SocketStreamServer` import error).
* Refactor `libp2p/transport/webrtc/multiaddr_utils.py` to use native py-multiaddr 0.2.0 parsing (`protocols()`, `value_for_protocol()`) instead of runtime protocol registration and custom string parsing.
* Regenerate `docs/dependency_graph/dependencies.md` via the OSO dependency-graph script.
* Add `newsfragments/1356.misc.rst`.
* **Redis:** removed from the `test` dependency group (not needed for `make test` / core CI). Redis remains available via `tox -e py*-interop`, `interop/` subproject deps, and ad-hoc install for perf scripts. Interop perf helper tests skip when redis is not installed.

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)