### PR TITLE
Bump version from 0.6.0 to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "libp2p"
-version = "0.6.0"
+version = "0.7.0"
 description = "libp2p: The Python implementation of the libp2p networking stack"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"


### PR DESCRIPTION
## What was wrong?

Py-libp2p was on old version.

## How was it fixed?

Changed version from 0.6.0 to 0.7.0 for release.

### To-Do

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](<>)
