### PR TITLE
fix(varint): reject 10-byte terminator overflow and align error types

### DIFF
--- a/libp2p/utils/varint.py
+++ b/libp2p/utils/varint.py
@@ -29,6 +29,14 @@ HIGH_MASK = 2**7
 # The maximum shift width for a 64 bit integer.  We shouldn't have to decode
 # integers larger than this.
 SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
+UINT64_MAX = 2**64 - 1
+
+_VARINT_OVERFLOW_MSG = "Varint decoding error: integer exceeds maximum size of 64 bits."
+
+
+def _reject_uvarint_overflow(value: int) -> None:
+    if value > UINT64_MAX:
+        raise ParseError(_VARINT_OVERFLOW_MSG)
 
 
 def encode_uvarint(value: int) -> bytes:
@@ -48,9 +56,9 @@ def decode_uvarint(data: bytes) -> int:
     """
     Decode a varint from bytes.
 
-    Raises ``ParseError`` if ``data`` is empty or ends mid-varint (its final
-    byte still has the continuation bit set), and ``ValueError`` if the value
-    exceeds 64 bits.
+    Raises ``ParseError`` if ``data`` is empty, ends mid-varint (its final
+    byte still has the continuation bit set), or encodes a value larger than
+    64 bits.
     """
     if not data:
         raise ParseError("Unexpected end of data")
@@ -61,10 +69,11 @@ def decode_uvarint(data: bytes) -> int:
     for byte in data:
         result |= (byte & 0x7F) << shift
         if (byte & 0x80) == 0:
+            _reject_uvarint_overflow(result)
             return result
         shift += 7
         if shift >= 64:
-            raise ValueError("Varint too long")
+            raise ParseError(_VARINT_OVERFLOW_MSG)
 
     # The loop consumed every byte without finding a terminator: the final
     # byte still had the continuation bit set, so the varint is truncated.
@@ -77,16 +86,18 @@ def decode_varint_from_bytes(data: bytes) -> int:
 
 
 async def decode_uvarint_from_stream(reader: Reader) -> int:
-    """https://en.wikipedia.org/wiki/LEB128."""
+    """
+    Decode an unsigned varint from a stream.
+
+    A canonical protobuf-style 64-bit uvarint is at most 10 bytes (shifts
+    0..63).  Raises ``ParseError`` if the encoding is over-long or decodes to
+    a value larger than 64 bits.  Raises ``IncompleteReadError`` if the stream
+    ends before the varint is complete.
+    """
     res = 0
     for shift in itertools.count(0, 7):
-        # A canonical 64-bit uvarint is at most 10 bytes (shifts 0..63); a
-        # shift of SHIFT_64_BIT_MAX (70) means an 11th byte, which would encode
-        # a value > 64 bits. Reject it before reading rather than after.
         if shift >= SHIFT_64_BIT_MAX:
-            raise ParseError(
-                "Varint decoding error: integer exceeds maximum size of 64 bits."
-            )
+            raise ParseError(_VARINT_OVERFLOW_MSG)
 
         byte = await read_exactly(reader, 1)
         value = byte[0]
@@ -95,6 +106,7 @@ async def decode_uvarint_from_stream(reader: Reader) -> int:
 
         if not value & HIGH_MASK:
             break
+    _reject_uvarint_overflow(res)
     return res
 
 
@@ -102,6 +114,15 @@ def decode_varint_with_size(data: bytes) -> tuple[int, int]:
     """
     Decode a varint from bytes and return both the value and the number of bytes
     consumed.
+
+    Unlike :func:`decode_uvarint`, this function does **not** raise on a
+    truncated varint: it returns ``(partial_value, bytes_consumed)`` for
+    whatever prefix was consumed.  The final consumed byte may still have the
+    continuation bit (``0x80``) set when the varint never terminated.  Callers
+    such as identify format-detection and WebRTC framing rely on this contract.
+
+    Raises ``ValueError`` only when a continuation would require an 11th byte
+    (``shift >= 64``).
 
     Returns:
         Tuple[int, int]: (value, bytes_consumed)

--- a/newsfragments/1458.bugfix.rst
+++ b/newsfragments/1458.bugfix.rst
@@ -1,0 +1,1 @@
+Reject 10-byte uvarint encodings whose terminating byte overflows 64 bits, and align ``decode_uvarint`` over-long failures to ``ParseError``.

--- a/tests/core/utils/test_varint.py
+++ b/tests/core/utils/test_varint.py
@@ -78,10 +78,6 @@ def test_decode_varint_from_bytes_invalid():
     with pytest.raises(ParseError, match="Unexpected end of data"):
         decode_varint_from_bytes(b"")
 
-    # Truncated varint (final byte still has the continuation bit set).
-    with pytest.raises(ParseError):
-        decode_varint_from_bytes(b"\x80")
-
 
 def test_encode_varint_prefixed():
     """Test encoding messages with varint length prefix."""
@@ -247,3 +243,28 @@ async def test_decode_uvarint_from_stream_rejects_over_long():
     assert (
         await decode_uvarint_from_stream(MockReader(encode_uvarint(max_u64))) == max_u64
     )
+
+
+def test_decode_uvarint_rejects_over_long_buffer():
+    """An 11-byte uvarint encoding must be rejected on the buffer path (#1458)."""
+    over_long = b"\x80" * 10 + b"\x01"
+    with pytest.raises(ParseError, match="64 bits"):
+        decode_varint_from_bytes(over_long)
+
+
+def test_decode_uvarint_rejects_terminator_overflow():
+    """
+    A 10-byte encoding whose terminating byte still carries extra payload
+    bits decodes to a value > 2^64-1 and must be rejected (#1458).
+    """
+    overflow = b"\xff" * 9 + b"\x7f"
+    with pytest.raises(ParseError, match="64 bits"):
+        decode_varint_from_bytes(overflow)
+
+
+@pytest.mark.trio
+async def test_decode_uvarint_from_stream_rejects_terminator_overflow():
+    """Stream decoder must reject 10-byte terminator overflow (#1458)."""
+    overflow = b"\xff" * 9 + b"\x7f"
+    with pytest.raises(ParseError, match="64 bits"):
+        await decode_uvarint_from_stream(MockReader(overflow))


### PR DESCRIPTION
Fixes #1458

## What was wrong?

A 10-byte uvarint encoding whose terminating byte still carries extra payload bits could decode to a value greater than 2^64-1 (e.g. `decode_uvarint(b"\xff" * 9 + b"\x7f")`). Over-long buffer-path failures also raised `ValueError` while the stream decoder raised `ParseError`, so callers catching only one type handled the two malformation classes inconsistently.

## How was it fixed?

- Added a shared `_reject_uvarint_overflow` guard used by `decode_uvarint` and `decode_uvarint_from_stream` before returning a decoded value.
- Unified over-long buffer-path failures to `ParseError` with the same message as the stream decoder.
- Expanded docstrings for `decode_uvarint_from_stream` and `decode_varint_with_size` (truncation/partial-return contract documented; behavior of `decode_varint_with_size` unchanged for WebRTC `except ValueError` guards).
- Added rejection tests for 11-byte encodings and 10-byte terminator overflow on both buffer and stream paths.

## Test plan

- [x] `pytest tests/core/utils/test_varint.py tests/core/utils/test_varint_message_limits.py`
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test`
- [x] `make linux-docs`

#### Cute Animal Picture

![European otter](https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/European_otter_01.jpg/330px-European_otter_01.jpg)