### PR TITLE
fix(tls): verify libp2p identity without PKIX CA trust

### DIFF
--- a/docs/tls-support.rst
+++ b/docs/tls-support.rst
@@ -189,6 +189,15 @@ AutoTLS bootstrap flow and is not reachable on a standard node.
 - Use TLS 1.3 or later.
 - Pin certificates for critical peers.
 
+Platform requirements
+~~~~~~~~~~~~~~~~~~~~~
+
+- **CPython 3.10+** is required for the TLS transport. Inbound server contexts
+  use ctypes to access the underlying OpenSSL ``SSL_CTX`` handle; this is not
+  supported on PyPy or other non-CPython runtimes.
+- The ``libssl`` shared library loaded via ctypes must match the OpenSSL
+  version linked to CPython's ``_ssl`` module.
+
 Troubleshooting
 ---------------
 
@@ -199,9 +208,12 @@ Troubleshooting
    * - Problem
      - Cause
      - Solution
-   * - Certificate not trusted
-     - Self-signed without trust store entry
-     - Add cert to local trust store or disable verification **only** in testing.
+   * - Certificate verification failed
+     - Missing libp2p extension, invalid signature, or expired cert
+     - Ensure peers use libp2p TLS identity certificates; check system clock.
+   * - ``TLSV1_ALERT_UNKNOWN_CA``
+     - Legacy PKIX rejection of self-signed libp2p certs (fixed in recent releases)
+     - Upgrade to a release with libp2p extension verification; no PKIX trust store needed.
    * - Protocol negotiation failed
      - One peer does not support `/tls/1.0.0`
      - Enable TLS on both peers or use Noise.

--- a/docs/tls-support.rst
+++ b/docs/tls-support.rst
@@ -118,12 +118,15 @@ Dialer node:
 
 **Note for testing with self-signed certificates**
 
-When testing with self-signed certificates, peers need to trust each other's certificates.
-You can do this by calling ``trust_peer_cert_pem()`` on the TLS transport before creating the host:
+When testing with self-signed certificates in unit tests or demos, peers may call
+``trust_peer_cert_pem()`` to preload a peer cert into the OpenSSL trust store.
+Production interop does **not** require this: identity is verified via the
+libp2p X.509 extension after the handshake (same model as go-libp2p and
+js-libp2p).
 
 .. code-block:: python
 
-   # For testing: trust peer certificates
+   # Optional for tests/demos only: PKIX trust store workaround
    listener_tls.trust_peer_cert_pem(dialer_tls.get_certificate_pem())
    dialer_tls.trust_peer_cert_pem(listener_tls.get_certificate_pem())
 
@@ -163,10 +166,10 @@ Mutual authentication (inbound)
 
 Inbound TLS connections **must** present a client certificate that carries the
 libp2p X.509 extension so py-libp2p can derive and verify the remote Peer ID.
-The server-side SSL context requests a client certificate (``CERT_OPTIONAL``);
-post-handshake logic enforces the requirement. If the remote peer completes the
-TLS handshake without sending a certificate, the connection is rejected and no
-``SecureSession`` is created.
+The server requests a client certificate during the TLS handshake; post-handshake
+logic enforces the requirement via the libp2p extension (not PKIX CA trust). If
+the remote peer completes the TLS handshake without sending a certificate, the
+connection is rejected and no ``SecureSession`` is created.
 
 **AutoTLS exception:** When ``enable_autotls=True``, broker registration may
 use the primitive key-exchange side-channel or a placeholder identity instead

--- a/docs/tls-support.rst
+++ b/docs/tls-support.rst
@@ -164,11 +164,20 @@ Security Considerations
 Mutual authentication (inbound)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Per `libp2p specs/tls/tls.md` (Handshake Protocol + Peer Authentication):
+
+- Servers **must** require client authentication during the TLS handshake.
+- Endpoints **must** verify peer identity via the libp2p Public Key Extension
+  in a self-signed certificate (not PKIX CA trust).
+- If the remote peer sends no certificate, or extension/signature verification
+  fails, the connection **must** be aborted.
+
 Inbound TLS connections **must** present a client certificate that carries the
 libp2p X.509 extension so py-libp2p can derive and verify the remote Peer ID.
 The server requests a client certificate during the TLS handshake; post-handshake
