### PR TITLE
fix(tcp): wrap ProtocolLookupError on dial + #391 regression tests

### DIFF
--- a/libp2p/transport/tcp/tcp.py
+++ b/libp2p/transport/tcp/tcp.py
@@ -261,7 +261,14 @@ class TCP(ITransport):
     async def _dial_resolved(self, maddr: Multiaddr) -> IRawConnection:
         """Dial using a multiaddr that has an IP (no DNS)."""
         host_str = extract_ip_from_multiaddr(maddr)
-        port_str = maddr.value_for_protocol("tcp")
+        try:
+            port_str = maddr.value_for_protocol("tcp")
+        except ProtocolLookupError as error:
+            # Defence in depth: Swarm/TransportManager should filter these via
+            # can_dial(), but match listen()'s handling if a bad addr slips through.
+            raise OpenConnectionError(
+                f"Failed to dial {maddr}: no TCP component in multiaddr."
+            ) from error
 
         if host_str is None:
             raise OpenConnectionError(

--- a/newsfragments/391.bugfix.rst
+++ b/newsfragments/391.bugfix.rst
@@ -1,0 +1,3 @@
+TCP dial now raises ``OpenConnectionError`` instead of leaking
+``ProtocolLookupError`` when a multiaddr has no TCP component, matching
+listen() and closing the defence-in-depth gap left after #1357 / #391.

--- a/tests/core/network/test_swarm.py
+++ b/tests/core/network/test_swarm.py
@@ -26,6 +26,9 @@ from libp2p.network.exceptions import (
 from libp2p.network.swarm import (
     Swarm,
 )
+from libp2p.peer.id import (
+    ID,
+)
 from libp2p.tools.anyio_service import (
     background_trio_service,
 )
@@ -613,3 +616,48 @@ async def test_swarm_peer_id_validation(security_protocol):
         # Verify connections are established
         assert correct_peer_id in swarms[0].connections
         assert swarms[0].get_peer_id() in swarms[1].connections
+
+
+@pytest.mark.trio
+async def test_swarm_skips_unsupported_multiaddrs():
+    """
+    Regression for #391: peerstore UDP/QUIC-only addresses must not dial via
+    TCP. TransportManager filters them and dial_peer raises SwarmException.
+    """
+    swarm = new_swarm()
+    peer_id = ID.from_pubkey(generate_new_ed25519_identity().public_key)
+    unsupported = [
+        Multiaddr("/ip4/127.0.0.1/udp/9090"),
+        Multiaddr("/ip4/127.0.0.1/udp/9090/quic"),
+    ]
+    swarm.peerstore.add_addrs(peer_id, unsupported, ttl=3600)
+
+    with pytest.raises(SwarmException, match="No supported transport"):
+        await swarm.dial_peer(peer_id)
+
+
+@pytest.mark.trio
+async def test_swarm_filters_unsupported_and_dials_tcp():
+    """
+    Mixed peerstore: unsupported addrs are skipped; a reachable TCP addr is used.
+    """
+    async with SwarmFactory.create_batch_and_listen(2) as swarms:
+        dialer, listener = swarms[0], swarms[1]
+        peer_id = listener.get_peer_id()
+        tcp_addrs = tuple(
+            addr
+            for transport in listener.listeners.values()
+            for addr in transport.get_addrs()
+        )
+        assert tcp_addrs
+
+        mixed = [
+            Multiaddr("/ip4/127.0.0.1/udp/9090"),
+            Multiaddr("/ip4/127.0.0.1/udp/9090/quic-v1"),
+            *tcp_addrs,
+        ]
+        dialer.peerstore.add_addrs(peer_id, mixed, ttl=3600)
+
+        connections = await dialer.dial_peer(peer_id)
+        assert len(connections) > 0
+        assert peer_id in dialer.connections

--- a/tests/core/transport/test_tcp.py
+++ b/tests/core/transport/test_tcp.py
@@ -68,6 +68,22 @@ async def test_tcp_listener_raises_on_missing_port(nursery):
 
 
 @pytest.mark.trio
+async def test_tcp_dial_raises_open_connection_error_for_non_tcp_addr():
+    """dial() must not leak ProtocolLookupError for non-TCP multiaddrs (#391)."""
+    transport = TCP()
+    with pytest.raises(OpenConnectionError, match="no TCP component"):
+        await transport.dial(Multiaddr("/ip4/127.0.0.1/udp/9090"))
+
+
+def test_tcp_can_dial_rejects_udp_and_quic():
+    transport = TCP()
+    assert transport.can_dial(Multiaddr("/ip4/127.0.0.1/tcp/9000")) is True
+    assert transport.can_dial(Multiaddr("/ip4/127.0.0.1/udp/9090")) is False
+    assert transport.can_dial(Multiaddr("/ip4/127.0.0.1/udp/9090/quic")) is False
+    assert transport.can_dial(Multiaddr("/ip4/127.0.0.1/udp/9090/quic-v1")) is False
+
+
+@pytest.mark.trio
 async def test_tcp_listener_raises_on_bind_failure(nursery):
     """listen() raises OpenConnectionError (not a raw OSError) when port is in use."""
 


### PR DESCRIPTION
## Summary
- Close the defence-in-depth gap left after #1357: `TCP._dial_resolved` now catches `ProtocolLookupError` and raises `OpenConnectionError` (same as `listen()`), so a non-TCP multiaddr cannot leak a raw multiaddr exception if it bypasses `TransportManager`.
- Add Swarm-level regression tests for the #391 case (UDP/QUIC-only peerstore → clear `SwarmException`; mixed addrs still dial TCP).
- Follow-up to closed #1351 / #391 (core filtering already shipped in #1357).

## Test plan
- [x] `pytest tests/core/transport/test_tcp.py::test_tcp_dial_raises_open_connection_error_for_non_tcp_addr`
- [x] `pytest tests/core/transport/test_tcp.py::test_tcp_can_dial_rejects_udp_and_quic`
- [x] `pytest tests/core/network/test_swarm.py::test_swarm_skips_unsupported_multiaddrs`
- [x] `pytest tests/core/network/test_swarm.py::test_swarm_filters_unsupported_and_dials_tcp`
- [x] CI green


Made with [Cursor](https://cursor.com)