### PR TITLE
feat(health): /ipfs/ping/1.0.0 probe, docs, real-network tests, and GUI (#1453)

### DIFF
--- a/docs/connection_health_monitoring.rst
+++ b/docs/connection_health_monitoring.rst
@@ -120,9 +120,10 @@ Probe behavior (issue #1453)
     Record successful ping RTT into peerstore LatencyEWMA (seconds).
 
 ``abort_connection_on_ping_failure`` (``bool``, default ``False``)
-    When ``True``, close the probed connection immediately after a failed ping.
-    Replacement rules still apply on later ticks; Protect applies to replace,
-    not to this local abort.
+    When ``True``, close the probed connection immediately after a failed ping
+    via the connection's normal Swarm teardown (``SwarmConn.close`` /
+    ``remove_conn``, including notifees and rcmgr). Replacement rules still
+    apply on later ticks; Protect applies to replace, not to this local abort.
 
 Host and Swarm API
 ------------------

--- a/docs/connection_health_monitoring.rst
+++ b/docs/connection_health_monitoring.rst
@@ -1,0 +1,216 @@
+Connection Health Monitoring
+============================
+
+py-libp2p ships an **opt-in** connection health monitor as a Python-local QoS
+layer. It is **disabled by default** and does not change wire-protocol behavior
+for peers that do not enable it.
+
+See also:
+
+- :doc:`examples.connection_health_monitoring` — runnable examples and CLI
+- :doc:`libp2p.network.health` — module API reference
+- :doc:`examples.health_monitoring` — example package automodule
+
+Overview
+--------
+
+When enabled via ``ConnectionConfig.enable_health_monitoring``, the swarm runs
+``ConnectionHealthMonitor``, which:
+
+- Probes **each connection** periodically using ``/ipfs/ping/1.0.0`` (not
+  ``PingService.ping(peer_id)``, which selects the best connection per peer).
+- Maintains per-connection metrics and a composite ``health_score`` (0.0–1.0).
+- Replaces persistently unhealthy connections using **dial-first** semantics
+  (a replacement must succeed before the old connection is dropped).
+- Skips auto-replacement for ConnMgr **Protect** peers (``tag_store``).
+- Integrates with load-balancing strategies ``health_based`` and
+  ``latency_based`` for outbound stream selection.
+
+Relationship to other py-libp2p features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **ConnMgr** (watermarks, trim, Protect/tags): health replace respects Protect;
+  trimming is unchanged.
+- **Load balancing** (``ConnectionConfig.load_balancing_strategy``): ``best``,
+  ``round_robin``, ``least_loaded``, ``health_based``, ``latency_based``.
+- **Peerstore**: optional RTT recording into LatencyEWMA after successful pings.
+
+When to enable
+--------------
+
+Enable health monitoring when you:
+
+- Run multiple connections per peer and want health-aware routing.
+- Need visibility into connection quality (latency, success rate, scores).
+- Want automatic dial-first replacement of degraded paths.
+
+Leave it disabled (default) for minimal overhead or when you manage connectivity
+entirely at the application layer.
+
+Configuration reference
+-----------------------
+
+All fields live on ``libp2p.network.config.ConnectionConfig``.
+
+Core toggle
+~~~~~~~~~~~
+
+``enable_health_monitoring`` (``bool``, default ``False``)
+    Master switch for the monitor service and health data structures.
+
+Timing
+~~~~~~
+
+``health_initial_delay`` (``float``, default ``60.0`` seconds)
+    Delay before the first monitoring cycle (avoids startup noise).
+
+``health_warmup_window`` (``float``, default ``5.0`` seconds)
+    Skip checks on very new connections.
+
+``health_check_interval`` (``float``, default ``60.0`` seconds)
+    Period between full connection scan cycles.
+
+``ping_timeout`` (``float``, default ``5.0`` seconds)
+    Overall timeout for a single connection ping probe.
+
+Thresholds and replacement
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``min_health_threshold`` (``float``, default ``0.3``)
+    Score below which a connection counts as unhealthy.
+
+``min_connections_per_peer`` (``int``, default ``1``)
+    Minimum connections to keep; replace is blocked unless critically unhealthy.
+
+``max_ping_latency`` (``float``, default ``1000.0`` ms)
+    Maximum acceptable ping latency before marking unhealthy.
+
+``min_ping_success_rate`` (``float``, default ``0.7``)
+    Minimum ping success rate before marking unhealthy.
+
+``max_failed_streams`` (``int``, default ``5``)
+    Failed stream count threshold.
+
+``unhealthy_grace_period`` (``int``, default ``3``)
+    Consecutive unhealthy evaluations before replace.
+
+``critical_health_threshold`` (``float``, default ``0.1``)
+    Allows replace even at ``min_connections_per_peer`` when score is critical.
+
+Scoring weights
+~~~~~~~~~~~~~~~
+
+``latency_weight`` (``float``, default ``0.4``)
+    Weight for latency in ``health_score``.
+
+``success_rate_weight`` (``float``, default ``0.4``)
+    Weight for ping success rate.
+
+``stability_weight`` (``float``, default ``0.2``)
+    Weight for connection stability.
+
+Probe behavior (issue #1453)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``skip_ping_when_streams_open`` (``bool``, default ``False``)
+    When ``True``, skip probes on busy connections (legacy behavior). Default
+    probes even when application streams are open.
+
+``record_ping_latency_in_peerstore`` (``bool``, default ``True``)
+    Record successful ping RTT into peerstore LatencyEWMA (seconds).
+
+``abort_connection_on_ping_failure`` (``bool``, default ``False``)
+    When ``True``, close the probed connection immediately after a failed ping.
+    Replacement rules still apply on later ticks; Protect applies to replace,
+    not to this local abort.
+
+Host and Swarm API
+------------------
+
+All methods are available on ``IHost`` (delegates to swarm when monitoring is
+enabled).
+
+``get_connection_health(peer_id) -> dict``
+    Per-peer summary: connection count, average score/latency/success rate,
+    per-connection details via ``connections`` list.
+
+``get_network_health_summary() -> dict``
+    Global summary: ``total_peers``, ``total_connections``,
+    ``average_peer_health``, ``peers_with_issues``, ``peer_details``.
+
+``export_health_metrics(format="json"|"prometheus") -> str``
+    JSON export mirrors ``get_network_health_summary()`` structure.
+    Prometheus export exposes gauges such as ``libp2p_peers_total``,
+    ``libp2p_connections_total``, ``libp2p_average_peer_health``,
+    ``libp2p_peers_with_issues``.
+
+``get_health_monitor_status() -> dict`` (async)
+    Service status: ``enabled``, ``monitoring_task_started``,
+    ``check_interval_seconds``, connection/peer counts.
+
+Operator guide
+--------------
+
+Enable on a host
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from libp2p import new_host
+    from libp2p.network.config import ConnectionConfig
+
+    config = ConnectionConfig(
+        enable_health_monitoring=True,
+        health_check_interval=30.0,
+        load_balancing_strategy="health_based",
+    )
+    host = new_host(connection_config=config)
+
+When auto-replace runs vs is skipped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Replace runs when thresholds fail for ``unhealthy_grace_period`` consecutive
+checks **and**:
+
+- The connection has no open streams (active traffic blocks replace).
+- The peer is **not** ConnMgr-protected.
+- Dial-first replacement succeeds.
+- Either above ``min_connections_per_peer`` after removal, or critically unhealthy.
+
+Live demo and GUI
+~~~~~~~~~~~~~~~~~
+
+Console script (after install):
+
+.. code-block:: bash
+
+    health-monitoring-demo --peers 10 --scenario all
+
+Module invocation:
+
+.. code-block:: bash
+
+    python -m examples.health_monitoring.live_demo --peers 10 --scenario healthy,protect
+    python -m examples.health_monitoring.live_demo --gui tui
+    python -m examples.health_monitoring.live_demo --gui web --gui-port 8765
+
+``--gui tui`` opens a terminal table; ``--gui web`` serves HTML plus
+``/api/summary`` (JSON) and ``/api/metrics?format=prometheus``.
+
+Config-only walkthrough (no connections):
+
+.. code-block:: bash
+
+    python examples/health_monitoring/basic_example.py
+
+Reading health summaries
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    summary = host.get_network_health_summary()
+    peer = host.get_connection_health(some_peer_id)
+    print(host.export_health_metrics("json"))
+
+Protect a peer from auto-replace (ConnMgr API / ``tag_store.Protect``) before
+expecting replace to skip that peer.

--- a/docs/examples.connection_health_monitoring.rst
+++ b/docs/examples.connection_health_monitoring.rst
@@ -1,38 +1,22 @@
-Connection Health Monitoring
-============================
+Connection Health Monitoring Examples
+=======================================
 
-This example demonstrates the **optional**, Python-local connection health
-monitoring extension for py-libp2p. It is inspired by go-libp2p ConnMgr
-(Protect/tags/watermarks), peerstore LatencyEWMA, and swarm ``bestConn``
-selection — but go-libp2p does **not** ship a proactive health monitor,
-``health_score``, or auto-replace of unhealthy connections. Those behaviors
-here are an opt-in QoS layer, not a wire-protocol or cross-impl requirement.
+Runnable examples for the opt-in connection health monitor. For the full user
+guide (configuration reference, API shapes, operator notes), see
+:doc:`connection_health_monitoring`.
 
 Overview
 --------
 
-.. note::
-   The code snippets throughout this document are excerpts demonstrating key
-   concepts. They cannot be copy-pasted and run directly as they require an
-   async context. For complete, runnable examples, see
-   ``examples/health_monitoring/basic_example.py`` (config walkthrough) and
-   ``examples/health_monitoring/live_demo.py`` (N local peers, live scores).
+Connection health monitoring enhances multiple-connections-per-peer support with:
 
-Connection health monitoring enhances the existing multiple connections per peer
-support by adding:
+- Health metrics (latency, success rate, stream counts, ``health_score``)
+- Periodic ``/ipfs/ping/1.0.0`` probes per connection
+- Dial-first unhealthy connection replacement (skips ConnMgr Protect)
+- Health-aware load balancing (``health_based``, ``latency_based``)
 
-- **Health Metrics Tracking**: Latency, success rates, stream counts, and more
-- **Proactive Health Checks**: Periodic monitoring and automatic connection replacement
-- **Health-Aware Load Balancing**: Route traffic to the healthiest connections
-- **Automatic Recovery**: Replace unhealthy connections automatically (dial-first;
-  skips ConnMgr-protected peers)
-
-Basic Setup
+Basic setup
 -----------
-
-To enable connection health monitoring, configure the `ConnectionConfig` with
-health monitoring parameters and pass it to `new_host()`. The following is a
-snippet; the full runnable script is in ``examples/health_monitoring/basic_example.py``.
 
 .. code-block:: python
 
@@ -40,261 +24,57 @@ snippet; the full runnable script is in ``examples/health_monitoring/basic_examp
     from libp2p.network.config import ConnectionConfig
     from libp2p.crypto.rsa import create_new_key_pair
 
-    # Enable health monitoring
     connection_config = ConnectionConfig(
         enable_health_monitoring=True,
-        health_check_interval=30.0,  # Check every 30 seconds
-        ping_timeout=3.0,  # 3 second ping timeout
-        min_health_threshold=0.4,  # Minimum health score
-        min_connections_per_peer=2,  # Maintain at least 2 connections
-        load_balancing_strategy="health_based"  # Use health-based selection
+        health_check_interval=30.0,
+        ping_timeout=3.0,
+        min_health_threshold=0.4,
+        min_connections_per_peer=2,
+        load_balancing_strategy="health_based",
     )
 
-    # Create host with health monitoring
     host = new_host(
         key_pair=create_new_key_pair(),
-        connection_config=connection_config
+        connection_config=connection_config,
     )
 
-Configuration Options
----------------------
-
-Health Monitoring Settings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- **enable_health_monitoring**: Enable/disable connection health monitoring (default: False)
-- **health_check_interval**: Interval between health checks in seconds (default: 60.0)
-- **ping_timeout**: Timeout for ping operations in seconds (default: 5.0)
-- **min_health_threshold**: Minimum health score (0.0-1.0) for connections (default: 0.3)
-- **min_connections_per_peer**: Minimum connections to maintain per peer (default: 1)
-
-Load Balancing Strategies
+Load balancing strategies
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **best**: go-libp2p-style heuristics (prefer direct, then more streams; default)
-- **round_robin**: Simple round-robin selection
-- **least_loaded**: Select connection with fewest streams
-- **health_based**: Select connection with highest health score (Python extension)
-- **latency_based**: Select connection with lowest latency (Python extension)
+- **best** — prefer direct connections, then fewer streams (default)
+- **round_robin** — rotate across connections
+- **least_loaded** — fewest open streams
+- **health_based** — highest ``health_score``
+- **latency_based** — lowest ping latency
 
-Health Metrics
---------------
-
-The system tracks various connection health metrics:
-
-**Basic Metrics:**
-- **Ping Latency**: Response time for health checks
-- **Success Rate**: Percentage of successful operations
-- **Stream Count**: Number of active streams
-- **Connection Age**: How long the connection has been established
-- **Health Score**: Overall health rating (0.0 to 1.0)
-
-**Advanced Metrics:**
-- **Bandwidth Usage**: Real-time bandwidth tracking with time windows
-- **Error History**: Detailed error tracking with timestamps
-- **Connection Events**: Lifecycle event logging (establishment, closure, etc.)
-- **Connection Stability**: Error rate-based stability scoring
-- **Peak/Average Bandwidth**: Performance trend analysis
-
-Host-Level Health Monitoring API
----------------------------------
-
-The health monitoring features are now accessible through the high-level host API:
+Host API (snippet)
+------------------
 
 .. code-block:: python
 
-    # Access health information through the host interface
-
-    # Get health summary for a specific peer
     peer_health = host.get_connection_health(peer_id)
-    print(f"Peer health: {peer_health}")
-
-    # Get global network health summary
     network_health = host.get_network_health_summary()
-    print(f"Total peers: {network_health.get('total_peers', 0)}")
-    print(f"Total connections: {network_health.get('total_connections', 0)}")
-    print(f"Average health: {network_health.get('average_peer_health', 0.0)}")
-
-    # Export metrics in different formats
     json_metrics = host.export_health_metrics("json")
     prometheus_metrics = host.export_health_metrics("prometheus")
 
-Example: Health-Based Load Balancing
-------------------------------------
+Running the examples
+--------------------
 
-.. code-block:: python
-
-    from libp2p import new_host
-    from libp2p.network.config import ConnectionConfig
-    from libp2p.crypto.rsa import create_new_key_pair
-
-    # Configure for production use with health-based load balancing
-    connection_config = ConnectionConfig(
-        enable_health_monitoring=True,
-        max_connections_per_peer=5,  # More connections for redundancy
-        health_check_interval=120.0,  # Less frequent checks in production
-        ping_timeout=10.0,  # Longer timeout for slow networks
-        min_health_threshold=0.6,  # Higher threshold for production
-        min_connections_per_peer=3,  # Maintain more connections
-        load_balancing_strategy="health_based"  # Prioritize healthy connections
-    )
-
-    host = new_host(
-        key_pair=create_new_key_pair(),
-        connection_config=connection_config
-    )
-
-    # Use host as normal - health monitoring works transparently
-    # In your async main() function:
-    #   async with host.run(listen_addrs=["/ip4/127.0.0.1/tcp/0"]):
-    #       # Health monitoring and load balancing happen automatically
-    #       stream = await host.new_stream(peer_id, ["/echo/1.0.0"])
-
-Example: Advanced Health Monitoring
-------------------------------------
-
-The enhanced health monitoring provides advanced capabilities:
-
-.. code-block:: python
-
-    from libp2p import new_host
-    from libp2p.network.config import ConnectionConfig
-    from libp2p.crypto.rsa import create_new_key_pair
-
-    # Advanced health monitoring with comprehensive tracking
-    connection_config = ConnectionConfig(
-        enable_health_monitoring=True,
-        health_check_interval=15.0,  # More frequent checks
-        ping_timeout=2.0,  # Faster ping timeout
-        min_health_threshold=0.5,  # Higher threshold
-        min_connections_per_peer=2,
-        load_balancing_strategy="health_based",
-        # Advanced health scoring configuration
-        latency_weight=0.4,
-        success_rate_weight=0.4,
-        stability_weight=0.2,
-        max_ping_latency=1000.0,  # ms
-        min_ping_success_rate=0.7,
-        max_failed_streams=5
-    )
-
-    host = new_host(
-        key_pair=create_new_key_pair(),
-        connection_config=connection_config
-    )
-
-    # Access advanced health metrics through host API
-    # In your async main() function:
-    #   async with host.run(listen_addrs=["/ip4/127.0.0.1/tcp/0"]):
-    #       peer_health = host.get_connection_health(peer_id)
-    #       global_health = host.get_network_health_summary()
-    #       json_metrics = host.export_health_metrics("json")
-    #       prometheus_metrics = host.export_health_metrics("prometheus")
-
-Example: Latency-Based Load Balancing
--------------------------------------
-
-.. code-block:: python
-
-    # Optimize for lowest latency connections
-    connection_config = ConnectionConfig(
-        enable_health_monitoring=True,
-        load_balancing_strategy="latency_based",  # Route to lowest latency
-        health_check_interval=30.0,
-        ping_timeout=5.0,
-        max_connections_per_peer=3
-    )
-
-    host = new_host(
-        key_pair=create_new_key_pair(),
-        connection_config=connection_config
-    )
-
-    # Streams will automatically route to lowest latency connections
-
-Example: Disabling Health Monitoring
-------------------------------------
-
-For performance-critical scenarios, health monitoring can be disabled:
-
-.. code-block:: python
-
-    # Disable health monitoring for maximum performance
-    connection_config = ConnectionConfig(
-        enable_health_monitoring=False,
-        load_balancing_strategy="round_robin"  # Fall back to simple strategy
-    )
-
-    host = new_host(
-        key_pair=create_new_key_pair(),
-        connection_config=connection_config
-    )
-
-    # Host operates with minimal overhead, no health monitoring
-
-Backwards Compatibility
------------------------
-
-Health monitoring is fully backwards compatible:
-
-.. code-block:: python
-
-    # Existing code continues to work unchanged
-    host = new_host()  # Uses default configuration (health monitoring disabled)
-
-    # Only when you explicitly enable it does health monitoring activate
-    config = ConnectionConfig(enable_health_monitoring=True)
-    host_with_health = new_host(connection_config=config)
-
-Running the Example
--------------------
-
-To run a live multi-peer demo (default 25 hosts, all scenarios):
+Live multi-peer demo:
 
 .. code-block:: bash
 
     python -m examples.health_monitoring.live_demo
-    python -m examples.health_monitoring.live_demo --peers 10 --scenario healthy,protect
+    python -m examples.health_monitoring.live_demo --peers 10 --scenario all
+    python -m examples.health_monitoring.live_demo --gui tui
+    python -m examples.health_monitoring.live_demo --gui web --gui-port 8765
+    health-monitoring-demo --peers 10 --scenario healthy,protect
 
-To walk through the host API without opening connections:
+Config walkthrough (no connections):
 
 .. code-block:: bash
 
     python examples/health_monitoring/basic_example.py
 
-The live demo shows:
-
-1. Opt-in health monitoring through ``new_host(connection_config=...)``
-2. A configurable star of local TCP peers (``--peers``, default 25)
-3. Selectable scenarios (``--scenario``, default ``all``): healthy scores,
-   a no-monitor observer, ConnMgr ``Protect``, concurrent echo traffic,
-   and peer churn
-4. Peer and network health summaries after the monitor pings
-
-Benefits
---------
-
-1. **API Consistency**: Health monitoring now works with the same high-level `new_host()` API used in all examples
-2. **Production Reliability**: Prevent silent failures by detecting unhealthy connections early
-3. **Performance Optimization**: Route traffic to healthiest connections, reduce latency
-4. **Operational Visibility**: Monitor connection quality in real-time through host interface
-5. **Automatic Recovery**: Replace degraded connections automatically
-6. **Standard Compliance**: Match capabilities of Go and JavaScript libp2p implementations
-
-Integration with Existing Code
-------------------------------
-
-Health monitoring integrates seamlessly with existing host-based code:
-
-- All new features are optional and don't break existing code
-- Health monitoring can be enabled/disabled per host instance
-- Existing examples work unchanged - just add `connection_config` parameter
-- Backward compatibility is maintained
-- No need to switch from `new_host()` to low-level swarm APIs
-
-.. code-block:: python
-
-    host = new_host()  # Basic usage
-    host = new_host(connection_config=config)  # Health monitoring - same API
-
-For more information, see the :doc:`../libp2p.network` module documentation.
+See :doc:`connection_health_monitoring` for all ``ConnectionConfig`` health
+fields and tuning notes.

--- a/docs/examples.health_monitoring.rst
+++ b/docs/examples.health_monitoring.rst
@@ -1,6 +1,10 @@
 examples.health\_monitoring package
 ===================================
 
+Example scripts for the opt-in connection health monitor (live demo, config
+walkthrough, QUIC sample). User guide: :doc:`connection_health_monitoring`.
+Runnable example snippets: :doc:`examples.connection_health_monitoring`.
+
 Submodules
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,11 @@ The Python implementation of the libp2p networking stack
     release_notes
 
 .. toctree::
-    :maxdepth: 1
-    :caption: py-libp2p
+   :maxdepth: 1
+   :caption: py-libp2p
 
     Examples <examples>
+    Connection Health Monitoring <connection_health_monitoring>
     Filecoin Architecture Positioning <filecoin_architecture_positioning>
     API <libp2p>
 

--- a/docs/libp2p.network.health.rst
+++ b/docs/libp2p.network.health.rst
@@ -1,7 +1,10 @@
-:orphan:
-
 libp2p.network.health package
 =============================
+
+Optional connection health monitoring for py-libp2p: per-connection metrics,
+``/ipfs/ping/1.0.0`` probes, dial-first replace, and health-aware load balancing.
+
+User guide: :doc:`../connection_health_monitoring`.
 
 Submodules
 ----------
@@ -10,6 +13,14 @@ libp2p.network.health.data\_structures module
 ---------------------------------------------
 
 .. automodule:: libp2p.network.health.data_structures
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+libp2p.network.health.ping\_probe module
+----------------------------------------
+
+.. automodule:: libp2p.network.health.ping_probe
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/libp2p.network.rst
+++ b/docs/libp2p.network.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    libp2p.network.connection
+   libp2p.network.health
    libp2p.network.stream
 
 Submodules

--- a/examples/health_monitoring/README.md
+++ b/examples/health_monitoring/README.md
@@ -1,8 +1,9 @@
 # Health Monitoring Demo
 
-Optional **Python-local** connection health / resource-manager demos. Inspired by
-go-libp2p ConnMgr and metrics patterns; the proactive health monitor is **not**
-a go-libp2p feature and is off by default in `ConnectionConfig`.
+Optional **Python-local** connection health demos for py-libp2p. The proactive
+health monitor is **off by default** in `ConnectionConfig`.
+
+User guide: `docs/connection_health_monitoring.rst` (after `make docs`).
 
 ## Live multi-peer demo (recommended)
 
@@ -20,9 +21,13 @@ configurable scenarios (`all` by default):
 python -m examples.health_monitoring.live_demo
 python -m examples.health_monitoring.live_demo --peers 25 --scenario all
 python -m examples.health_monitoring.live_demo --peers 10 --scenario healthy,protect
+python -m examples.health_monitoring.live_demo --gui tui
+python -m examples.health_monitoring.live_demo --gui web --gui-port 8765
 python -m examples.health_monitoring.live_demo --list-scenarios
 # or, after install: health-monitoring-demo
 ```
+
+Optional richer TUI: `pip install -e ".[health-demo]"` (installs `rich`).
 
 Config-only API walkthrough (no real connections):
 
@@ -59,40 +64,11 @@ Open UIs:
 - Prometheus: http://localhost:9090/targets
 - Grafana: http://localhost:3000
 
-**Validating the data**
-
-The demo uses fixed limits: **10 connections**, **20 streams**, **32 MB** memory. Each second it tries to add 1 connection, 1 stream (if there is at least one connection), and 100–500 KB memory per peer. So over time you should see usage rise until it hits the limits, then blocks.
-
-1. **Exporter vs logs** (with `run_demo.py` running):
-
-   ```bash
-   curl -s http://localhost:8000/metrics | grep -E '^libp2p_rcmgr_(connections|streams|memory|blocked)'
-   ```
-
-   Compare the numbers with what the demo prints: `Current: N conns, M streams, K bytes memory` and `Blocked: ...`. The gauges should match.
-
-1. **Prometheus** (http://localhost:9090 → Graph):
-
-   - `libp2p_rcmgr_connections{scope="system"}` — total connections (should stay ≤ 10).
-   - `libp2p_rcmgr_streams{scope="system"}` — total streams (≤ 20).
-   - `libp2p_rcmgr_memory{scope="system"}` — bytes (≤ 32*1024*1024).
-   - `libp2p_rcmgr_blocked_resources` — blocked events; should increase when you are at a limit.
-
-1. **Sanity checks**: Connections and streams should level off at 10 and 20; memory at or below 32 MB. After ~15–20 seconds you should see some blocked resources (connections or memory). The Grafana dashboard panels use these same metrics.
-
-Notes:
-
-- The Grafana dashboard `py-libp2p Resource Manager` is auto-provisioned.
-- If you change the exporter port, re-run `configure.py` and `docker compose restart prometheus`.
-- Prometheus reaches the host via `host.docker.internal` (docker-compose sets `host-gateway`). If the py-libp2p target stays DOWN, try the Docker bridge IP in `prometheus.yml` (e.g. `172.17.0.1:8000` from `ip addr show docker0`) or your machine’s IP.
-- If port 8000 is already in use, run the demo on another port (e.g. `python run_demo.py --port 8001`), then run `configure.py --port 8001` and `docker compose restart prometheus`.
-
 **Testing**
-
-Tests for `run_demo.py` (different parameters, limit enforcement) live under the main test suite:
 
 ```bash
 pytest tests/examples/test_health_monitoring_run_demo.py -v
+pytest tests/examples/test_health_monitoring_live_demo.py -v
 ```
 
 Stop:

--- a/examples/health_monitoring/health_view.py
+++ b/examples/health_monitoring/health_view.py
@@ -1,0 +1,53 @@
+"""Shared helpers for health monitoring demo views."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from libp2p.abc import IHost
+
+
+def build_peer_table(host: IHost) -> list[dict[str, Any]]:
+    """Build per-peer rows for TUI / web tables."""
+    summary = host.get_network_health_summary()
+    rows: list[dict[str, Any]] = []
+    swarm = host.get_network()
+    tag_store = getattr(swarm, "tag_store", None)
+
+    for detail in summary.get("peer_details", []):
+        peer_id_str = str(detail.get("peer_id", ""))
+        protected = False
+        if tag_store is not None:
+            try:
+                from libp2p.peer.id import ID
+
+                protected = tag_store.is_protected(ID.from_string(peer_id_str))
+            except Exception:
+                protected = False
+
+        unhealthy = int(detail.get("unhealthy_connections", 0))
+        rows.append(
+            {
+                "peer_id": peer_id_str[:20],
+                "connections": detail.get("connection_count", 0),
+                "score": round(float(detail.get("average_health_score", 0.0)), 3),
+                "latency_ms": round(float(detail.get("average_latency_ms", 0.0)), 1),
+                "success_rate": round(
+                    float(detail.get("average_success_rate", 0.0)), 3
+                ),
+                "protected": protected,
+                "unhealthy": unhealthy,
+            }
+        )
+
+    return rows
+
+
+def get_metrics_snapshot(host: IHost, format: str = "json") -> str:
+    """Return exported metrics from the host."""
+    return host.export_health_metrics(format)
+
+
+def get_network_summary_dict(host: IHost) -> dict[str, Any]:
+    """Return the network health summary as a dict."""
+    return host.get_network_health_summary()

--- a/examples/health_monitoring/live_demo.py
+++ b/examples/health_monitoring/live_demo.py
@@ -64,6 +64,8 @@ class DemoOptions:
     streams_per_peer: int = 3
     strategy: str = "health_based"
     connect_limit: int = 8
+    gui: str = "none"
+    gui_port: int = 8765
 
 
 def parse_scenarios(raw: str | Sequence[str]) -> tuple[str, ...]:
@@ -422,6 +424,8 @@ async def run_live_demo(
     streams_per_peer: int = 3,
     strategy: str = "health_based",
     connect_limit: int = 8,
+    gui: str = "none",
+    gui_port: int = 8765,
 ) -> dict[str, Any]:
     """
     Run the live multi-peer health demo.
@@ -441,6 +445,8 @@ async def run_live_demo(
         streams_per_peer=streams_per_peer,
         strategy=strategy,
         connect_limit=connect_limit,
+        gui=gui,
+        gui_port=gui_port,
     )
     leaf_count = peers - 1
     protect_n, churn_n = _clamp_counts(options, leaf_count)
@@ -482,6 +488,22 @@ async def run_live_demo(
         swarm = hub.get_network()
         print(f"  Connected. Hub connections: {swarm.get_total_connections()}")
         result["total_connections"] = swarm.get_total_connections()
+
+        if options.gui != "none":
+            print(f"\n  Entering GUI mode ({options.gui})...")
+            await trio.sleep(options.wait_for_monitor)
+            result["network_health"] = hub.get_network_health_summary()
+            result["monitor_status"] = await hub.get_health_monitor_status()
+            if options.gui == "tui":
+                from examples.health_monitoring.tui import run_health_tui
+
+                await run_health_tui(hub)
+            elif options.gui == "web":
+                from examples.health_monitoring.web_gui import run_health_web
+
+                await run_health_web(hub, port=options.gui_port)
+            result["json_metrics"] = hub.export_health_metrics("json")
+            return result
 
         remaining_leaves: list[IHost] = list(leaves)
         protected_leaves: list[IHost] = []
@@ -545,7 +567,10 @@ async def run_live_demo(
         print("    1. Health monitoring is off by default; enable via ConnectionConfig")
         print("    2. Scores update after the background monitor pings idle conns")
         print("    3. Protect() is ConnMgr importance — health must not fight it")
-        print("    4. Default LB 'best' matches go-libp2p; health_based is Python-only")
+        print(
+            "    4. Default LB 'best' is direct/stream heuristic; "
+            "health_based uses scores"
+        )
         print()
 
     return result
@@ -622,6 +647,18 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print available scenarios and exit",
     )
+    parser.add_argument(
+        "--gui",
+        choices=("none", "tui", "web"),
+        default="none",
+        help="Live health view: terminal (tui) or local web server (web)",
+    )
+    parser.add_argument(
+        "--gui-port",
+        type=int,
+        default=8765,
+        help="Port for --gui web (default: 8765)",
+    )
     return parser
 
 
@@ -644,6 +681,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             churn_count=args.churn_count,
             streams_per_peer=args.streams_per_peer,
             strategy=args.strategy,
+            gui=args.gui,
+            gui_port=args.gui_port,
         )
 
     trio.run(_run)

--- a/examples/health_monitoring/tui.py
+++ b/examples/health_monitoring/tui.py
@@ -1,0 +1,107 @@
+"""Terminal UI for live connection health monitoring."""
+
+from __future__ import annotations
+
+import sys
+
+import trio
+
+from libp2p.abc import IHost
+
+from .health_view import build_peer_table, get_network_summary_dict
+
+
+def _format_table(rows: list[dict[str, object]], summary: dict[str, object]) -> str:
+    headers = (
+        "peer_id",
+        "conns",
+        "score",
+        "latency_ms",
+        "success",
+        "prot",
+        "unhl",
+    )
+    lines = [
+        "Connection health (Ctrl+C to quit)",
+        f"Peers: {summary.get('total_peers', 0)}  "
+        f"Connections: {summary.get('total_connections', 0)}  "
+        f"Avg health: {summary.get('average_peer_health', 0.0):.3f}",
+        "",
+        "  ".join(f"{h:>12}" for h in headers),
+        "-" * 90,
+    ]
+    for row in rows:
+        lines.append(
+            "  ".join(
+                [
+                    f"{str(row.get('peer_id', '')):>12}"[:12],
+                    f"{row.get('connections', 0)!s:>12}",
+                    f"{row.get('score', 0)!s:>12}",
+                    f"{row.get('latency_ms', 0)!s:>12}",
+                    f"{row.get('success_rate', 0)!s:>12}",
+                    f"{'Y' if row.get('protected') else 'N':>12}",
+                    f"{row.get('unhealthy', 0)!s:>12}",
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+async def run_health_tui(host: IHost, refresh_interval: float = 1.0) -> None:
+    """Refresh a terminal table until cancelled."""
+    try:
+        from rich.console import Console
+        from rich.live import Live
+        from rich.table import Table
+    except ImportError:
+        try:
+            while True:
+                summary = get_network_summary_dict(host)
+                rows = build_peer_table(host)
+                sys.stdout.write("\033[2J\033[H")
+                sys.stdout.write(_format_table(rows, summary) + "\n")
+                sys.stdout.flush()
+                await trio.sleep(refresh_interval)
+        except trio.Cancelled:
+            return
+        return
+
+    console = Console()
+
+    def render_rich() -> Table:
+        table = Table(title="py-libp2p connection health")
+        for col in (
+            "peer_id",
+            "conns",
+            "score",
+            "latency_ms",
+            "success",
+            "protected",
+            "unhealthy",
+        ):
+            table.add_column(col)
+        summary = get_network_summary_dict(host)
+        for row in build_peer_table(host):
+            table.add_row(
+                str(row["peer_id"]),
+                str(row["connections"]),
+                str(row["score"]),
+                str(row["latency_ms"]),
+                str(row["success_rate"]),
+                "Y" if row["protected"] else "N",
+                str(row["unhealthy"]),
+            )
+        table.caption = (
+            f"Peers={summary.get('total_peers', 0)} "
+            f"Conns={summary.get('total_connections', 0)} "
+            f"Avg={summary.get('average_peer_health', 0.0):.3f}"
+        )
+        return table
+
+    with Live(render_rich(), console=console, refresh_per_second=1) as live:
+        try:
+            while True:
+                await trio.sleep(refresh_interval)
+                live.update(render_rich())
+        except trio.Cancelled:
+            return

--- a/examples/health_monitoring/web_gui.py
+++ b/examples/health_monitoring/web_gui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from html import escape
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 from typing import Any
@@ -21,16 +22,19 @@ from .health_view import (
 def _html_page(rows: list[dict[str, Any]], summary: dict[str, Any]) -> bytes:
     body_rows = "".join(
         "<tr>"
-        f"<td>{row['peer_id']}</td>"
-        f"<td>{row['connections']}</td>"
-        f"<td>{row['score']}</td>"
-        f"<td>{row['latency_ms']}</td>"
-        f"<td>{row['success_rate']}</td>"
-        f"<td>{'yes' if row['protected'] else 'no'}</td>"
-        f"<td>{row['unhealthy']}</td>"
+        f"<td>{escape(str(row['peer_id']))}</td>"
+        f"<td>{escape(str(row['connections']))}</td>"
+        f"<td>{escape(str(row['score']))}</td>"
+        f"<td>{escape(str(row['latency_ms']))}</td>"
+        f"<td>{escape(str(row['success_rate']))}</td>"
+        f"<td>{escape('yes' if row['protected'] else 'no')}</td>"
+        f"<td>{escape(str(row['unhealthy']))}</td>"
         "</tr>"
         for row in rows
     )
+    total_peers = escape(str(summary.get("total_peers", 0)))
+    total_conns = escape(str(summary.get("total_connections", 0)))
+    avg_health = escape(f"{float(summary.get('average_peer_health', 0.0)):.3f}")
     html = f"""<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"/>
@@ -44,9 +48,9 @@ th {{ background: #f0f0f0; }}
 </style>
 </head><body>
 <h1>Connection health</h1>
-<p>Peers: {summary.get("total_peers", 0)} |
-Connections: {summary.get("total_connections", 0)} |
-Avg health: {summary.get("average_peer_health", 0.0):.3f}</p>
+<p>Peers: {total_peers} |
+Connections: {total_conns} |
+Avg health: {avg_health}</p>
 <p><a href="/api/summary">JSON summary</a> |
 <a href="/api/metrics">JSON metrics</a> |
 <a href="/api/metrics?format=prometheus">Prometheus</a></p>

--- a/examples/health_monitoring/web_gui.py
+++ b/examples/health_monitoring/web_gui.py
@@ -1,0 +1,132 @@
+"""Local web UI for live connection health monitoring."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import trio
+
+from libp2p.abc import IHost
+
+from .health_view import (
+    build_peer_table,
+    get_metrics_snapshot,
+    get_network_summary_dict,
+)
+
+
+def _html_page(rows: list[dict[str, Any]], summary: dict[str, Any]) -> bytes:
+    body_rows = "".join(
+        "<tr>"
+        f"<td>{row['peer_id']}</td>"
+        f"<td>{row['connections']}</td>"
+        f"<td>{row['score']}</td>"
+        f"<td>{row['latency_ms']}</td>"
+        f"<td>{row['success_rate']}</td>"
+        f"<td>{'yes' if row['protected'] else 'no'}</td>"
+        f"<td>{row['unhealthy']}</td>"
+        "</tr>"
+        for row in rows
+    )
+    html = f"""<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8"/>
+<meta http-equiv="refresh" content="2"/>
+<title>py-libp2p health</title>
+<style>
+body {{ font-family: sans-serif; margin: 1rem; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #ccc; padding: 0.4rem 0.6rem; text-align: left; }}
+th {{ background: #f0f0f0; }}
+</style>
+</head><body>
+<h1>Connection health</h1>
+<p>Peers: {summary.get("total_peers", 0)} |
+Connections: {summary.get("total_connections", 0)} |
+Avg health: {summary.get("average_peer_health", 0.0):.3f}</p>
+<p><a href="/api/summary">JSON summary</a> |
+<a href="/api/metrics">JSON metrics</a> |
+<a href="/api/metrics?format=prometheus">Prometheus</a></p>
+<table>
+<tr><th>peer_id</th><th>conns</th><th>score</th><th>latency_ms</th>
+<th>success</th><th>protected</th><th>unhealthy</th></tr>
+{body_rows}
+</table>
+</body></html>"""
+    return html.encode("utf-8")
+
+
+def _make_handler(host: IHost) -> type[BaseHTTPRequestHandler]:
+    class HealthHandler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path == "/":
+                summary = get_network_summary_dict(host)
+                rows = build_peer_table(host)
+                payload = _html_page(rows, summary)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+
+            if parsed.path == "/api/summary":
+                data = json.dumps(get_network_summary_dict(host)).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+
+            if parsed.path == "/api/metrics":
+                params = parse_qs(parsed.query)
+                fmt = params.get("format", ["json"])[0]
+                if fmt not in ("json", "prometheus"):
+                    fmt = "json"
+                body = get_metrics_snapshot(host, fmt).encode("utf-8")
+                ctype = (
+                    "text/plain; version=0.0.4"
+                    if fmt == "prometheus"
+                    else "application/json"
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+    return HealthHandler
+
+
+async def run_health_web(
+    host: IHost,
+    *,
+    host_addr: str = "127.0.0.1",
+    port: int = 8765,
+) -> None:
+    """Serve health HTML and JSON/Prometheus APIs until cancelled."""
+    handler = _make_handler(host)
+    server = ThreadingHTTPServer((host_addr, port), handler)
+
+    async def serve() -> None:
+        await trio.to_thread.run_sync(server.serve_forever)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(serve)
+        print(f"Health web UI: http://{host_addr}:{port}/")
+        try:
+            await trio.sleep_forever()
+        finally:
+            server.shutdown()

--- a/libp2p/host/ping.py
+++ b/libp2p/host/ping.py
@@ -98,6 +98,22 @@ async def _handle_ping(stream: INetStream, peer_id: PeerID) -> bool:
     return True
 
 
+async def perform_ping_roundtrip(
+    stream: INetStream, cancel_scope: trio.CancelScope | None = None
+) -> int:
+    """
+    Perform a single ping round-trip and return RTT in **milliseconds**.
+
+    Public entry point for health probes and other callers that already
+    negotiated ``/ipfs/ping/1.0.0`` on a stream.
+
+    Matches go-libp2p's Result.RTT.Milliseconds() convention.
+    Raises ValueError if the pong payload does not match the sent ping.
+    Raises trio.TooSlowError if the peer takes longer than RESP_TIMEOUT seconds.
+    """
+    return await _ping(stream, cancel_scope=cancel_scope)
+
+
 async def _ping(
     stream: INetStream, cancel_scope: trio.CancelScope | None = None
 ) -> int:

--- a/libp2p/network/config.py
+++ b/libp2p/network/config.py
@@ -197,6 +197,12 @@ class ConnectionConfig:
     # Health score threshold below which a connection is considered critically
     # unhealthy and can be replaced even at minimum connections
     critical_health_threshold: float = 0.1  # 0.0 to 1.0
+    # When True, skip ping probes if the connection already has open streams
+    skip_ping_when_streams_open: bool = False
+    # Record successful ping RTT in peerstore LatencyEWMA (seconds)
+    record_ping_latency_in_peerstore: bool = True
+    # When True, close the connection immediately after a failed ping probe
+    abort_connection_on_ping_failure: bool = False
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""

--- a/libp2p/network/health/monitor.py
+++ b/libp2p/network/health/monitor.py
@@ -16,6 +16,7 @@ from libp2p.peer.id import ID
 from libp2p.tools.anyio_service import Service
 
 from .data_structures import HealthMonitorStatus
+from .ping_probe import ConnectionPingResult, ping_connection
 
 if TYPE_CHECKING:
     from libp2p.network.swarm import Swarm
@@ -159,22 +160,38 @@ class ConnectionHealthMonitor(Service):
                 self.swarm.initialize_connection_health(peer_id, conn)
                 return
 
-            # Measure ping latency
-            start_time = trio.current_time()
-            ping_success = await self._ping_connection(conn)
-            latency_ms = (trio.current_time() - start_time) * 1000
+            ping_result = await self._ping_connection(conn)
+
+            if ping_result.skipped:
+                return
+
+            latency_ms = ping_result.rtt_ms
+            ping_success = ping_result.success
 
             # Update health metrics
             health = self.swarm.health_data[peer_id][conn]
             health.update_ping_metrics(latency_ms, ping_success)
             health.update_stream_metrics(len(conn.get_streams()))
 
+            if (
+                ping_success
+                and ping_result.protocol_supported
+                and getattr(self.config, "record_ping_latency_in_peerstore", True)
+            ):
+                try:
+                    self.swarm.peerstore.record_latency(peer_id, latency_ms / 1000.0)
+                except Exception as error:
+                    logger.debug(
+                        "Failed to record ping latency for %s: %s", peer_id, error
+                    )
+
             # Log health status periodically
             if ping_success:
                 logger.debug(
                     f"Health check for {peer_id}: latency={latency_ms:.1f}ms, "
                     f"score={health.health_score:.2f}, "
-                    f"success_rate={health.ping_success_rate:.2f}"
+                    f"success_rate={health.ping_success_rate:.2f}, "
+                    f"ping_protocol={ping_result.protocol_supported}"
                 )
             else:
                 logger.warning(
@@ -182,6 +199,26 @@ class ConnectionHealthMonitor(Service):
                     f"score={health.health_score:.2f}, "
                     f"success_rate={health.ping_success_rate:.2f}"
                 )
+
+            if not ping_success and getattr(
+                self.config, "abort_connection_on_ping_failure", False
+            ):
+                logger.info(
+                    "Aborting connection to %s after failed ping probe", peer_id
+                )
+                self.swarm.cleanup_connection_health(peer_id, conn)
+                if (
+                    peer_id in self.swarm.connections
+                    and conn in self.swarm.connections[peer_id]
+                ):
+                    self.swarm.connections[peer_id].remove(conn)
+                try:
+                    await conn.close()
+                except Exception as error:
+                    logger.debug(
+                        "Error closing connection after ping failure: %s", error
+                    )
+                return
 
             # Check if connection needs replacement
             if self._should_replace_connection(peer_id, conn):
@@ -194,46 +231,24 @@ class ConnectionHealthMonitor(Service):
                 health = self.swarm.health_data[peer_id][conn]
                 health.add_error(f"Health check error: {e}")
 
-    async def _ping_connection(self, conn: INetConn) -> bool:
+    async def _ping_connection(self, conn: INetConn) -> ConnectionPingResult:
         """
-        Ping a connection to measure responsiveness.
+        Ping a connection using ``/ipfs/ping/1.0.0`` on that specific connection.
 
-        Uses a simple stream creation test as a health check.
-        In a production implementation, this could use a dedicated ping protocol.
-
-        Note: When active streams are present, we skip the ping to avoid
-        interfering with active communication. This is a performance optimization
-        that assumes active streams indicate the connection is functional.
-        However, this may mask connection issues in some edge cases where streams
-        are open but the connection is degraded. For more aggressive health
-        checking, consider performing lightweight pings even with active streams.
+        When ``skip_ping_when_streams_open`` is enabled, busy connections are
+        skipped (legacy behavior). By default, probes run even with open streams.
         """
-        try:
-            # If there are active streams, avoid intrusive ping; assume healthy
-            # This is a performance optimization to avoid interfering with
-            # active communication, but may mask some connection issues
-            if len(conn.get_streams()) > 0:
-                return True
-
-            # Use a timeout for the ping
-            with trio.move_on_after(self.config.ping_timeout):
-                # Create a throwaway stream and immediately reset it to avoid
-                # affecting muxer stream accounting in tests
-                stream = await conn.new_stream()
-                try:
-                    await stream.reset()
-                finally:
-                    # Best-effort close in case reset was a no-op
-                    try:
-                        await stream.close()
-                    except Exception:
-                        pass
-                return True
-
-        except Exception as e:
-            logger.debug(f"Ping failed for connection: {e}")
-
-        return False
+        negotiate_timeout = int(
+            self.config.outbound_stream_protocol_negotiation_timeout
+        )
+        return await ping_connection(
+            conn,
+            ping_timeout=self.config.ping_timeout,
+            negotiate_timeout=negotiate_timeout,
+            skip_when_streams_open=getattr(
+                self.config, "skip_ping_when_streams_open", False
+            ),
+        )
 
     def _should_replace_connection(self, peer_id: ID, conn: INetConn) -> bool:
         """Determine if a connection should be replaced based on health metrics."""

--- a/libp2p/network/health/monitor.py
+++ b/libp2p/network/health/monitor.py
@@ -206,12 +206,8 @@ class ConnectionHealthMonitor(Service):
                 logger.info(
                     "Aborting connection to %s after failed ping probe", peer_id
                 )
-                self.swarm.cleanup_connection_health(peer_id, conn)
-                if (
-                    peer_id in self.swarm.connections
-                    and conn in self.swarm.connections[peer_id]
-                ):
-                    self.swarm.connections[peer_id].remove(conn)
+                # SwarmConn.close() -> swarm.remove_conn() handles health cleanup,
+                # connection list removal, and rcmgr lifecycle notification.
                 try:
                     await conn.close()
                 except Exception as error:
@@ -306,13 +302,13 @@ class ConnectionHealthMonitor(Service):
         """
         Replace an unhealthy connection with a new one.
 
-        Dial a replacement first (go-libp2p does not auto-replace; this is a
-        Python-local QoS policy). Only drop the old connection after a new one
-        succeeds, so we never go below ``min_connections_per_peer`` on failure.
+        Dial a replacement first (Python-local QoS; not a wire-protocol
+        requirement). Only drop the old connection after a new one succeeds,
+        so we never go below ``min_connections_per_peer`` on failure.
         Protected peers (ConnMgr Protect / tag_store) are never auto-replaced.
         """
         try:
-            # Respect go-libp2p Protect semantics via TagStore
+            # Skip ConnMgr-protected peers (tag_store Protect)
             tag_store = getattr(self.swarm, "tag_store", None)
             if tag_store is not None and tag_store.is_protected(peer_id):
                 logger.info(
@@ -396,14 +392,7 @@ class ConnectionHealthMonitor(Service):
                     peer_id,
                 )
 
-            # Now safe to drop the old connection
-            self.swarm.cleanup_connection_health(peer_id, old_conn)
-            if (
-                peer_id in self.swarm.connections
-                and old_conn in self.swarm.connections[peer_id]
-            ):
-                self.swarm.connections[peer_id].remove(old_conn)
-
+            # Drop via SwarmConn.close() so remove_conn cleans health + rcmgr.
             try:
                 await old_conn.close()
             except Exception as e:

--- a/libp2p/network/health/ping_probe.py
+++ b/libp2p/network/health/ping_probe.py
@@ -1,0 +1,113 @@
+"""
+Per-connection ping probe for connection health monitoring.
+
+Opens a stream on a specific ``INetConn``, negotiates ``/ipfs/ping/1.0.0``,
+and measures RTT. Used by :class:`ConnectionHealthMonitor` instead of
+``PingService.ping(peer_id)``, which selects the best connection per peer.
+"""
+
+from dataclasses import dataclass
+import logging
+
+import trio
+
+from libp2p.abc import INetConn, INetStream
+from libp2p.host.ping import (
+    ID as PING_PROTOCOL,
+    perform_ping_roundtrip,
+)
+from libp2p.protocol_muxer.exceptions import ProtocolNotSupportedError
+from libp2p.protocol_muxer.multiselect_client import MultiselectClient
+from libp2p.protocol_muxer.multiselect_communicator import MultiselectCommunicator
+
+logger = logging.getLogger("libp2p.network.health.ping_probe")
+
+
+@dataclass(frozen=True)
+class ConnectionPingResult:
+    """Outcome of a health ping against one connection."""
+
+    success: bool
+    rtt_ms: float = 0.0
+    protocol_supported: bool = False
+    skipped: bool = False
+
+
+async def _close_stream(stream: INetStream) -> None:
+    try:
+        await stream.close()
+    except Exception:
+        try:
+            await stream.reset()
+        except Exception:
+            pass
+
+
+async def ping_connection(
+    conn: INetConn,
+    *,
+    ping_timeout: float,
+    negotiate_timeout: int | None = None,
+    skip_when_streams_open: bool = False,
+) -> ConnectionPingResult:
+    """
+    Ping a specific connection using ``/ipfs/ping/1.0.0``.
+
+    Parameters
+    ----------
+    conn:
+        The connection to probe (not load-balanced across peers).
+    ping_timeout:
+        Overall timeout in seconds for the probe.
+    negotiate_timeout:
+        Multiselect negotiation timeout in seconds. Defaults to ``ping_timeout``.
+    skip_when_streams_open:
+        When ``True``, skip probing if the connection already has open streams
+        and return ``success=True`` with ``skipped=True``.
+
+    """
+    if skip_when_streams_open and len(conn.get_streams()) > 0:
+        return ConnectionPingResult(success=True, skipped=True)
+
+    if negotiate_timeout is None:
+        negotiate_timeout = max(1, int(ping_timeout))
+
+    with trio.move_on_after(ping_timeout) as scope:
+        stream: INetStream | None = None
+        try:
+            stream = await conn.new_stream()
+            negotiate_start = trio.current_time()
+            communicator = MultiselectCommunicator(stream)
+            client = MultiselectClient()
+            try:
+                await client.select_one_of(
+                    [PING_PROTOCOL],
+                    communicator,
+                    negotiate_timeout,
+                )
+            except ProtocolNotSupportedError:
+                negotiation_rtt_ms = (trio.current_time() - negotiate_start) * 1000
+                return ConnectionPingResult(
+                    success=True,
+                    rtt_ms=negotiation_rtt_ms,
+                    protocol_supported=False,
+                )
+
+            rtt_ms = float(await perform_ping_roundtrip(stream))
+            return ConnectionPingResult(
+                success=True,
+                rtt_ms=rtt_ms,
+                protocol_supported=True,
+            )
+        except trio.Cancelled:
+            raise
+        except Exception as error:
+            logger.debug("Ping probe failed: %s", error)
+            return ConnectionPingResult(success=False)
+        finally:
+            if stream is not None:
+                await _close_stream(stream)
+
+    if scope.cancelled_caught:
+        logger.debug("Ping probe timed out after %ss", ping_timeout)
+    return ConnectionPingResult(success=False)

--- a/newsfragments/1453.feature.rst
+++ b/newsfragments/1453.feature.rst
@@ -1,0 +1,1 @@
+The opt-in connection health monitor now probes each connection with ``/ipfs/ping/1.0.0``, with Sphinx docs, a live demo TUI/web UI, and extra config flags for busy-connection skip, peerstore RTT, and abort-on-ping-failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ Homepage = "https://github.com/libp2p/py-libp2p"
 
 [project.optional-dependencies]
 webrtc = ["aiortc>=1.15,<2.0"]
+health-demo = ["rich>=13.0"]
 
 [project.scripts]
 chat-demo = "examples.chat.chat:main"

--- a/tests/core/network/test_health_monitor.py
+++ b/tests/core/network/test_health_monitor.py
@@ -20,6 +20,7 @@ from libp2p.network.health.data_structures import (
     create_default_connection_health,
 )
 from libp2p.network.health.monitor import ConnectionHealthMonitor
+from libp2p.network.health.ping_probe import ConnectionPingResult
 from libp2p.peer.id import ID
 from libp2p.tools.anyio_service import background_trio_service
 
@@ -96,6 +97,8 @@ class MockSwarm:
         self.dial_peer_replacement_called = 0
         self.tag_store = Mock()
         self.tag_store.is_protected = Mock(return_value=False)
+        self.peerstore = Mock()
+        self.peerstore.record_latency = Mock()
 
     @property
     def _is_health_monitoring_enabled(self) -> bool:
@@ -184,8 +187,16 @@ async def test_health_monitor_starts_with_initial_delay() -> None:
 
 
 @pytest.mark.trio
-async def test_check_all_connections() -> None:
+async def test_check_all_connections(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test checking health of all connections."""
+    ping_calls: list[INetConn] = []
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        ping_calls.append(conn)
+        return ConnectionPingResult(success=True, rtt_ms=1.0, protocol_supported=True)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(enable_health_monitoring=True, health_warmup_window=0.0)
     swarm = MockSwarm(config)
 
@@ -208,10 +219,7 @@ async def test_check_all_connections() -> None:
     # Check all connections
     await monitor._check_all_connections()
 
-    # Verify new_stream was called for each connection (ping check)
-    assert conn1.new_stream_called
-    assert conn2.new_stream_called
-    assert conn3.new_stream_called
+    assert ping_calls == [conn1, conn2, conn3]
 
 
 @pytest.mark.trio
@@ -259,8 +267,14 @@ async def test_check_connection_health_initializes_missing() -> None:
 
 
 @pytest.mark.trio
-async def test_ping_connection_success() -> None:
-    """Test successful ping operation."""
+async def test_ping_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test successful ping operation delegates to ping probe."""
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        return ConnectionPingResult(success=True, rtt_ms=5.0, protocol_supported=True)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(enable_health_monitoring=True, ping_timeout=1.0)
     swarm = MockSwarm(config)
     peer_id = ID(b"peer1")
@@ -268,66 +282,109 @@ async def test_ping_connection_success() -> None:
 
     monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
 
-    # Ping the connection
     result = await monitor._ping_connection(conn)
 
-    assert result is True
-    assert conn.new_stream_called
+    assert result.success is True
+    assert result.rtt_ms == 5.0
+    assert result.protocol_supported is True
 
 
 @pytest.mark.trio
-async def test_ping_connection_failure() -> None:
+async def test_ping_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test failed ping operation."""
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        return ConnectionPingResult(success=False)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(enable_health_monitoring=True, ping_timeout=1.0)
     swarm = MockSwarm(config)
     peer_id = ID(b"peer1")
-    conn = MockConnection(peer_id, fail_new_stream=True)
+    conn = MockConnection(peer_id)
 
     monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
 
-    # Ping the connection (should fail)
     result = await monitor._ping_connection(conn)
 
-    assert result is False
+    assert result.success is False
 
 
 @pytest.mark.trio
-async def test_ping_connection_with_active_streams() -> None:
-    """Test ping skipped when connection has active streams."""
+async def test_ping_connection_with_active_streams_default_pings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """By default, ping runs even when streams are open."""
+    seen_skip: list[bool] = []
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        seen_skip.append(bool(kwargs.get("skip_when_streams_open")))
+        return ConnectionPingResult(success=True, rtt_ms=3.0, protocol_supported=True)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(enable_health_monitoring=True)
     swarm = MockSwarm(config)
     peer_id = ID(b"peer1")
     conn = MockConnection(peer_id)
-
-    # Add active streams
-    mock_stream = Mock(spec=INetStream)
-    conn.streams.add(mock_stream)
+    conn.streams.add(Mock(spec=INetStream))
 
     monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
-
-    # Ping the connection
     result = await monitor._ping_connection(conn)
 
-    # Should succeed without creating new stream
-    assert result is True
-    assert not conn.new_stream_called
+    assert result.success is True
+    assert seen_skip == [False]
 
 
 @pytest.mark.trio
-async def test_ping_connection_timeout() -> None:
+async def test_ping_connection_skip_when_streams_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy skip-if-busy when skip_ping_when_streams_open is enabled."""
+    seen_skip: list[bool] = []
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        seen_skip.append(bool(kwargs.get("skip_when_streams_open")))
+        if kwargs.get("skip_when_streams_open"):
+            return ConnectionPingResult(success=True, skipped=True)
+        return ConnectionPingResult(success=True, rtt_ms=3.0, protocol_supported=True)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
+    config = ConnectionConfig(
+        enable_health_monitoring=True, skip_ping_when_streams_open=True
+    )
+    swarm = MockSwarm(config)
+    peer_id = ID(b"peer1")
+    conn = MockConnection(peer_id)
+    conn.streams.add(Mock(spec=INetStream))
+
+    monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
+    result = await monitor._ping_connection(conn)
+
+    assert result.skipped is True
+    assert seen_skip == [True]
+
+
+@pytest.mark.trio
+async def test_ping_connection_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test ping timeout handling."""
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        return ConnectionPingResult(success=False)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(enable_health_monitoring=True, ping_timeout=0.1)
     swarm = MockSwarm(config)
     peer_id = ID(b"peer1")
-    conn = MockConnection(peer_id, stream_timeout=True)
+    conn = MockConnection(peer_id)
 
     monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
 
-    # Ping the connection (should timeout)
-    with trio.fail_after(1.0):  # Overall timeout
-        result = await monitor._ping_connection(conn)
+    result = await monitor._ping_connection(conn)
 
-    assert result is False
+    assert result.success is False
 
 
 @pytest.mark.trio
@@ -714,8 +771,16 @@ async def test_has_health_data() -> None:
 
 
 @pytest.mark.trio
-async def test_health_check_updates_metrics() -> None:
+async def test_health_check_updates_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test health check updates connection metrics correctly."""
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        return ConnectionPingResult(success=True, rtt_ms=12.5, protocol_supported=True)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
     config = ConnectionConfig(
         enable_health_monitoring=True,
         health_warmup_window=0.0,  # Disable warmup for test
@@ -730,19 +795,46 @@ async def test_health_check_updates_metrics() -> None:
 
     monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
 
-    # Get initial health state
     health = swarm.health_data[peer_id][conn]
     initial_last_ping = health.last_ping
 
-    # Small delay to ensure timestamp changes
     await trio.sleep(0.01)
 
-    # Perform health check
     await monitor._check_connection_health(peer_id, conn)
 
-    # Verify metrics updated
     assert health.last_ping > initial_last_ping
-    assert health.ping_latency >= 0
+    assert health.ping_latency == 12.5
+    swarm.peerstore.record_latency.assert_called_once_with(peer_id, 12.5 / 1000.0)
+
+
+@pytest.mark.trio
+async def test_abort_connection_on_ping_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed ping closes connection when abort_connection_on_ping_failure is set."""
+
+    async def fake_ping(conn: INetConn, **kwargs: object) -> ConnectionPingResult:
+        return ConnectionPingResult(success=False)
+
+    monkeypatch.setattr("libp2p.network.health.monitor.ping_connection", fake_ping)
+
+    config = ConnectionConfig(
+        enable_health_monitoring=True,
+        health_warmup_window=0.0,
+        abort_connection_on_ping_failure=True,
+    )
+    swarm = MockSwarm(config)
+    peer_id = ID(b"peer1")
+    conn = MockConnection(peer_id)
+    swarm.connections[peer_id] = [conn]
+    swarm.initialize_connection_health(peer_id, conn)
+
+    monitor = ConnectionHealthMonitor(swarm)  # type: ignore[arg-type]
+    await monitor._check_connection_health(peer_id, conn)
+
+    assert conn.close_called
+    assert conn not in swarm.connections[peer_id]
+    assert swarm.cleanup_connection_health_called == 1
 
 
 if __name__ == "__main__":

--- a/tests/core/network/test_health_monitor.py
+++ b/tests/core/network/test_health_monitor.py
@@ -45,10 +45,14 @@ class MockConnection(INetConn):
         self.event_started = trio.Event()
         self.new_stream_called = False
         self.close_called = False
+        self.swarm: Any = None
 
     async def close(self) -> None:
         self._is_closed = True
         self.close_called = True
+        # Mirror SwarmConn.close() -> swarm.remove_conn(self)
+        if self.swarm is not None:
+            self.swarm.remove_conn(self)
 
     @property
     def is_closed(self) -> bool:
@@ -119,11 +123,28 @@ class MockSwarm:
             if not self.health_data[peer_id]:
                 del self.health_data[peer_id]
 
+    def remove_conn(self, swarm_conn: INetConn) -> None:
+        """Mirror Swarm.remove_conn: clean health, then drop from the list."""
+        peer_id = getattr(swarm_conn, "peer_id", None)
+        if peer_id is None:
+            muxed = getattr(swarm_conn, "muxed_conn", None)
+            peer_id = getattr(muxed, "peer_id", None)
+        if peer_id is None:
+            return
+        self.cleanup_connection_health(peer_id, swarm_conn)
+        if peer_id in self.connections:
+            self.connections[peer_id] = [
+                conn for conn in self.connections[peer_id] if conn != swarm_conn
+            ]
+            if not self.connections[peer_id]:
+                del self.connections[peer_id]
+
     async def dial_peer_replacement(self, peer_id: ID) -> INetConn | None:
         """Mock replacement connection dialing."""
         self.dial_peer_replacement_called += 1
         # Return a new mock connection
         new_conn = MockConnection(peer_id)
+        new_conn.swarm = self
         if peer_id not in self.connections:
             self.connections[peer_id] = []
         self.connections[peer_id].append(new_conn)
@@ -584,6 +605,8 @@ async def test_replace_unhealthy_connection() -> None:
     peer_id = ID(b"peer1")
     old_conn = MockConnection(peer_id)
     healthy_conn = MockConnection(peer_id)  # Keep a healthy connection
+    old_conn.swarm = swarm
+    healthy_conn.swarm = swarm
 
     # Add two connections to swarm (so we can replace one)
     swarm.connections[peer_id] = [old_conn, healthy_conn]
@@ -826,6 +849,7 @@ async def test_abort_connection_on_ping_failure(
     swarm = MockSwarm(config)
     peer_id = ID(b"peer1")
     conn = MockConnection(peer_id)
+    conn.swarm = swarm
     swarm.connections[peer_id] = [conn]
     swarm.initialize_connection_health(peer_id, conn)
 
@@ -833,7 +857,7 @@ async def test_abort_connection_on_ping_failure(
     await monitor._check_connection_health(peer_id, conn)
 
     assert conn.close_called
-    assert conn not in swarm.connections[peer_id]
+    assert conn not in swarm.connections.get(peer_id, [])
     assert swarm.cleanup_connection_health_called == 1
 
 

--- a/tests/core/network/test_health_monitor_real_network.py
+++ b/tests/core/network/test_health_monitor_real_network.py
@@ -1,0 +1,114 @@
+"""Real-network integration tests for connection health monitoring."""
+
+from typing import Any, cast
+
+import pytest
+from multiaddr import Multiaddr
+import trio
+
+from libp2p.host.basic_host import BasicHost
+from libp2p.network.config import ConnectionConfig
+from libp2p.network.connection.swarm_connection import SwarmConn
+from libp2p.tools.anyio_service import background_trio_service
+from libp2p.tools.utils import connect
+from libp2p.utils.address_validation import (
+    get_available_interfaces,
+    get_optimal_binding_address,
+)
+from tests.utils.factories import SwarmFactory
+
+
+def _is_loopback_only() -> bool:
+    addrs = get_available_interfaces(0, "tcp")
+    if not addrs:
+        return True
+    return all("/ip4/127." in str(addr) or "/ip6/::1" in str(addr) for addr in addrs)
+
+
+def _health_config() -> ConnectionConfig:
+    return ConnectionConfig(
+        enable_health_monitoring=True,
+        health_initial_delay=0.0,
+        health_warmup_window=0.0,
+        health_check_interval=1.0,
+        ping_timeout=5.0,
+        skip_ping_when_streams_open=False,
+        min_connections_per_peer=1,
+        unhealthy_grace_period=1,
+    )
+
+
+@pytest.mark.trio
+async def test_health_monitor_updates_rtt_on_real_network() -> None:
+    """Health monitor records ping RTT over a non-loopback path when available."""
+    if _is_loopback_only():
+        pytest.skip("No non-loopback interfaces available for real-network test")
+
+    bind_addr = get_optimal_binding_address(0, "tcp")
+    bind_str = str(bind_addr)
+    assert "/ip4/127." not in bind_str and "/ip6/::1" not in bind_str
+
+    config = _health_config()
+    swarm_factory = cast(Any, SwarmFactory)
+    swarm_a = swarm_factory(connection_config=config)
+    swarm_b = swarm_factory(connection_config=config)
+    host_a = BasicHost(swarm_a)
+    host_b = BasicHost(swarm_b)
+
+    async with background_trio_service(swarm_a):
+        async with background_trio_service(swarm_b):
+            await swarm_a.listen(bind_addr)
+            await swarm_b.listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+            await connect(host_a, host_b)
+
+            peer_a = host_a.get_id()
+            conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
+            swarm_b.initialize_connection_health(peer_a, conn)
+
+            monitor = swarm_b._health_monitor
+            assert monitor is not None
+            await monitor._check_connection_health(peer_a, conn)
+
+            summary = host_b.get_connection_health(peer_a)
+            assert summary["average_latency_ms"] >= 0
+            assert summary["average_health_score"] > 0
+
+
+@pytest.mark.trio
+async def test_health_monitor_detects_failed_ping_on_real_network() -> None:
+    """A closed connection yields failed ping metrics on the next probe."""
+    if _is_loopback_only():
+        pytest.skip("No non-loopback interfaces available for real-network test")
+
+    config = _health_config()
+    bind_addr = get_optimal_binding_address(0, "tcp")
+    swarm_factory = cast(Any, SwarmFactory)
+    swarm_a = swarm_factory(connection_config=config)
+    swarm_b = swarm_factory(connection_config=config)
+    host_a = BasicHost(swarm_a)
+    host_b = BasicHost(swarm_b)
+
+    async with background_trio_service(swarm_a):
+        async with background_trio_service(swarm_b):
+            await swarm_a.listen(bind_addr)
+            await swarm_b.listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+            await connect(host_a, host_b)
+
+            peer_a = host_a.get_id()
+            conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
+            swarm_b.initialize_connection_health(peer_a, conn)
+
+            monitor = swarm_b._health_monitor
+            assert monitor is not None
+
+            await monitor._check_connection_health(peer_a, conn)
+            health = swarm_b.health_data[peer_a][conn]
+            assert health.ping_success_rate > 0.5
+
+            await conn.close()
+            await trio.sleep(0.05)
+
+            result = await monitor._ping_connection(conn)
+            assert result.success is False
+            health.update_ping_metrics(0.0, False)
+            assert health.ping_success_rate < 1.0

--- a/tests/core/network/test_health_monitor_real_network.py
+++ b/tests/core/network/test_health_monitor_real_network.py
@@ -3,7 +3,6 @@
 from typing import Any, cast
 
 import pytest
-from multiaddr import Multiaddr
 import trio
 
 from libp2p.host.basic_host import BasicHost
@@ -25,6 +24,11 @@ def _is_loopback_only() -> bool:
     return all("/ip4/127." in str(addr) or "/ip6/::1" in str(addr) for addr in addrs)
 
 
+def _assert_non_loopback(addr: object) -> None:
+    addr_str = str(addr)
+    assert "/ip4/127." not in addr_str and "/ip6/::1" not in addr_str, addr_str
+
+
 def _health_config() -> ConnectionConfig:
     return ConnectionConfig(
         enable_health_monitoring=True,
@@ -40,13 +44,18 @@ def _health_config() -> ConnectionConfig:
 
 @pytest.mark.trio
 async def test_health_monitor_updates_rtt_on_real_network() -> None:
-    """Health monitor records ping RTT over a non-loopback path when available."""
+    """
+    Health monitor records ping RTT when both hosts bind non-loopback TCP.
+
+    Skipped on loopback-only machines (typical restricted CI images).
+    """
     if _is_loopback_only():
         pytest.skip("No non-loopback interfaces available for real-network test")
 
-    bind_addr = get_optimal_binding_address(0, "tcp")
-    bind_str = str(bind_addr)
-    assert "/ip4/127." not in bind_str and "/ip6/::1" not in bind_str
+    bind_a = get_optimal_binding_address(0, "tcp")
+    bind_b = get_optimal_binding_address(0, "tcp")
+    _assert_non_loopback(bind_a)
+    _assert_non_loopback(bind_b)
 
     config = _health_config()
     swarm_factory = cast(Any, SwarmFactory)
@@ -57,8 +66,8 @@ async def test_health_monitor_updates_rtt_on_real_network() -> None:
 
     async with background_trio_service(swarm_a):
         async with background_trio_service(swarm_b):
-            await swarm_a.listen(bind_addr)
-            await swarm_b.listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+            await swarm_a.listen(bind_a)
+            await swarm_b.listen(bind_b)
             await connect(host_a, host_b)
 
             peer_a = host_a.get_id()
@@ -76,12 +85,20 @@ async def test_health_monitor_updates_rtt_on_real_network() -> None:
 
 @pytest.mark.trio
 async def test_health_monitor_detects_failed_ping_on_real_network() -> None:
-    """A closed connection yields failed ping metrics on the next probe."""
+    """
+    A closed connection yields failed ping metrics on the next probe.
+
+    Both peers bind non-loopback TCP; skipped when only loopback is available.
+    """
     if _is_loopback_only():
         pytest.skip("No non-loopback interfaces available for real-network test")
 
     config = _health_config()
-    bind_addr = get_optimal_binding_address(0, "tcp")
+    bind_a = get_optimal_binding_address(0, "tcp")
+    bind_b = get_optimal_binding_address(0, "tcp")
+    _assert_non_loopback(bind_a)
+    _assert_non_loopback(bind_b)
+
     swarm_factory = cast(Any, SwarmFactory)
     swarm_a = swarm_factory(connection_config=config)
     swarm_b = swarm_factory(connection_config=config)
@@ -90,8 +107,8 @@ async def test_health_monitor_detects_failed_ping_on_real_network() -> None:
 
     async with background_trio_service(swarm_a):
         async with background_trio_service(swarm_b):
-            await swarm_a.listen(bind_addr)
-            await swarm_b.listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+            await swarm_a.listen(bind_a)
+            await swarm_b.listen(bind_b)
             await connect(host_a, host_b)
 
             peer_a = host_a.get_id()

--- a/tests/core/network/test_health_ping_probe.py
+++ b/tests/core/network/test_health_ping_probe.py
@@ -30,7 +30,7 @@ async def test_ping_connection_real_hosts() -> None:
 
 @pytest.mark.trio
 async def test_ping_connection_records_peerstore_latency() -> None:
-    """Successful ping updates peerstore LatencyEWMA when enabled."""
+    """Monitor records successful ping RTT into peerstore LatencyEWMA."""
     config = ConnectionConfig(
         enable_health_monitoring=True,
         health_warmup_window=0.0,
@@ -42,10 +42,10 @@ async def test_ping_connection_records_peerstore_latency() -> None:
         conn = cast(SwarmConn, swarm.get_connections(peer_b)[0])
 
         swarm.initialize_connection_health(peer_b, conn)
-        result = await ping_connection(conn, ping_timeout=5.0, negotiate_timeout=10)
-        assert result.success is True
+        monitor = swarm._health_monitor
+        assert monitor is not None
 
-        if result.protocol_supported:
-            swarm.peerstore.record_latency(peer_b, max(result.rtt_ms / 1000.0, 0.001))
-            latency = swarm.peerstore.latency_EWMA(peer_b)
-            assert latency > 0
+        await monitor._check_connection_health(peer_b, conn)
+
+        latency = swarm.peerstore.latency_EWMA(peer_b)
+        assert latency > 0

--- a/tests/core/network/test_health_ping_probe.py
+++ b/tests/core/network/test_health_ping_probe.py
@@ -1,14 +1,32 @@
 """Integration tests for per-connection ping probes."""
 
+from collections.abc import Callable
 from typing import cast
 
 import pytest
+import trio
 
 from libp2p.network.config import ConnectionConfig
 from libp2p.network.connection.swarm_connection import SwarmConn
 from libp2p.network.health.ping_probe import ping_connection
 from libp2p.network.swarm import Swarm
+from libp2p.peer.id import ID
 from tests.utils.factories import host_pair_factory
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 5.0,
+    poll_interval: float = 0.01,
+) -> None:
+    """Poll until ``predicate`` is true (event-driven readiness)."""
+    deadline = trio.current_time() + timeout
+    while trio.current_time() < deadline:
+        if predicate():
+            return
+        await trio.sleep(poll_interval)
+    raise TimeoutError(f"Condition not met within {timeout}s")
 
 
 @pytest.mark.trio
@@ -30,10 +48,18 @@ async def test_ping_connection_real_hosts() -> None:
 
 @pytest.mark.trio
 async def test_ping_connection_records_peerstore_latency() -> None:
-    """Monitor records successful ping RTT into peerstore LatencyEWMA."""
+    """
+    Monitor records a successful ping RTT into peerstore LatencyEWMA.
+
+    Waits for health metrics and ``record_latency`` rather than asserting
+    ``EWMA > 0``: on fast CI, integer-ms RTT can be ``0``, which is still a
+    valid recorded sample.
+    """
     config = ConnectionConfig(
         enable_health_monitoring=True,
         health_warmup_window=0.0,
+        # Keep the background monitor from racing this explicit check.
+        health_initial_delay=3600.0,
         record_ping_latency_in_peerstore=True,
     )
     async with host_pair_factory(connection_config=config) as (host_a, host_b):
@@ -45,7 +71,28 @@ async def test_ping_connection_records_peerstore_latency() -> None:
         monitor = swarm._health_monitor
         assert monitor is not None
 
+        health = swarm.health_data[peer_b][conn]
+        initial_last_ping = health.last_ping
+
+        recorded: list[tuple[ID, float]] = []
+        original_record = swarm.peerstore.record_latency
+
+        def spy_record_latency(peer_id: ID, rtt: float) -> None:
+            recorded.append((peer_id, rtt))
+            original_record(peer_id, rtt)
+
+        swarm.peerstore.record_latency = spy_record_latency  # type: ignore[method-assign]
+
         await monitor._check_connection_health(peer_b, conn)
 
-        latency = swarm.peerstore.latency_EWMA(peer_b)
-        assert latency > 0
+        await _wait_until(
+            lambda: health.last_ping > initial_last_ping
+            and health.ping_success_rate > 0
+        )
+        await _wait_until(lambda: len(recorded) > 0)
+
+        peer_id, rtt_seconds = recorded[0]
+        assert peer_id == peer_b
+        assert rtt_seconds >= 0.0
+        # First sample seeds EWMA (may be 0.0s when RTT rounds down to 0 ms).
+        assert swarm.peerstore.latency_EWMA(peer_b) == rtt_seconds

--- a/tests/core/network/test_health_ping_probe.py
+++ b/tests/core/network/test_health_ping_probe.py
@@ -1,0 +1,51 @@
+"""Integration tests for per-connection ping probes."""
+
+from typing import cast
+
+import pytest
+
+from libp2p.network.config import ConnectionConfig
+from libp2p.network.connection.swarm_connection import SwarmConn
+from libp2p.network.health.ping_probe import ping_connection
+from libp2p.network.swarm import Swarm
+from tests.utils.factories import host_pair_factory
+
+
+@pytest.mark.trio
+async def test_ping_connection_real_hosts() -> None:
+    """Ping probe returns RTT over a live TCP connection."""
+    async with host_pair_factory() as (host_a, host_b):
+        peer_b = host_b.get_id()
+        conn = cast(
+            SwarmConn,
+            host_a.get_network().get_connections(peer_b)[0],
+        )
+
+        result = await ping_connection(conn, ping_timeout=5.0, negotiate_timeout=10)
+
+        assert result.success is True
+        assert result.protocol_supported is True
+        assert result.rtt_ms >= 0
+
+
+@pytest.mark.trio
+async def test_ping_connection_records_peerstore_latency() -> None:
+    """Successful ping updates peerstore LatencyEWMA when enabled."""
+    config = ConnectionConfig(
+        enable_health_monitoring=True,
+        health_warmup_window=0.0,
+        record_ping_latency_in_peerstore=True,
+    )
+    async with host_pair_factory(connection_config=config) as (host_a, host_b):
+        peer_b = host_b.get_id()
+        swarm = cast(Swarm, host_a.get_network())
+        conn = cast(SwarmConn, swarm.get_connections(peer_b)[0])
+
+        swarm.initialize_connection_health(peer_b, conn)
+        result = await ping_connection(conn, ping_timeout=5.0, negotiate_timeout=10)
+        assert result.success is True
+
+        if result.protocol_supported:
+            swarm.peerstore.record_latency(peer_b, max(result.rtt_ms / 1000.0, 0.001))
+            latency = swarm.peerstore.latency_EWMA(peer_b)
+            assert latency > 0

--- a/tests/examples/test_health_monitoring_live_demo.py
+++ b/tests/examples/test_health_monitoring_live_demo.py
@@ -47,6 +47,32 @@ def test_health_view_imports() -> None:
     assert callable(web_gui.run_health_web)
 
 
+def test_web_gui_html_escapes_peer_id() -> None:
+    from examples.health_monitoring.web_gui import _html_page
+
+    html = _html_page(
+        [
+            {
+                "peer_id": "<script>alert(1)</script>",
+                "connections": 1,
+                "score": 0.9,
+                "latency_ms": 1.5,
+                "success_rate": 1.0,
+                "protected": False,
+                "unhealthy": 0,
+            }
+        ],
+        {
+            "total_peers": 1,
+            "total_connections": 1,
+            "average_peer_health": 0.9,
+        },
+    ).decode("utf-8")
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+
+
 @pytest.mark.trio
 async def test_live_health_demo_connects_and_reports() -> None:
     result = await run_live_demo(

--- a/tests/examples/test_health_monitoring_live_demo.py
+++ b/tests/examples/test_health_monitoring_live_demo.py
@@ -29,6 +29,22 @@ def test_parser_defaults() -> None:
     args = build_parser().parse_args([])
     assert args.peers == 25
     assert args.scenario == "all"
+    assert args.gui == "none"
+    assert args.gui_port == 8765
+
+
+def test_parser_gui_options() -> None:
+    args = build_parser().parse_args(["--gui", "web", "--gui-port", "9000"])
+    assert args.gui == "web"
+    assert args.gui_port == 9000
+
+
+def test_health_view_imports() -> None:
+    from examples.health_monitoring import health_view, tui, web_gui
+
+    assert callable(health_view.build_peer_table)
+    assert callable(tui.run_health_tui)
+    assert callable(web_gui.run_health_web)
 
 
 @pytest.mark.trio

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -51,6 +51,7 @@ from libp2p.host.routed_host import (
 from libp2p.io.abc import (
     ReadWriteCloser,
 )
+from libp2p.network.config import ConnectionConfig
 from libp2p.network.connection.raw_connection import (
     RawConnection,
 )
@@ -464,6 +465,7 @@ class SwarmFactory(factory.Factory):
         )
     )
     transports = factory.LazyFunction(lambda: [TCP()])
+    connection_config = factory.LazyFunction(ConnectionConfig)
 
     @classmethod
     @asynccontextmanager
@@ -472,6 +474,7 @@ class SwarmFactory(factory.Factory):
         key_pair: KeyPair | None = None,
         security_protocol: TProtocol | None = None,
         muxer_opt: TMuxerOptions | None = None,
+        connection_config: ConnectionConfig | None = None,
     ) -> AsyncIterator[Swarm]:
         # `factory.Factory.__init__` does *not* prepare a *default value* if we pass
         # an argument explicitly with `None`. If an argument is `None`, we don't pass it
@@ -483,6 +486,8 @@ class SwarmFactory(factory.Factory):
             optional_kwargs["security_protocol"] = security_protocol
         if muxer_opt is not None:
             optional_kwargs["muxer_opt"] = muxer_opt
+        if connection_config is not None:
+            optional_kwargs["connection_config"] = connection_config
         swarm = cls(**optional_kwargs)
         async with background_trio_service(swarm):
             await swarm.listen(LISTEN_MADDR)
@@ -495,12 +500,15 @@ class SwarmFactory(factory.Factory):
         number: int,
         security_protocol: TProtocol | None = None,
         muxer_opt: TMuxerOptions | None = None,
+        connection_config: ConnectionConfig | None = None,
     ) -> AsyncIterator[tuple[Swarm, ...]]:
         async with AsyncExitStack() as stack:
             ctx_mgrs = [
                 await stack.enter_async_context(
                     cls.create_and_listen(
-                        security_protocol=security_protocol, muxer_opt=muxer_opt
+                        security_protocol=security_protocol,
+                        muxer_opt=muxer_opt,
+                        connection_config=connection_config,
                     )
                 )
                 for _ in range(number)
@@ -530,9 +538,13 @@ class HostFactory(factory.Factory):
         number: int,
         security_protocol: TProtocol | None = None,
         muxer_opt: TMuxerOptions | None = None,
+        connection_config: ConnectionConfig | None = None,
     ) -> AsyncIterator[tuple[BasicHost, ...]]:
         async with SwarmFactory.create_batch_and_listen(
-            number, security_protocol=security_protocol, muxer_opt=muxer_opt
+            number,
+            security_protocol=security_protocol,
+            muxer_opt=muxer_opt,
+            connection_config=connection_config,
         ) as swarms:
             hosts = tuple(BasicHost(swarm) for swarm in swarms)
             yield hosts
@@ -836,9 +848,13 @@ async def swarm_pair_factory(
 async def host_pair_factory(
     security_protocol: TProtocol | None = None,
     muxer_opt: TMuxerOptions | None = None,
+    connection_config: ConnectionConfig | None = None,
 ) -> AsyncIterator[tuple[BasicHost, BasicHost]]:
     async with HostFactory.create_batch_and_listen(
-        2, security_protocol=security_protocol, muxer_opt=muxer_opt
+        2,
+        security_protocol=security_protocol,
+        muxer_opt=muxer_opt,
+        connection_config=connection_config,
     ) as hosts:
         await connect(hosts[0], hosts[1])
         yield hosts[0], hosts[1]


### PR DESCRIPTION
Closes #1453 — follow-up to #1203 (opt-in connection health monitor).

## What's changed

### Protocol
- **New `libp2p/network/health/ping_probe.py`** — per-connection `/ipfs/ping/1.0.0` probe using multiselect negotiation.  Returns a typed `ConnectionPingResult(success, rtt_ms, protocol_supported, skipped)`.
- Unsupported ping protocol → connection counted as alive; negotiation RTT recorded.
- Probes run by default even when application streams are open (`skip_ping_when_streams_open=False`).
- Expose `perform_ping_roundtrip()` from `libp2p/host/ping.py` as a public helper.
- Refactor `ConnectionHealthMonitor._ping_connection()` to delegate to the new probe; fix latency accounting to use actual ping RTT.
- Three new `ConnectionConfig` fields:
  - `skip_ping_when_streams_open` (default `False`) — opt-in to skip probing busy connections.
  - `record_ping_latency_in_peerstore` (default `True`) — write RTT into peerstore `LatencyEWMA` after each successful ping.
  - `abort_connection_on_ping_failure` (default `False`) — immediately close a failing connection without waiting for the grace period.
- Add `health-demo = ["rich>=13.0"]` optional dependency for the TUI.

### Tests
- Update `tests/core/network/test_health_monitor.py` with mocked `ping_connection`; add cases for unsupported protocol, default ping-while-busy, skip-when-streams-open opt-in, abort-on-failure, and peerstore latency recording.
- New `tests/core/network/test_health_ping_probe.py` — real two-host integration tests over live TCP.
- New `tests/core/network/test_health_monitor_real_network.py` — non-loopback integration test (auto-skipped on loopback-only CI) asserting RTT updates and closed-connection detection.
- Extend `tests/utils/factories.py` to accept optional `connection_config` in `SwarmFactory`, `HostFactory`, and `host_pair_factory`.

### Documentation
- New `docs/connection_health_monitoring.rst` — py-libp2p-only user guide: overview, when-to-enable, full config reference, host/swarm API shapes, operator guide.
- Rewrite `docs/examples.connection_health_monitoring.rst` — remove go/js-libp2p comparison language; cross-link to user guide.
- Expand `docs/libp2p.network.health.rst` — narrative intro, cross-links, `ping_probe` automodule; wire into Sphinx TOCs.
- Update `examples/health_monitoring/README.md` — remove comparison language; document GUI usage.

### Health GUI
- New `examples/health_monitoring/health_view.py` — shared `build_peer_table()` and `get_metrics_snapshot()` helpers.
- New `examples/health_monitoring/tui.py` — terminal table with `rich` rendering (ANSI fallback).
- New `examples/health_monitoring/web_gui.py` — stdlib HTTP server on `127.0.0.1:8765` with `GET /`, `GET /api/summary`, `GET /api/metrics` (supports `?format=prometheus`).
- Wire `--gui none|tui|web` and `--gui-port` into `live_demo.py`.

`make pr` and `make docs` pass.

Made with [Cursor](https://cursor.com)