-logic enforces the requirement via the libp2p extension (not PKIX CA trust). If
-the remote peer completes the TLS handshake without sending a certificate, the
+logic enforces the requirement via ``verify_certificate_chain()`` (validity
+window, single cert, self-signature, extension OID, host-key signature, peer ID).
+If the remote peer completes the TLS handshake without sending a certificate, the
 connection is rejected and no ``SecureSession`` is created.
 
 **AutoTLS exception:** When ``enable_autotls=True``, broker registration may

--- a/examples/tls/tls_listener_dialer_demo.py
+++ b/examples/tls/tls_listener_dialer_demo.py
@@ -112,9 +112,8 @@ async def run_full_test():
 
     listener_tls = TLSTransport(listener_key_pair)
     dialer_tls = TLSTransport(dialer_key_pair)
-
-    listener_tls.trust_peer_cert_pem(dialer_tls.get_certificate_pem())
-    dialer_tls.trust_peer_cert_pem(listener_tls.get_certificate_pem())
+    # PKIX trust-store preloading is optional for demos; production interop uses
+    # libp2p extension verification after the handshake.
 
     listener_sec_opt = {PROTOCOL_ID: listener_tls}
     dialer_sec_opt = {PROTOCOL_ID: dialer_tls}

--- a/libp2p/security/tls/openssl_verify.py
+++ b/libp2p/security/tls/openssl_verify.py
@@ -12,6 +12,18 @@ at the OpenSSL layer via a verify callback that always accepts.
 
 See libp2p specs/tls/tls.md Peer Authentication: identity is carried in a
 self-signed certificate with the libp2p Public Key Extension, not PKIX CA trust.
+
+Platform requirements
+---------------------
+- **CPython only.** ``_ssl_ctx_ptr()`` reads the undocumented ``PySSLContext``
+  struct layout via ``id(context) + offset``. This is unsupported on PyPy,
+  GraalPython, and other non-CPython runtimes.
+- **libssl coupling.** ctypes must load the same OpenSSL shared library that
+  CPython's ``_ssl`` module is linked against. On Windows we prefer the DLL
+  directory adjacent to ``_ssl.pyd``; on Unix we use ``find_library("ssl")``.
+
+Long-term, an upstream CPython API exposing the ``SSL_CTX*`` handle would
+remove the need for the layout hack.
 """
 
 from __future__ import annotations
@@ -26,9 +38,6 @@ from typing import Any
 # OpenSSL SSL_VERIFY_PEER requests a peer certificate during the handshake.
 _VERIFY_PEER = 0x01
 
-# Keep callbacks alive for the process lifetime; OpenSSL stores only a pointer.
-_verify_callbacks: list[Any] = []
-
 _libssl: ctypes.CDLL | None = None
 _SSL_CTX_set_verify: Any = None
 
@@ -41,11 +50,12 @@ def _load_libssl() -> ctypes.CDLL:
         dll_dir = Path(_ssl.__file__).resolve().parent
         for name in ("libssl-3.dll", "libssl-1_1.dll", "ssleay32.dll"):
             for candidate in (dll_dir / name, Path(name)):
-                if candidate == Path(name) or candidate.is_file():
-                    try:
-                        return ctypes.CDLL(str(candidate))
-                    except OSError:
-                        continue
+                if not candidate.is_file():
+                    continue
+                try:
+                    return ctypes.CDLL(str(candidate))
+                except OSError:
+                    continue
         raise RuntimeError("Could not load libssl on Windows")
 
     libname = ctypes.util.find_library("ssl")
@@ -72,9 +82,13 @@ def _ensure_libssl() -> None:
 
 
 def _ssl_ctx_ptr(context: ssl.SSLContext) -> int:
-    """Return the OpenSSL SSL_CTX* for a Python SSLContext (CPython layout)."""
-    # PySSLContext: PyObject_HEAD then SSL_CTX *ctx.
-    # 64-bit: 16 bytes; 32-bit: 8 bytes.
+    """
+    Return the OpenSSL SSL_CTX* for a Python SSLContext (CPython layout).
+
+    Reads ``PySSLContext.ctx`` via a fixed offset past ``PyObject_HEAD``
+    (16 bytes on 64-bit, 8 bytes on 32-bit). This layout is undocumented and
+    may change in future CPython versions or free-threaded builds.
+    """
     offset = 16 if sys.maxsize > 2**32 else 8
     # pyrefly: ignore
     ptr = ctypes.cast(
@@ -92,6 +106,9 @@ def _accept_all_verify_cb(_preverify_ok: int, _x509_ctx: int) -> int:
 
 _VerifyCallback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
 
+# Single process-lifetime callback; OpenSSL stores only a pointer.
+_ACCEPT_ALL_VERIFY_CB = _VerifyCallback(_accept_all_verify_cb)
+
 
 def install_skip_pkix_peer_verification(context: ssl.SSLContext) -> None:
     """
