### PR TITLE
fix(network): wrap ConnectionResetError in RawConnError for read/write

### DIFF
--- a/libp2p/network/connection/raw_connection.py
+++ b/libp2p/network/connection/raw_connection.py
@@ -49,7 +49,7 @@ class RawConnection(IRawConnection):
             await self.stream.write(data)
         except ConnectionClosedError:
             raise
-        except IOException as error:
+        except (IOException, ConnectionResetError) as error:
             raise RawConnError from error
 
     async def read(self, n: int | None = None) -> bytes:
@@ -64,7 +64,7 @@ class RawConnection(IRawConnection):
             return await self.stream.read(n)
         except ConnectionClosedError:
             raise
-        except IOException as error:
+        except (IOException, ConnectionResetError) as error:
             raise RawConnError from error
 
     async def close(self) -> None:

--- a/newsfragments/1468.bugfix.rst
+++ b/newsfragments/1468.bugfix.rst
@@ -1,0 +1,4 @@
+``RawConnection.read()`` and ``RawConnection.write()`` now catch
+``ConnectionResetError`` from the underlying stream and wrap it in
+``RawConnError``, preventing OS-level connection-reset errors from leaking to
+callers that expect ``RawConnError`` for all connection failures.

--- a/tests/core/network/test_raw_connection.py
+++ b/tests/core/network/test_raw_connection.py
@@ -1,0 +1,39 @@
+"""Tests for RawConnection error handling."""
+
+import pytest
+
+from libp2p.io.abc import ReadWriteCloser
+from libp2p.network.connection.exceptions import RawConnError
+from libp2p.network.connection.raw_connection import RawConnection
+
+
+class MockStreamRaisesConnectionReset(ReadWriteCloser):
+    """A mock stream that always raises ConnectionResetError on read/write."""
+
+    async def read(self, n: int | None = None) -> bytes:
+        raise ConnectionResetError("Connection reset by peer")
+
+    async def write(self, data: bytes) -> None:
+        raise ConnectionResetError("Connection reset by peer")
+
+    async def close(self) -> None:
+        pass
+
+    def get_remote_address(self) -> tuple[str, int]:
+        return ("127.0.0.1", 1234)
+
+
+@pytest.mark.trio
+async def test_raw_connection_handles_connection_reset_error_on_read():
+    """RawConnection.read() must wrap ConnectionResetError into RawConnError."""
+    conn = RawConnection(MockStreamRaisesConnectionReset(), initiator=True)
+    with pytest.raises(RawConnError):
+        await conn.read(10)
+
+
+@pytest.mark.trio
+async def test_raw_connection_handles_connection_reset_error_on_write():
+    """RawConnection.write() must wrap ConnectionResetError into RawConnError."""
+    conn = RawConnection(MockStreamRaisesConnectionReset(), initiator=True)
+    with pytest.raises(RawConnError):
+        await conn.write(b"hello")


### PR DESCRIPTION
## What was wrong?

Issue #1468

`RawConnection.read()` and `RawConnection.write()` caught `IOException` subclasses but not `ConnectionResetError`, which is an OS-level `OSError` subclass outside the `IOException` hierarchy. When the remote peer closes the connection abruptly, the raw `ConnectionResetError` leaked to callers that consistently expect `RawConnError` for all connection failures, causing unexpected crashes.

This was first identified in PR #1167 by @gitsofaryan.

## How was it fixed?

Added `ConnectionResetError` to the `except` tuple in both `read()` and `write()`:

```python
except (IOException, ConnectionResetError) as error:
    raise RawConnError from error
```

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

![a dog shaking hands](https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/YellowLabradorLooking_new.jpg/1200px-YellowLabradorLooking_new.jpg)

Made with [Cursor](https://cursor.com)