### PR TITLE
fix(peerstore): load persisted keypairs on restore

### DIFF
--- a/libp2p/peer/persistent/async_/peerstore.py
+++ b/libp2p/peer/persistent/async_/peerstore.py
@@ -16,7 +16,12 @@ import trio
 from trio import MemoryReceiveChannel, MemorySendChannel
 
 from libp2p.abc_async import IAsyncPeerStore
+from libp2p.crypto.exceptions import CryptographyError
 from libp2p.crypto.keys import KeyPair, PrivateKey, PublicKey
+from libp2p.crypto.serialization import (
+    deserialize_private_key,
+    deserialize_public_key,
+)
 from libp2p.custom_types import MetadataValue
 from libp2p.peer.envelope import Envelope
 from libp2p.peer.id import ID
@@ -151,16 +156,15 @@ class AsyncPersistentPeerStore(IAsyncPeerStore):
                     key_key = self._get_key_key(peer_id)
                     key_data = await self.datastore.get(key_key)
                     if key_data:
-                        # For now, store keys as metadata until keypair serialization
-                        # keys_metadata = deserialize_metadata(key_data)
-                        # TODO: Implement proper keypair deserialization
-                        # peer_data.pubkey = deserialize_public_key(
-                        #     keys_metadata.get(b"pubkey", b"")
-                        # )
-                        # peer_data.privkey = deserialize_private_key(
-                        #     keys_metadata.get(b"privkey", b"")
-                        # )
-                        pass
+                        keys_metadata = deserialize_metadata(key_data)
+                        if keys_metadata.get("pubkey"):
+                            peer_data.pubkey = deserialize_public_key(
+                                keys_metadata["pubkey"]
+                            )
+                        if keys_metadata.get("privkey"):
+                            peer_data.privkey = deserialize_private_key(
+                                keys_metadata["privkey"]
+                            )
 
                     # Load metadata
                     metadata_key = self._get_metadata_key(peer_id)
@@ -187,7 +191,13 @@ class AsyncPersistentPeerStore(IAsyncPeerStore):
                         # Convert nanoseconds back to seconds for latmap
                         peer_data.latmap = latency_ns / 1_000_000_000
 
-                except (SerializationError, KeyError, ValueError, TypeError) as e:
+                except (
+                    SerializationError,
+                    CryptographyError,
+                    KeyError,
+                    ValueError,
+                    TypeError,
+                ) as e:
                     logger.error(f"Failed to load peer data for {peer_id}: {e}")
                     # Continue with empty peer data
                 except Exception:
@@ -216,7 +226,7 @@ class AsyncPersistentPeerStore(IAsyncPeerStore):
                 addr_data = serialize_addresses(peer_data.addrs)
                 await self.datastore.put(addr_key, addr_data)
 
-            # Save keys (temporarily as metadata until proper keypair serialization)
+            # Save keys as serialized metadata (pubkey/privkey protobuf bytes)
             if peer_data.pubkey or peer_data.privkey:
                 key_key = self._get_key_key(peer_id)
                 keys_metadata = {}

--- a/libp2p/peer/persistent/sync/peerstore.py
+++ b/libp2p/peer/persistent/sync/peerstore.py
@@ -15,7 +15,12 @@ import time
 from multiaddr import Multiaddr
 
 from libp2p.abc import IPeerStore
+from libp2p.crypto.exceptions import CryptographyError
 from libp2p.crypto.keys import KeyPair, PrivateKey, PublicKey
+from libp2p.crypto.serialization import (
+    deserialize_private_key,
+    deserialize_public_key,
+)
 from libp2p.custom_types import MetadataValue
 from libp2p.peer.envelope import Envelope
 from libp2p.peer.id import ID
@@ -153,16 +158,15 @@ class SyncPersistentPeerStore(IPeerStore):
                     key_key = self._get_key_key(peer_id)
                     key_data = self.datastore.get(key_key)
                     if key_data:
-                        # For now, store keys as metadata until keypair serialization
-                        # keys_metadata = deserialize_metadata(key_data)
-                        # TODO: Implement proper keypair deserialization
-                        # peer_data.pubkey = deserialize_public_key(
-                        #     keys_metadata.get(b"pubkey", b"")
-                        # )
-                        # peer_data.privkey = deserialize_private_key(
-                        #     keys_metadata.get(b"privkey", b"")
-                        # )
-                        pass
+                        keys_metadata = deserialize_metadata(key_data)
+                        if keys_metadata.get("pubkey"):
+                            peer_data.pubkey = deserialize_public_key(
+                                keys_metadata["pubkey"]
+                            )
+                        if keys_metadata.get("privkey"):
+                            peer_data.privkey = deserialize_private_key(
+                                keys_metadata["privkey"]
+                            )
 
                     # Load metadata
                     metadata_key = self._get_metadata_key(peer_id)
@@ -189,7 +193,13 @@ class SyncPersistentPeerStore(IPeerStore):
                         # Convert nanoseconds back to seconds for latmap
                         peer_data.latmap = latency_ns / 1_000_000_000
 
-                except (SerializationError, KeyError, ValueError, TypeError) as e:
+                except (
+                    SerializationError,
+                    CryptographyError,
+                    KeyError,
+                    ValueError,
+                    TypeError,
+                ) as e:
                     logger.error(f"Failed to load peer data for {peer_id}: {e}")
                     # Continue with empty peer data
                 except Exception:
@@ -218,7 +228,7 @@ class SyncPersistentPeerStore(IPeerStore):
                 addr_data = serialize_addresses(peer_data.addrs)
                 self.datastore.put(addr_key, addr_data)
 
