### PR TITLE
fix(tcp): re-enable stale IPv6 listen/dial integration test

### DIFF
--- a/newsfragments/1189.bugfix.rst
+++ b/newsfragments/1189.bugfix.rst
@@ -1,0 +1,4 @@
+Re-enable the ``test_ipv6_tcp_listen_and_dial`` integration test. The skip was
+added when ``listen()`` took an external nursery; PR #1308 switched to an
+internal system task, making IPv6 listen/dial work correctly. The test now
+passes without modification.

--- a/tests/core/transport/test_tcp.py
+++ b/tests/core/transport/test_tcp.py
@@ -304,10 +304,6 @@ async def test_ipv6_tcp_dial_fails_on_nonexistent_server():
 
 
 @pytest.mark.trio
-@pytest.mark.skip(
-    reason="IPv6 listener hangs - trio.serve_tcp may need IPv6-specific configuration"
-)
-# TODO: Open follow-up issue to re-enable when IPv6 listen/dial is stable
 async def test_ipv6_tcp_listen_and_dial(nursery):
     """Test that TCP transport can listen and dial using IPv6 addresses."""
     transport = TCP()


### PR DESCRIPTION
## Summary

Closes #1189.

Removes a stale `@pytest.mark.skip` from `test_ipv6_tcp_listen_and_dial` in `tests/core/transport/test_tcp.py`.

**Why the skip existed:** The decorator was added in d8e64558 alongside the initial IPv6 feature. At that point `listen()` accepted an external `nursery` parameter, and the external-nursery code path had an IPv6-specific hang (interaction between the pytest-trio nursery and `trio.serve_tcp` on AF_INET6 sockets).

**Why it is now safe to remove:** PR #1308 refactored `listen()` to drop the `nursery` parameter entirely and switch to `trio.lowlevel.spawn_system_task` for the internal server loop. That change fixed the root cause. Two other pieces were already in place:
- `multiaddr_from_socket` correctly unpacks the 4-tuple `(host, port, flowinfo, scope_id)` returned by `getsockname()` on IPv6 sockets (needed for `get_addrs()`)
- `trio.serve_tcp` sets `IPV6_V6ONLY=1` automatically when it opens an AF_INET6 socket — no extra socket options needed

The skip was never revisited after #1308 landed.

## Test plan

- `pytest tests/core/transport/test_tcp.py -k ipv6` — 4 passed
- `pytest tests/core/transport/test_tcp.py` — 12 passed
- `make lint` clean (ruff, ruff-format)

## References

- Fixes: #1189
- Root cause introduced by: d8e64558
- Root cause fixed by: #1308 (PR that removed the nursery parameter from `listen()`)