### PR TITLE
test(quic): join nurseries instead of sleeping in listener race tests

### DIFF
--- a/newsfragments/1430.internal.rst
+++ b/newsfragments/1430.internal.rst
@@ -1,0 +1,1 @@
+Stop the two ``TestQUICListenerRaceConditions`` tests from racing on a fixed ``trio.sleep(0.1)``. ``test_multiple_cid_routing_concurrent_load`` and ``test_promotion_race_condition`` now join a nursery around their concurrent tasks so the assertions run only after every task has finished, instead of guessing how long the tasks take.

--- a/tests/core/transport/quic/test_listener.py
+++ b/tests/core/transport/quic/test_listener.py
@@ -421,12 +421,12 @@ class TestQUICListenerRaceConditions:
                     except Exception:
                         pass  # Some attempts may fail, that's expected
 
-                # Launch multiple concurrent promotion attempts
-                for _ in range(10):
-                    nursery.start_soon(attempt_promotion)
-
-                # Give time for promotions to complete
-                await trio.sleep(0.1)
+                # Launch concurrent promotion attempts. Wait for all of them to
+                # finish by joining a dedicated nursery instead of sleeping a
+                # fixed amount, which races under load.
+                async with trio.open_nursery() as attempt_nursery:
+                    for _ in range(10):
+                        attempt_nursery.start_soon(attempt_promotion)
 
                 # Verify only one connection object was created
                 assert len(set(connection_objects)) <= 1, (
@@ -555,14 +555,15 @@ class TestQUICListenerRaceConditions:
                     if conn:
                         found_connections.append((cid, id(conn)))
 
-                # Route packets with different CIDs concurrently
+                # Route packets with different CIDs concurrently. Wait for every
+                # lookup to finish by joining a dedicated nursery rather than
+                # sleeping a fixed amount: under load a single lookup can take
+                # longer than the sleep, leaving found_connections empty.
                 cids = [primary_cid, secondary_cid1, secondary_cid2, secondary_cid3]
-                for _ in range(5):  # Multiple rounds
-                    for cid in cids:
-                        nursery.start_soon(route_packet, cid)
-
-                # Give time for routing to complete
-                await trio.sleep(0.1)
+                async with trio.open_nursery() as route_nursery:
+                    for _ in range(5):  # Multiple rounds
+                        for cid in cids:
+                            route_nursery.start_soon(route_packet, cid)
 
                 # Verify all CIDs route to the same connection object
                 connection_ids = {conn_id for _, conn_id in found_connections}


### PR DESCRIPTION
Two tests in `TestQUICListenerRaceConditions` spawn a batch of tasks into the nursery, sleep a fixed 0.1s, then assert on what those tasks collected:

```python
for _ in range(5):
    for cid in cids:
        nursery.start_soon(route_packet, cid)
await trio.sleep(0.1)
connection_ids = {conn_id for _, conn_id in found_connections}
assert len(connection_ids) == 1
```

The 0.1s is a guess at how long the concurrent tasks take. On a loaded runner they aren't done yet when the assert runs, so it sees an empty or partial result. That's how it failed on CI (tox 3.13, core):

```
AssertionError: All CIDs should route to same connection, got 0 different connections
assert 0 == 1  where 0 = len(set())
```

The same job logged `Slow find_by_connection_id: 115.01ms`, so a single lookup took longer than the whole sleep budget. `test_promotion_race_condition` has the same shape and is a latent flake for the same reason.

Instead of sleeping, spawn the tasks into their own nursery and let the `async with` block join them — once it exits every task has finished, so the assertions are deterministic with no timing involved.

I left the `trio.sleep(0.1)` near line 256 alone: that one waits for the server to be ready before dialing, which is a separate concern from this race, and I didn't want to widen the diff.

Ran `TestQUICListenerRaceConditions` locally in a loop and the full `test_listener.py` file, all green.

Closes #1430. Background on this being the same fixed-sleep pattern we've been cleaning up: #1401, #1408.