@@ -103,7 +120,10 @@ def install_skip_pkix_peer_verification(context: ssl.SSLContext) -> None:
     PKIX CA chains.  This helper satisfies the TLS-layer certificate request
     while deferring identity checks to verify_certificate_chain().
     """
+    if sys.implementation.name != "cpython":
+        raise RuntimeError(
+            "libp2p TLS PKIX skip requires CPython; "
+            f"unsupported implementation: {sys.implementation.name}"
+        )
     _ensure_libssl()
-    verify_cb = _VerifyCallback(_accept_all_verify_cb)
-    _verify_callbacks.append(verify_cb)
-    _SSL_CTX_set_verify(_ssl_ctx_ptr(context), _VERIFY_PEER, verify_cb)
+    _SSL_CTX_set_verify(_ssl_ctx_ptr(context), _VERIFY_PEER, _ACCEPT_ALL_VERIFY_CB)

--- a/libp2p/security/tls/openssl_verify.py
+++ b/libp2p/security/tls/openssl_verify.py
@@ -9,19 +9,19 @@ Go uses InsecureSkipVerify + VerifyPeerCertificate; Node.js uses
 rejectUnauthorized=false + requestCert=true + custom verifyPeerCertificate.
 We mirror that by requesting peer certificates while skipping PKIX verification
 at the OpenSSL layer via a verify callback that always accepts.
+
+See libp2p specs/tls/tls.md Peer Authentication: identity is carried in a
+self-signed certificate with the libp2p Public Key Extension, not PKIX CA trust.
 """
 
 from __future__ import annotations
 
 import ctypes
 import ctypes.util
+from pathlib import Path
 import ssl
+import sys
 from typing import Any
-
-_libssl = ctypes.CDLL(ctypes.util.find_library("ssl"))
-SSL_CTX_set_verify = _libssl.SSL_CTX_set_verify
-SSL_CTX_set_verify.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
-SSL_CTX_set_verify.restype = None
 
 # OpenSSL SSL_VERIFY_PEER requests a peer certificate during the handshake.
 _VERIFY_PEER = 0x01
@@ -29,13 +29,56 @@ _VERIFY_PEER = 0x01
 # Keep callbacks alive for the process lifetime; OpenSSL stores only a pointer.
 _verify_callbacks: list[Any] = []
 
+_libssl: ctypes.CDLL | None = None
+_SSL_CTX_set_verify: Any = None
+
+
+def _load_libssl() -> ctypes.CDLL:
+    """Load the platform OpenSSL libssl shared library."""
+    if sys.platform == "win32":
+        import _ssl
+
+        dll_dir = Path(_ssl.__file__).resolve().parent
+        for name in ("libssl-3.dll", "libssl-1_1.dll", "ssleay32.dll"):
+            for candidate in (dll_dir / name, Path(name)):
+                if candidate == Path(name) or candidate.is_file():
+                    try:
+                        return ctypes.CDLL(str(candidate))
+                    except OSError:
+                        continue
+        raise RuntimeError("Could not load libssl on Windows")
+
+    libname = ctypes.util.find_library("ssl")
+    if libname is not None:
+        return ctypes.CDLL(libname)
+
+    for fallback in ("libssl.so.3", "libssl.so.1.1", "ssl"):
+        try:
+            return ctypes.CDLL(fallback)
+        except OSError:
+            continue
+
+    raise RuntimeError("Could not load libssl")
+
+
+def _ensure_libssl() -> None:
+    global _libssl, _SSL_CTX_set_verify
+    if _libssl is not None:
+        return
+    _libssl = _load_libssl()
+    _SSL_CTX_set_verify = _libssl.SSL_CTX_set_verify
+    _SSL_CTX_set_verify.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+    _SSL_CTX_set_verify.restype = None
+
 
 def _ssl_ctx_ptr(context: ssl.SSLContext) -> int:
     """Return the OpenSSL SSL_CTX* for a Python SSLContext (CPython layout)."""
