### PR TITLE
ci: install webrtc extra in tox so WebRTC tests run in CI

### DIFF
--- a/newsfragments/1437.misc.rst
+++ b/newsfragments/1437.misc.rst
@@ -1,0 +1,1 @@
+Install the ``webrtc`` extra (``aiortc``) in the tox test environments so the WebRTC transport tests run in CI instead of being skipped.

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ per-file-ignores=__init__.py:F401
 usedevelop=True
 commands_pre=
     uv pip install --upgrade pip
-    uv pip install --group dev -e .
+    uv pip install --group dev -e ".[webrtc]"
 commands=
     core: pytest -n auto --timeout=1200 --durations=40 --durations-min=1.0 {posargs:tests/core}
     demos: pytest -n auto --timeout=1200 --durations=40 --durations-min=1.0 {posargs:tests/examples}


### PR DESCRIPTION
## What

`tox.ini` `commands_pre` now installs `-e ".[webrtc]"`, so `aiortc` is present in the `core` / `windows` test envs.

## Why

No extra was installed, so every test in `tests/core/transport/webrtc/` has been **skipped** in CI (`HAS_AIORTC` / `HAS_AIOICE` guards) — green meant untested. First step for #1437 (WebRTC-Direct STUN listener) so follow-up PRs actually prove themselves.

## Notes

- aiortc 1.15 is pure Python; `av` and `pylibsrtp` ship manylinux_2_28 + win_amd64 wheels for cp310–cp313 → no apt deps.
- Locally with the extra installed: `tests/core/transport/webrtc` 177 passed; `mypy -p libp2p` and `pyrefly check` clean.

Refs #1437