### PR TITLE
fix(pubsub): replay recent messages once a peer's outbound stream is registered

### DIFF
--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -831,7 +831,37 @@ class Pubsub(Service, IPubsub):
                     error,
                 )
 
+        await self._send_recent_messages_to_new_peer(peer_id)
+
         logger.debug("added new peer %s", peer_id)
+
+    async def _send_recent_messages_to_new_peer(self, peer_id: ID) -> None:
+        """
+        Replay recent messages to a peer whose subscriptions we already hold.
+
+        ``handle_subscription`` normally does this, but it runs off the inbound
+        stream and can fire before ``_handle_new_peer`` has registered the
+        outbound stream in ``peers``. Its catch-up is a no-op in that ordering,
+        so the messages are lost unless the replay also runs here.
+
+        :param peer_id: the peer that just became writable
+        """
+        if not hasattr(self.router, "send_recent_messages"):
+            return
+
+        subscribed_topics = [
+            topic for topic, peers in self.peer_topics.items() if peer_id in peers
+        ]
+        for topic in subscribed_topics:
+            try:
+                await self.router.send_recent_messages(peer_id, topic)  # type: ignore[attr-defined]
+            except Exception as error:
+                logger.debug(
+                    "failed to send recent messages for topic %s to peer %s: %s",
+                    topic,
+                    peer_id,
+                    error,
+                )
 
     async def _handle_new_peer_safe(self, peer_id: ID) -> None:
         """

--- a/newsfragments/1398.bugfix.rst
+++ b/newsfragments/1398.bugfix.rst
@@ -1,0 +1,1 @@
+gossipsub: replay recent messages to a peer once its outbound pubsub stream is registered. When a peer's subscription was processed before that stream existed, the mcache catch-up in ``handle_subscription`` had nothing to write to, so a message published right after connecting was dropped for good.

--- a/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
+++ b/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
@@ -17,11 +17,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import trio
 
+from libp2p.peer.id import (
+    ID,
+)
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID,
     GossipSub,
 )
 from libp2p.pubsub.pb import rpc_pb2
+from libp2p.pubsub.pubsub import (
+    Pubsub,
+)
 from libp2p.tools.utils import connect
 from tests.utils.factories import (
     IDFactory,
@@ -234,6 +240,68 @@ async def test_publish_before_identify_completes():
         assert received, (
             "Message published before identify was not delivered to the peer. "
             "The identify-aware publish queue may not be working."
+        )
+
+
+@pytest.mark.trio
+async def test_publish_before_identify_with_subscription_before_stream(monkeypatch):
+    """
+    Regression test for the ordering that makes
+    ``test_publish_before_identify_completes`` flaky under load.
+
+    When the publisher learns of the peer's subscription *before* its own
+    outbound pubsub stream is registered, nothing is queued at publish time
+    (the peer is in neither ``peers`` nor ``peer_topics``) and the mcache
+    catch-up in ``handle_subscription`` cannot write yet. The replay must
+    therefore also run once the stream becomes available.
+    """
+    topic = "test-subscription-before-stream"
+    data = b"hello-from-early-publish"
+
+    # The publisher's delay must be the longer one: the subscriber's stream, and
+    # so its subscription, has to reach the publisher while the publisher's own
+    # outbound stream is still pending. Equal or inverted delays make this test
+    # exercise the ordering that already worked.
+    publisher_stream_delay = 1.0
+    subscriber_stream_delay = 0.3
+
+    original_handle_new_peer = Pubsub._handle_new_peer
+    delays: dict[Pubsub, float] = {}
+
+    async def delayed_handle_new_peer(self: Pubsub, peer_id: ID) -> None:
+        await trio.sleep(delays.get(self, 0))
+        await original_handle_new_peer(self, peer_id)
+
+    monkeypatch.setattr(Pubsub, "_handle_new_peer", delayed_handle_new_peer)
+
+    async with PubsubFactory.create_batch_with_gossipsub(
+        2,
+        degree=1,
+        degree_low=1,
+        degree_high=2,
+        heartbeat_interval=1,
+    ) as pubsubs:
+        delays[pubsubs[0]] = publisher_stream_delay
+        delays[pubsubs[1]] = subscriber_stream_delay
+
+        await pubsubs[0].subscribe(topic)
+        sub_1 = await pubsubs[1].subscribe(topic)
+
+        await connect(pubsubs[0].host, pubsubs[1].host)
+        await pubsubs[0].publish(topic, data)
+
+        # Outlast the publisher's own stream setup, then leave room to propagate.
+        await trio.sleep(publisher_stream_delay + 4)
+
+        received = False
+        with trio.move_on_after(2):
+            async for msg in sub_1:
+                if msg.data == data:
+                    received = True
+                    break
+        assert received, (
+            "Message published before identify was not delivered when the peer's "
+            "subscription arrived before the outbound pubsub stream was ready."
         )
 
 


### PR DESCRIPTION
## What was wrong?

Issue # — none filed; this is the flake behind `tox (3.12, core)`, e.g. [run 29641232846](https://github.com/libp2p/py-libp2p/actions/runs/29641232846) (push to `main`).

`tests/core/pubsub/test_gossipsub_identify_aware_publish.py::test_publish_before_identify_completes` fails intermittently under `pytest -n auto`. It is a real message-loss bug, not a bad test.

Publishing right after `connect()` can catch the peer in neither `pubsub.peers` nor `pubsub.peer_topics`. `GossipSub.publish` queues into `_pending_messages` only for peers in one of those two, so nothing is queued at all. The safety net is the mcache replay in `handle_subscription`, but `send_recent_messages` returns early when `peer_id not in pubsub.peers`. That replay runs off the peer's *inbound* stream, independent of the *outbound* stream `_handle_new_peer` registers — so when the subscription is processed first, the replay no-ops, the later `flush_pending_messages` finds an empty queue, and the message is lost with nothing to retry it.

An idle machine finishes identify before `publish()` runs, so the path is never exercised. CI load exercises it.

## How was it fixed?

`_handle_new_peer` now runs the replay as well, once it has registered the stream, via `_send_recent_messages_to_new_peer`. Whichever of the two events lands last triggers the catch-up.

Neither ordering double-sends: the path that ran first finds nothing to do. If a subscription lands concurrently between the two, the duplicate is dropped by the receiver's seen cache (`push_msg` → `_is_msg_seen`).

This is on the connection-setup path for floodsub too, where the `hasattr` check makes it a no-op. Behaviour changes in the fixing direction only; no API change.

### Testing

`test_publish_before_identify_with_subscription_before_stream` forces the losing ordering with asymmetric `_handle_new_peer` delays (publisher 1.0s, subscriber 0.3s) instead of hoping for it. It fails on `main` and passes here. Full `tests/core/pubsub` green (402 tests) rebased onto `bb346f20`; `ruff` and `mypy -p libp2p` clean.

### Not fixed here

- `_handle_dead_peer` returns early at pubsub.py:877, before the `peer_topics` cleanup, so a peer dropping while half-registered leaks its entry. This replay has no `was_newly_added` guard like `handle_subscription`'s, so a reconnect would replay the full gossip window. The fix is disconnect-handling surgery.
- This patches the recovery path, not the real gap: `GossipSub.publish`'s queueing predicate. Fixing that changes queueing semantics for every pubsub user.
- `IPubsubRouter` (abc.py:3153) declares neither `send_recent_messages` nor `flush_pending_messages`, so this adds the fourth `hasattr(self.router, ...)` probe in the file.

### To-Do

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes — N/A, no user-facing docs cover this path
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![otter](https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Fischotter%2C_Lutra_Lutra.JPG/640px-Fischotter%2C_Lutra_Lutra.JPG)