-    # PySSLContext: PyObject_HEAD (16 bytes on 64-bit) then SSL_CTX *ctx.
+    # PySSLContext: PyObject_HEAD then SSL_CTX *ctx.
+    # 64-bit: 16 bytes; 32-bit: 8 bytes.
+    offset = 16 if sys.maxsize > 2**32 else 8
     # pyrefly: ignore
     ptr = ctypes.cast(
-        id(context) + 16,
+        id(context) + offset,
         ctypes.POINTER(ctypes.c_void_p),
     ).contents.value
     if ptr is None:
@@ -54,10 +97,13 @@ def install_skip_pkix_peer_verification(context: ssl.SSLContext) -> None:
     """
     Request peer certificates but skip PKIX/CA chain verification.
 
-    libp2p verifies peer identity via the libp2p X.509 extension after the
-    handshake completes. This must be called after the final verify_mode is set
-    on the context.
+    libp2p specs/tls/tls.md requires servers to request client authentication
+    during the TLS handshake (Handshake Protocol) and endpoints to verify peer
+    identity via the libp2p Public Key Extension (Peer Authentication), not via
+    PKIX CA chains.  This helper satisfies the TLS-layer certificate request
+    while deferring identity checks to verify_certificate_chain().
     """
+    _ensure_libssl()
     verify_cb = _VerifyCallback(_accept_all_verify_cb)
     _verify_callbacks.append(verify_cb)
-    SSL_CTX_set_verify(_ssl_ctx_ptr(context), _VERIFY_PEER, verify_cb)
+    _SSL_CTX_set_verify(_ssl_ctx_ptr(context), _VERIFY_PEER, verify_cb)

--- a/libp2p/security/tls/openssl_verify.py
+++ b/libp2p/security/tls/openssl_verify.py
@@ -1,0 +1,63 @@
+"""
+OpenSSL helpers for libp2p TLS.
+
+Python's ssl module maps CERT_OPTIONAL to OpenSSL peer verification, which
+rejects self-signed libp2p identity certificates with TLSV1_ALERT_UNKNOWN_CA
+before our libp2p extension verification runs.
+
+Go uses InsecureSkipVerify + VerifyPeerCertificate; Node.js uses
+rejectUnauthorized=false + requestCert=true + custom verifyPeerCertificate.
+We mirror that by requesting peer certificates while skipping PKIX verification
+at the OpenSSL layer via a verify callback that always accepts.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import ssl
+from typing import Any
+
+_libssl = ctypes.CDLL(ctypes.util.find_library("ssl"))
+SSL_CTX_set_verify = _libssl.SSL_CTX_set_verify
+SSL_CTX_set_verify.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+SSL_CTX_set_verify.restype = None
+
+# OpenSSL SSL_VERIFY_PEER requests a peer certificate during the handshake.
+_VERIFY_PEER = 0x01
+
+# Keep callbacks alive for the process lifetime; OpenSSL stores only a pointer.
+_verify_callbacks: list[Any] = []
+
+
+def _ssl_ctx_ptr(context: ssl.SSLContext) -> int:
+    """Return the OpenSSL SSL_CTX* for a Python SSLContext (CPython layout)."""
+    # PySSLContext: PyObject_HEAD (16 bytes on 64-bit) then SSL_CTX *ctx.
+    # pyrefly: ignore
+    ptr = ctypes.cast(
+        id(context) + 16,
+        ctypes.POINTER(ctypes.c_void_p),
+    ).contents.value
+    if ptr is None:
+        raise RuntimeError("failed to resolve SSL_CTX pointer from SSLContext")
+    return ptr
+
+
+def _accept_all_verify_cb(_preverify_ok: int, _x509_ctx: int) -> int:
+    return 1
+
+
+_VerifyCallback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
+
+
+def install_skip_pkix_peer_verification(context: ssl.SSLContext) -> None:
+    """
+    Request peer certificates but skip PKIX/CA chain verification.
+
+    libp2p verifies peer identity via the libp2p X.509 extension after the
+    handshake completes. This must be called after the final verify_mode is set
+    on the context.
+    """
+    verify_cb = _VerifyCallback(_accept_all_verify_cb)
+    _verify_callbacks.append(verify_cb)
+    SSL_CTX_set_verify(_ssl_ctx_ptr(context), _VERIFY_PEER, verify_cb)

--- a/libp2p/security/tls/transport.py
+++ b/libp2p/security/tls/transport.py
@@ -136,10 +136,11 @@ class TLSTransport(ISecureTransport):
         # that are not bound to DNS names.
         ctx.check_hostname = False
 
-        # libp2p peers use self-signed identity certificates verified via the
-        # libp2p X.509 extension, not PKIX CA chains (see go-libp2p
-        # InsecureSkipVerify + VerifyPeerCertificate, js-libp2p
-        # rejectUnauthorized=false + verifyPeerCertificate).
+        # libp2p specs/tls/tls.md Peer Authentication: peers use self-signed
+        # certificates carrying the libp2p Public Key Extension (OID
+        # 1.3.6.1.4.1.53594.1.1), not PKIX CA chains.  Go/js skip TLS-layer
+        # PKIX and verify via extension + signature (see also design
+        # considerations.md: host key is not the certificate signing key).
         #
         # Python's CERT_OPTIONAL triggers OpenSSL PKIX verification and rejects
         # unknown self-signed peer certs with TLSV1_ALERT_UNKNOWN_CA before our

--- a/libp2p/security/tls/transport.py
+++ b/libp2p/security/tls/transport.py
@@ -552,7 +552,13 @@ class TLSTransport(ISecureTransport):
 
     def trust_peer_cert_pem(self, pem: str) -> None:
         """