-            # Save keys (temporarily as metadata until proper keypair serialization)
+            # Save keys as serialized metadata (pubkey/privkey protobuf bytes)
             if peer_data.pubkey or peer_data.privkey:
                 key_key = self._get_key_key(peer_id)
                 keys_metadata = {}

--- a/newsfragments/1466.bugfix.rst
+++ b/newsfragments/1466.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed persistent peerstore restore so public and private keys survive process restarts when using durable backends such as SQLite.

--- a/tests/core/peer/test_persistent_peerstore_persistence.py
+++ b/tests/core/peer/test_persistent_peerstore_persistence.py
@@ -11,6 +11,7 @@ import tempfile
 import pytest
 from multiaddr import Multiaddr
 
+from libp2p.crypto.ed25519 import create_new_key_pair
 from libp2p.peer.id import ID
 from libp2p.peer.peerstore import PeerStoreError
 from libp2p.peer.persistent import (
@@ -471,3 +472,99 @@ def test_sync_cross_backend_no_persistence():
         addrs = sqlite_store.addrs(peer_id)
         assert len(addrs) == 0
         sqlite_store.close()
+
+
+# ============================================================================
+# Keypair Persistence Tests
+# ============================================================================
+
+
+def test_sync_sqlite_keypair_persistence():
+    """Test that keypairs survive a peerstore restart."""
+    key_pair = create_new_key_pair()
+    peer_id = ID.from_pubkey(key_pair.public_key)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+
+        peerstore1 = create_sync_sqlite_peerstore(str(db_path))
+        peerstore1.add_key_pair(peer_id, key_pair)
+        peerstore1.close()
+
+        peerstore2 = create_sync_sqlite_peerstore(str(db_path))
+        assert peerstore2.pubkey(peer_id) == key_pair.public_key
+        assert peerstore2.privkey(peer_id) == key_pair.private_key
+        peerstore2.close()
+
+
+def test_sync_memory_keypair_not_persistent():
+    """Test that keypairs are not persisted in the memory backend."""
+    key_pair = create_new_key_pair()
+    peer_id = ID.from_pubkey(key_pair.public_key)
+
+    peerstore1 = create_sync_memory_peerstore()
+    peerstore1.add_key_pair(peer_id, key_pair)
+    peerstore1.close()
+
+    peerstore2 = create_sync_memory_peerstore()
+    with pytest.raises(PeerStoreError):
+        peerstore2.pubkey(peer_id)
+    peerstore2.close()
+
+
+def test_sync_sqlite_corrupt_keypair_blob_soft_fails():
+    """Corrupt key blobs must not crash restore; keys remain unavailable."""
+    key_pair = create_new_key_pair()
+    peer_id = ID.from_pubkey(key_pair.public_key)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+
+        peerstore1 = create_sync_sqlite_peerstore(str(db_path))
+        peerstore1.datastore.put(peerstore1._get_key_key(peer_id), b"not-valid-keys")
+        peerstore1.close()
+
+        peerstore2 = create_sync_sqlite_peerstore(str(db_path))
+        with pytest.raises(PeerStoreError):
+            peerstore2.pubkey(peer_id)
+        peerstore2.close()
+
+
+@pytest.mark.trio
+async def test_async_sqlite_keypair_persistence():
+    """Test that keypairs survive a peerstore restart (async)."""
+    key_pair = create_new_key_pair()
+    peer_id = ID.from_pubkey(key_pair.public_key)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+
+        peerstore1 = create_async_sqlite_peerstore(str(db_path))
+        await peerstore1.add_key_pair_async(peer_id, key_pair)
+        await peerstore1.close_async()
+
+        peerstore2 = create_async_sqlite_peerstore(str(db_path))
+        assert await peerstore2.pubkey_async(peer_id) == key_pair.public_key
+        assert await peerstore2.privkey_async(peer_id) == key_pair.private_key
+        await peerstore2.close_async()
+
+
+@pytest.mark.trio
+async def test_async_sqlite_corrupt_keypair_blob_soft_fails():
+    """Corrupt key blobs must not crash async restore; keys remain unavailable."""
+    key_pair = create_new_key_pair()
+    peer_id = ID.from_pubkey(key_pair.public_key)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = Path(temp_dir) / "test.db"
+
+        peerstore1 = create_async_sqlite_peerstore(str(db_path))
+        await peerstore1.datastore.put(
+            peerstore1._get_key_key(peer_id), b"not-valid-keys"
+        )
+        await peerstore1.close_async()
+
+        peerstore2 = create_async_sqlite_peerstore(str(db_path))
+        with pytest.raises(PeerStoreError):
+            await peerstore2.pubkey_async(peer_id)
+        await peerstore2.close_async()


### PR DESCRIPTION
## Summary

- Wire sync and async persistent peerstore restore to deserialize `pubkey` / `privkey` from the existing on-disk metadata blob (save path was already correct; load was a no-op TODO/`pass`).
- Add SQLite round-trip tests, memory non-persistence sanity check, and corrupt-blob soft-fail coverage.
- On-disk format unchanged (`key:` + peer ID → metadata map). No encryption-at-rest; private keys remain plaintext in the caller-chosen DB path if stored.

Fixes #1466

Related: #312, #945. Supersedes #1331 (that branch had merge conflicts, unrelated DMP template noise, and no newsfragment).

## Test plan

- [x] `pytest tests/core/peer/test_persistent_peerstore_persistence.py -k keypair`
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test` (3 unrelated flaky kad_dht tests failed under xdist; passed on isolated rerun)
- [x] `make linux-docs`


Made with [Cursor](https://cursor.com)