### PR TITLE
chore(deps): widen zeroconf pin to >=0.149.16,<0.151.0

### DIFF
--- a/docs/dependency_graph/dependencies.md
+++ b/docs/dependency_graph/dependencies.md
@@ -34,7 +34,7 @@ Total: 28 dependencies
 - **trio-typing** (>=0.0.4)
 - **trio-websocket** (>=0.11.0)
 - **types-requests**
-- **zeroconf** (>=0.147.0,\<0.148.0)
+- **zeroconf** (>=0.149.16,\<0.151.0)
 
 ## Optional Dependencies
 

--- a/newsfragments/1369.internal.rst
+++ b/newsfragments/1369.internal.rst
@@ -1,0 +1,1 @@
+Widened the ``zeroconf`` dependency range to ``>=0.149.16,<0.151.0`` to allow security and bugfix releases while keeping mDNS discovery on a tested 0.149–0.150 line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "trio-typing>=0.0.4",
     "trio-websocket>=0.11.0",
     "trio>=0.26.0",
-    "zeroconf (>=0.147.0,<0.148.0)",
+    "zeroconf>=0.149.16,<0.151.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/core/observability/test_oso_dependency_graph.py
+++ b/tests/core/observability/test_oso_dependency_graph.py
@@ -16,7 +16,7 @@ version = "0.0.1"
 requires-python = ">=3.10,<4.0"
 dependencies = [
   "requests>=2.30.0",
-  "zeroconf (>=0.147.0,<0.148.0)",
+  "zeroconf>=0.149.16,<0.151.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What was wrong?

Closes #1369

The `zeroconf` dependency was pinned to `>=0.147.0,<0.148.0`, blocking
newer releases with bug fixes and security patches needed for mDNS discovery.

## How was it fixed?

* Bump `zeroconf` to `>=0.149.16,<0.151.0` in `pyproject.toml`.
* Update OSO dependency-graph test fixture and regenerate `docs/dependency_graph/` artifacts.
* Add `newsfragments/1369.internal.rst`.

## Test plan

- [x] `pytest tests/core/discovery/mdns/ -q` (10 passed with zeroconf 0.150.0)
- [x] `pytest tests/core/observability/test_oso_dependency_graph.py -q`
- [x] CI green

### To-Do

- [x] Add entry to the release notes (newsfragment)
- [x] Regenerate dependency graph docs

Made with [Cursor](https://cursor.com)