-        Add a trusted peer certificate PEM.
+        Add a trusted peer certificate PEM (legacy / test-demo only).
+
+        Production interop does not require PKIX trust-store preloading: peer
+        identity is verified via the libp2p X.509 extension after the handshake.
+        Server-side contexts skip PKIX verification via
+        ``install_skip_pkix_peer_verification()``, so this method no longer
+        affects inbound verification behavior.
 
         Args:
             pem: The PEM-encoded certificate to trust

--- a/libp2p/security/tls/transport.py
+++ b/libp2p/security/tls/transport.py
@@ -23,6 +23,7 @@ from libp2p.security.tls.exceptions import (
     TLSHandshakeFailure,
 )
 from libp2p.security.tls.io import TLSReadWriter
+from libp2p.security.tls.openssl_verify import install_skip_pkix_peer_verification
 import libp2p.utils
 import libp2p.utils.paths
 
@@ -135,14 +136,20 @@ class TLSTransport(ISecureTransport):
         # that are not bound to DNS names.
         ctx.check_hostname = False
 
-        # For server-side (inbound) contexts we use CERT_OPTIONAL so that the
-        # TLS engine *requests* a client certificate from the remote peer.
-        # Without a CA configured Python will not reject an absent cert at the
-        # TLS layer, but the cert IS made available via getpeercert(binary_form=True)
-        # if one is sent.  Our post-handshake logic then enforces the hard
-        # requirement.
-        # For client-side (outbound) contexts CERT_NONE is fine because the
-        # server always sends a certificate in TLS 1.3.
+        # libp2p peers use self-signed identity certificates verified via the
+        # libp2p X.509 extension, not PKIX CA chains (see go-libp2p
+        # InsecureSkipVerify + VerifyPeerCertificate, js-libp2p
+        # rejectUnauthorized=false + verifyPeerCertificate).
+        #
+        # Python's CERT_OPTIONAL triggers OpenSSL PKIX verification and rejects
+        # unknown self-signed peer certs with TLSV1_ALERT_UNKNOWN_CA before our
+        # post-handshake extension check runs.  We therefore skip PKIX at the
+        # OpenSSL layer and enforce identity in secure_inbound/secure_outbound.
+        #
+        # Server: CERT_OPTIONAL requests a client certificate; an OpenSSL verify
+        # callback (install_skip_pkix_peer_verification) accepts any presented
+        # cert so the handshake completes and get_peer_certificate() works.
+        # Client: CERT_NONE — TLS 1.3 servers always send a certificate.
         ctx.verify_mode = ssl.CERT_OPTIONAL if server_side else ssl.CERT_NONE
 
         # Load our cached self-signed certificate bound to libp2p identity
@@ -228,7 +235,6 @@ class TLSTransport(ISecureTransport):
         # Load trusted peer certs as CA certificates if present
         # This enables mutual TLS when peers explicitly trust each other's certs
         if self._trusted_peer_certs_pem and server_side:
-            print("loading trust store")
             for i, cert_pem in enumerate(self._trusted_peer_certs_pem):
                 ca_file = tempfile.NamedTemporaryFile("w", delete=False, suffix=".pem")
                 ca_path = ca_file.name
@@ -243,10 +249,11 @@ class TLSTransport(ISecureTransport):
                             os.unlink(ca_path)
                     except (OSError, PermissionError):
                         pass
-            # Request client cert and verify against trusted CAs
-            ctx.verify_mode = ssl.CERT_OPTIONAL
             cnt = len(self._trusted_peer_certs_pem)
             logger.debug("TLS: loaded %d trusted certs", cnt)
+
+        if server_side:
+            install_skip_pkix_peer_verification(ctx)
 
         # ALPN: Set up protocol list with preferred muxers + "libp2p" fallback
         # Note: Python's ssl module doesn't support set_alpn_select_callback

--- a/newsfragments/1367.bugfix.rst
+++ b/newsfragments/1367.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed python×python TLS interop failures with ``TLSV1_ALERT_UNKNOWN_CA`` when using self-signed libp2p identity certificates. The TLS transport now requests peer certificates during the handshake while skipping PKIX CA verification at the OpenSSL layer, deferring identity checks to libp2p extension verification per the libp2p TLS specification.

--- a/tests/core/network/test_connection_management.py
+++ b/tests/core/network/test_connection_management.py
@@ -2,6 +2,9 @@
 Unit tests for connection management components (go-libp2p style).
 """
 
+import socket
+from unittest.mock import patch
+
 import pytest
 from multiaddr import Multiaddr
 
@@ -52,10 +55,20 @@ class TestExtractIpFromMultiaddr:
         assert "127.0.0.1" in ips or "::1" in ips
 
     async def test_invalid_dns(self):
-        # Test with invalid DNS name
+        # Test with invalid DNS name — mock resolution so the test does not
+        # depend on resolver/NXDOMAIN-hijacking behaviour (some ISPs return
+        # 127.0.0.1 for unknown names).
         addr = Multiaddr("/dns4/this-domain-does-not-exist-12345.com/tcp/1234")
-        ips = await extract_ip_from_multiaddr(addr)
-        # Should return empty list on resolution failure
+
+        async def _raise_gaierror(*_args, **_kwargs):
+            raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+        with patch(
+            "libp2p.network.connection_gate.trio.socket.getaddrinfo",
+            _raise_gaierror,
+        ):
+            ips = await extract_ip_from_multiaddr(addr)
+
         assert ips == []
 
     async def test_p2p_circuit_address(self):

--- a/tests/core/security/tls/test_tls.py
+++ b/tests/core/security/tls/test_tls.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import trio
 
 from libp2p import generate_new_rsa_identity
 from libp2p.peer.id import ID
@@ -70,6 +71,37 @@ async def test_secure_inbound_autotls_allows_primitive_exchange_identity() -> No
         session = await transport.secure_inbound(mock_conn)
 
     assert session.get_remote_peer() == ID.from_pubkey(client_keypair.public_key)
+
+
+@pytest.mark.trio
+async def test_tls_handshake_without_trust_store(nursery) -> None:
+    """Interop-style handshake: no PKIX trust store, libp2p extension only."""
+    keypair_a = generate_new_rsa_identity()
+    keypair_b = generate_new_rsa_identity()
+
+    t_a = TLSTransport(keypair_a)
+    t_b = TLSTransport(keypair_b)
+
+    local_secure_conn = None
+    remote_secure_conn = None
+
+    async def upgrade_local_conn(local_conn):
+        nonlocal local_secure_conn
+        local_secure_conn = await t_a.secure_outbound(local_conn, t_b.local_peer)
+
+    async def upgrade_remote_conn(remote_conn):
+        nonlocal remote_secure_conn
+        remote_secure_conn = await t_b.secure_inbound(remote_conn)
+
+    async with raw_conn_factory(nursery) as (local_conn, remote_conn):
+        async with trio.open_nursery() as n:
+            n.start_soon(upgrade_local_conn, local_conn)
+            n.start_soon(upgrade_remote_conn, remote_conn)
+
+        assert local_secure_conn is not None
+        assert remote_secure_conn is not None
+        assert local_secure_conn.get_remote_peer() == t_b.local_peer
+        assert remote_secure_conn.get_remote_peer() == t_a.local_peer
 
 
 @pytest.mark.trio

--- a/tests/core/security/tls/test_tls.py
+++ b/tests/core/security/tls/test_tls.py
@@ -6,7 +6,11 @@ import trio
 from libp2p import generate_new_rsa_identity
 from libp2p.peer.id import ID
 from libp2p.security.exceptions import HandshakeFailure
-from libp2p.security.tls.exceptions import TLSHandshakeFailure
+from libp2p.security.tls import certificate as certmod
+from libp2p.security.tls.exceptions import (
+    MissingLibp2pExtensionError,
+    TLSHandshakeFailure,
+)
 from libp2p.security.tls.transport import TLSTransport
 from libp2p.transport.exceptions import SecurityUpgradeFailure
 from libp2p.transport.upgrader import TransportUpgrader
@@ -27,6 +31,14 @@ def _mock_tls_reader_writer_no_cert() -> MagicMock:
     mock_rw = MagicMock()
     mock_rw.handshake = AsyncMock()
     mock_rw.get_peer_certificate.return_value = None
+    return mock_rw
+
+
+def _mock_tls_reader_writer_invalid_cert() -> MagicMock:
+    mock_rw = MagicMock()
+    mock_rw.handshake = AsyncMock()
+    _, invalid_cert = certmod.generate_self_signed_cert()
+    mock_rw.get_peer_certificate.return_value = invalid_cert
     return mock_rw
 
 
@@ -105,15 +117,37 @@ async def test_tls_handshake_without_trust_store(nursery) -> None:
 
 
 @pytest.mark.trio
+async def test_tls_handshake_rejects_invalid_cert_without_trust_store() -> None:
+    """PKIX skip must not weaken libp2p extension verification."""
+    keypair = generate_new_rsa_identity()
+    transport = TLSTransport(keypair, enable_autotls=False)
+    mock_conn = MagicMock()
+    mock_rw = _mock_tls_reader_writer_invalid_cert()
+
+    with (
+        patch("libp2p.security.tls.transport.TLSReadWriter", return_value=mock_rw),
+        pytest.raises(MissingLibp2pExtensionError),
+    ):
+        await transport.secure_inbound(mock_conn)
+
+    mock_rw_out = _mock_tls_reader_writer_invalid_cert()
+    mock_rw_out.remote_primitive_pk = None
+    mock_rw_out.remote_primitive_peerid = None
+
+    with (
+        patch("libp2p.security.tls.transport.TLSReadWriter", return_value=mock_rw_out),
+        pytest.raises(MissingLibp2pExtensionError),
+    ):
+        await transport.secure_outbound(mock_conn, transport.local_peer)
+
+
+@pytest.mark.trio
 async def test_tls_basic_handshake(nursery):
     keypair_a = generate_new_rsa_identity()
     keypair_b = generate_new_rsa_identity()
 
     t_a = TLSTransport(keypair_a)
     t_b = TLSTransport(keypair_b)
-    # Trust each other's certs during tests to avoid system verify failure
-    t_a.trust_peer_cert_pem(t_b.get_certificate_pem())
-    t_b.trust_peer_cert_pem(t_a.get_certificate_pem())
 
     async with tls_conn_factory(
         nursery, client_transport=t_a, server_transport=t_b

--- a/tests/transport/test_simultaneous_transports.py
+++ b/tests/transport/test_simultaneous_transports.py
@@ -8,6 +8,42 @@ from libp2p.peer.peerinfo import PeerInfo
 
 pytestmark = pytest.mark.trio
 
+_SERVER_LISTEN_ADDRS = [
+    Multiaddr("/ip4/127.0.0.1/tcp/0"),
+    Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
+    Multiaddr("/ip4/127.0.0.1/tcp/0/ws"),
+]
+
+
+def _protocol_names(addr: Multiaddr) -> set[str]:
+    return {p.name for p in addr.protocols()}
+
+
+def _is_plain_tcp_addr(addr: Multiaddr) -> bool:
+    protos = _protocol_names(addr)
+    return "tcp" in protos and "ws" not in protos and "wss" not in protos
+
+
+def _is_quic_addr(addr: Multiaddr) -> bool:
+    return any(p.startswith("quic") for p in _protocol_names(addr))
+
+
+async def _wait_for_listen_addr(
+    host,
+    predicate,
+    *,
+    label: str,
+    attempts: int = 50,
+    delay: float = 0.05,
+) -> Multiaddr:
+    """Poll until host advertises an address matching predicate."""
+    for _ in range(attempts):
+        matches = [a for a in host.get_addrs() if predicate(a)]
+        if matches:
+            return matches[0]
+        await trio.sleep(delay)
+    raise AssertionError(f"No {label} listen addr in {host.get_addrs()}")
+
 
 async def test_all_three_bind_concurrently():
     """
@@ -20,20 +56,10 @@ async def test_all_three_bind_concurrently():
         key_pair=kp,
         enable_quic=True,
         enable_websocket=True,
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-            Multiaddr("/ip4/127.0.0.1/tcp/0/ws"),
-        ],
+        listen_addrs=_SERVER_LISTEN_ADDRS,
     )
     start = trio.current_time()
-    async with host.run(
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-            Multiaddr("/ip4/127.0.0.1/tcp/0/ws"),
-        ]
-    ):
+    async with host.run(listen_addrs=_SERVER_LISTEN_ADDRS):
         elapsed = trio.current_time() - start
         addrs = host.get_addrs()
         assert len(addrs) == 3, f"Expected 3 addrs, got {addrs}"
@@ -45,21 +71,11 @@ async def test_tcp_client_connects_to_tcp_listener():
     server = new_host(
         enable_quic=True,
         enable_websocket=True,
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-            Multiaddr("/ip4/127.0.0.1/tcp/0/ws"),
-        ],
+        listen_addrs=_SERVER_LISTEN_ADDRS,
     )
-    async with server.run(
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-            Multiaddr("/ip4/127.0.0.1/tcp/0/ws"),
-        ]
-    ):
-        tcp_addr = next(
-            a for a in server.get_addrs() if "tcp" in str(a) and "ws" not in str(a)
+    async with server.run(listen_addrs=_SERVER_LISTEN_ADDRS):
+        tcp_addr = await _wait_for_listen_addr(
+            server, _is_plain_tcp_addr, label="plain TCP"
         )
         client = new_host(listen_addrs=[])
         async with client.run(listen_addrs=[]):
@@ -71,18 +87,10 @@ async def test_quic_client_connects_to_quic_listener():
     server = new_host(
         enable_quic=True,
         enable_websocket=True,
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-        ],
+        listen_addrs=_SERVER_LISTEN_ADDRS[:2],
     )
-    async with server.run(
-        listen_addrs=[
-            Multiaddr("/ip4/127.0.0.1/tcp/0"),
-            Multiaddr("/ip4/127.0.0.1/udp/0/quic-v1"),
-        ]
-    ):
-        quic_addr = next(a for a in server.get_addrs() if "quic" in str(a))
+    async with server.run(listen_addrs=_SERVER_LISTEN_ADDRS[:2]):
+        quic_addr = await _wait_for_listen_addr(server, _is_quic_addr, label="QUIC")
         client = new_host(enable_quic=True, listen_addrs=[])
         async with client.run(listen_addrs=[]):
             await client.connect(PeerInfo(server.get_id(), [quic_addr]))

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -418,9 +418,7 @@ async def tls_conn_factory(
 ) -> AsyncIterator[tuple[ISecureConn, ISecureConn]]:
     local_transport = client_transport or TLSTransport(create_secp256k1_key_pair())
     remote_transport = server_transport or TLSTransport(create_secp256k1_key_pair())
-    # Trust each other's certs for test handshake
-    local_transport.trust_peer_cert_pem(remote_transport.get_certificate_pem())
-    remote_transport.trust_peer_cert_pem(local_transport.get_certificate_pem())
+    # Interop-style handshakes work without a PKIX trust store (libp2p extension only).
 
     local_secure_conn: ISecureConn | None = None
     remote_secure_conn: ISecureConn | None = None


### PR DESCRIPTION
## Summary

- Skip OpenSSL PKIX/CA verification for libp2p self-signed peer certificates (fixes `TLSV1_ALERT_UNKNOWN_CA` on python×python TLS interop/perf)
- Request client certificates via `SSL_CTX_set_verify` callback (mirrors go-libp2p `InsecureSkipVerify` + `VerifyPeerCertificate` and js-libp2p `rejectUnauthorized: false` + `verifyPeerCertificate`)
- Preserve #1341 mutual-auth: inbound connections without a client certificate are still rejected post-handshake
- Add `test_tls_handshake_without_trust_store` regression test (no `trust_peer_cert_pem`)

Fixes #1367

## Test plan

- [x] `pytest tests/core/security/tls/ -v` (16 passed)
- [x] unified-testing perf: `python-v0.x x python-v0.x` 8/8 pass with `--force-image-rebuild` (was 4/8)

## Related

- unified-testing PR #37
- #1340, #1341, #1344

Made with [Cursor](https://cursor.com)