### PR TITLE
fix(pubsub): event-driven mesh GRAFT on peer subscription

### DIFF
--- a/libp2p/abc.py
+++ b/libp2p/abc.py
@@ -3576,6 +3576,25 @@ class IPubsubRouter(ABC):
 
         """
 
+    async def on_peer_subscribed(self, peer_id: ID, topic: str) -> None:
+        """
+        React to a newly observed peer subscription for a topic.
+
+        Optional hook, invoked when a peer announces a subscription we had
+        not previously recorded. GossipSub uses this for event-driven mesh
+        first-fill (GRAFT) so publish does not wait on the next heartbeat.
+        Heartbeat still owns ongoing mesh maintenance. Routers that do not
+        use a mesh keep the no-op.
+
+        Parameters
+        ----------
+        peer_id : ID
+            The peer that subscribed.
+        topic : str
+            The topic they subscribed to.
+
+        """
+
 
 class IPubsub(ServiceAPI):
     """

--- a/libp2p/pubsub/gossipsub.py
+++ b/libp2p/pubsub/gossipsub.py
@@ -162,6 +162,9 @@ class GossipSub(IPubsubRouter, Service):
     _pending_control: DefaultDict[ID, rpc_pb2.ControlMessage]
     _max_pending_graft_prune_per_peer: int
 
+    # Event-based waiting for mesh membership (wait_for_mesh).
+    _mesh_peer_events: dict[tuple[ID, str], trio.Event]
+
     def __init__(
         self,
         protocols: Sequence[TProtocol],
@@ -293,6 +296,9 @@ class GossipSub(IPubsubRouter, Service):
         # Deferred retry queue for dropped control chunks.
         self._pending_control = defaultdict(lambda: rpc_pb2.ControlMessage())
         self._max_pending_graft_prune_per_peer = _MAX_PENDING_GRAFT_PRUNE_PER_PEER
+
+        # Event-based mesh membership waits (see wait_for_mesh).
+        self._mesh_peer_events = {}
 
         # Extensions support (v1.3+)
         self.extension_handlers: dict[str, Callable[[bytes, ID], Awaitable[None]]] = {}
@@ -787,6 +793,89 @@ class GossipSub(IPubsubRouter, Service):
                     exc_info=True,
                 )
 
+    def _is_gossipsub_peer(self, peer_id: ID) -> bool:
+        return self.peer_protocol.get(peer_id) in (
+            PROTOCOL_ID,
+            PROTOCOL_ID_V11,
+            PROTOCOL_ID_V12,
+            PROTOCOL_ID_V13,
+            PROTOCOL_ID_V14,
+            PROTOCOL_ID_V20,
+        )
+
+    def _notify_mesh_peer_added(self, peer_id: ID, topic: str) -> None:
+        """Wake any ``wait_for_mesh`` waiter for this peer/topic."""
+        key = (peer_id, topic)
+        event = self._mesh_peer_events.pop(key, None)
+        if event is not None:
+            event.set()
+
+    async def wait_for_mesh(
+        self, peer_id: ID, topic_id: str, timeout: float = 5.0
+    ) -> None:
+        """
+        Wait until *peer_id* is in ``mesh[topic_id]``.
+
+        Blocks on a :class:`trio.Event` set when the peer is added to the mesh
+        (subscription-driven GRAFT, ``join``, ``handle_graft``, or heartbeat
+        fill). Use this instead of sleeping or polling for mesh readiness.
+
+        :param peer_id: the peer to wait for in the mesh
+        :param topic_id: the topic whose mesh to check
+        :param timeout: maximum time to wait in seconds (default: 5.0)
+        :raises trio.TooSlowError: if the peer is not in the mesh within timeout
+        """
+        if topic_id in self.mesh and peer_id in self.mesh[topic_id]:
+            return
+        event = self._mesh_peer_events.setdefault((peer_id, topic_id), trio.Event())
+        with trio.fail_after(timeout):
+            await event.wait()
+
+    async def on_peer_subscribed(self, peer_id: ID, topic: str) -> None:
+        """
+        Event-driven mesh first-fill when a peer announces a subscription.
+
+        If we have already joined *topic* and the mesh is underfilled, GRAFT
+        the peer immediately instead of waiting for the next heartbeat. Ongoing
+        prune / opportunistic graft / degree maintenance remain heartbeat-owned.
+        """
+        if topic not in self.mesh:
+            return
+
+        if peer_id in self.mesh[topic]:
+            # Already meshed (e.g. remote GRAFT won the race); wake waiters.
+            self._notify_mesh_peer_added(peer_id, topic)
+            return
+
+        if peer_id in self.direct_peers:
+            return
+
+        if not self._is_gossipsub_peer(peer_id):
+            return
+
+        if self._check_back_off(peer_id, topic):
+            return
+
+        effective_degree_low = (
+            self.adaptive_degree_low
+            if self.adaptive_gossip_enabled
+            else self.degree_low
+        )
+        if len(self.mesh[topic]) >= effective_degree_low:
+            return
+
+        self.mesh[topic].add(peer_id)
+        if self.scorer is not None:
+            self.scorer.on_join_mesh(peer_id, topic)
+        self._notify_mesh_peer_added(peer_id, topic)
+
+        logger.debug(
+            "event-driven GRAFT of peer %s on topic %s after subscription",
+            peer_id,
+            topic,
+        )
+        await self.emit_graft(topic, peer_id)
+
     def remove_peer(self, peer_id: ID) -> None:
         """
         Notifies the router that a peer has been disconnected.
@@ -820,6 +909,11 @@ class GossipSub(IPubsubRouter, Service):
         # Discard any pending messages for this peer
         self._pending_messages.pop(peer_id, None)
         self._pending_control.pop(peer_id, None)
+
+        # Drop mesh-wait events for this peer (do not set — peer is gone).
+        stale_keys = [key for key in self._mesh_peer_events if key[0] == peer_id]
+        for key in stale_keys:
+            self._mesh_peer_events.pop(key, None)
 
         # Track disconnection for adaptive gossip metrics (only when enabled)
         if self.adaptive_gossip_enabled:
@@ -1118,6 +1212,7 @@ class GossipSub(IPubsubRouter, Service):
         # Add fanout peers to mesh and notifies them with a GRAFT(topic) control message
         for peer in fanout_peers:
             self.mesh[topic].add(peer)
+            self._notify_mesh_peer_added(peer, topic)
             await self.emit_graft(topic, peer)
 
         self.fanout.pop(topic, None)
@@ -1327,6 +1422,7 @@ class GossipSub(IPubsubRouter, Service):
                 for peer in selected_peers:
                     # Add peer to mesh[topic]
                     self.mesh[topic].add(peer)
+                    self._notify_mesh_peer_added(peer, topic)
 
                     # Emit GRAFT(topic) control message to peer
                     peers_to_graft[peer].append(topic)
@@ -1788,6 +1884,7 @@ class GossipSub(IPubsubRouter, Service):
 
             if sender_peer_id not in self.mesh[topic]:
                 self.mesh[topic].add(sender_peer_id)
+                self._notify_mesh_peer_added(sender_peer_id, topic)
                 if self.scorer is not None:
                     self.scorer.on_join_mesh(sender_peer_id, topic)
         else:
@@ -2918,6 +3015,7 @@ class GossipSub(IPubsubRouter, Service):
 
             if score > scorer.params.graylist_threshold:
                 self.mesh[topic].add(peer)
+                self._notify_mesh_peer_added(peer, topic)
                 peers_to_graft.append(peer)
                 # Notify scorer about the new mesh peer
                 if self.scorer is not None:
@@ -3002,6 +3100,7 @@ class GossipSub(IPubsubRouter, Service):
             grafted_count = 0
             for candidate in selected_candidates:
                 self.mesh[topic].add(candidate)
+                self._notify_mesh_peer_added(candidate, topic)
                 peers_to_graft[candidate].append(topic)
                 if self.scorer is not None:
                     self.scorer.on_join_mesh(candidate, topic)
@@ -3363,6 +3462,7 @@ class GossipSub(IPubsubRouter, Service):
         # Perform replacement: mutate mesh and emit PRUNE/GRAFT
         self.mesh[topic].discard(worst_peer)
         self.mesh[topic].add(best_replacement)
+        self._notify_mesh_peer_added(best_replacement, topic)
 
         if self.scorer is not None:
             self.scorer.on_leave_mesh(worst_peer, topic)
@@ -3390,6 +3490,7 @@ class GossipSub(IPubsubRouter, Service):
             logger.warning("Failed to emit PRUNE/GRAFT during peer replacement: %s", e)
             # Revert mesh and scorer on failure
             self.mesh[topic].add(worst_peer)
+            self._notify_mesh_peer_added(worst_peer, topic)
             self.mesh[topic].discard(best_replacement)
             if self.scorer is not None:
                 self.scorer.on_join_mesh(worst_peer, topic)

--- a/libp2p/pubsub/pubsub.py
+++ b/libp2p/pubsub/pubsub.py
@@ -781,6 +781,28 @@ class Pubsub(Service, IPubsub):
         with trio.fail_after(timeout):
             await event.wait()
 
+    async def wait_for_mesh(
+        self, peer_id: ID, topic_id: str, timeout: float = 5.0
+    ) -> None:
+        """
+        Wait until *peer_id* is in this node's GossipSub mesh for *topic_id*.
+
+        Delegates to the router's event-based ``wait_for_mesh``. Requires a
+        GossipSub router.
+
+        :param peer_id: the peer to wait for in the mesh
+        :param topic_id: the topic whose mesh to check
+        :param timeout: maximum time to wait in seconds (default: 5.0)
+        :raises TypeError: if the router does not support ``wait_for_mesh``
+        :raises trio.TooSlowError: if the peer is not in the mesh within timeout
+        """
+        wait = getattr(self.router, "wait_for_mesh", None)
+        if wait is None:
+            raise TypeError(
+                "wait_for_mesh requires a GossipSub router with mesh support"
+            )
+        await wait(peer_id, topic_id, timeout=timeout)
+
     async def ensure_peer_stream(self, peer_id: ID, timeout: float = 15.0) -> bool:
         """
         Ensure a pubsub stream with *peer_id* is open (idempotent).
@@ -1195,7 +1217,7 @@ class Pubsub(Service, IPubsub):
                 if key in self._subscription_events:
                     self._subscription_events.pop(key).set()
 
-                # Both hooks are async while `handle_subscription` is sync, so
+                # These hooks are async while `handle_subscription` is sync, so
                 # they have to be spawned.
                 if self.manager.is_running:
                     # Flush any messages that were queued while waiting for this
@@ -1211,6 +1233,15 @@ class Pubsub(Service, IPubsub):
                     # setup).
                     self.manager.run_task(
                         self._replay_recent_messages,
+                        origin_id,
+                        sub_message.topicid,
+                    )
+
+                    # Event-driven mesh first-fill (GossipSub GRAFT); no-op on
+                    # routers without a mesh. Avoids waiting on the next
+                    # heartbeat after subscribe-before-connect.
+                    self.manager.run_task(
+                        self.router.on_peer_subscribed,
                         origin_id,
                         sub_message.topicid,
                     )

--- a/newsfragments/1454.bugfix.rst
+++ b/newsfragments/1454.bugfix.rst
@@ -1,0 +1,2 @@
+GossipSub now GRAFTs peers into an underfilled mesh when their subscription is
+observed, so publish after join/connect no longer waits on the next heartbeat.

--- a/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
+++ b/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
@@ -50,15 +50,18 @@ def _identify_aware_publisher_state(publisher: Pubsub, peer_id: ID, topic: str) 
     in_peers = peer_id in publisher.peers
     in_protocol = False
     pending_queued = False
+    in_mesh = False
     router = publisher.router
     if isinstance(router, GossipSub):
         in_protocol = peer_id in router.peer_protocol
         pending_queued = bool(router._pending_messages.get(peer_id))
+        in_mesh = peer_id in router.mesh.get(topic, ())
     subscribed = peer_id in publisher.peer_topics.get(topic, ())
     return (
         f"peer_in_peers={in_peers}, "
         f"peer_in_protocol={in_protocol}, "
         f"peer_subscribed={subscribed}, "
+        f"peer_in_mesh={in_mesh}, "
         f"pending_queued={pending_queued}"
     )
 
@@ -450,6 +453,10 @@ async def test_publish_after_identify_still_works():
     """
     Sanity check: publishing *after* identify completes should still work
     normally (no regression from the queue logic).
+
+    Mesh membership is established by the event-driven GRAFT on subscription
+    observation (not the heartbeat), so this stays reliable with heartbeats
+    disabled for mcache safety in this file.
     """
     topic = "test-publish-after-identify"
     data = b"hello-normal-publish"
@@ -469,14 +476,53 @@ async def test_publish_after_identify_still_works():
         await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
         await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
         await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
         await pubsubs[0].publish(topic, data)
 
         await wait_for_pubsub_payload(
             sub_1,
             data,
-            fail_msg="Normal publish (after identify) was not delivered.",
+            fail_msg=lambda: (
+                "Normal publish (after identify) was not delivered. "
+                + _identify_aware_publisher_state(pubsubs[0], pubsubs[1].my_id, topic)
+            ),
         )
+
+
+@pytest.mark.trio
+async def test_mesh_forms_on_subscription_without_heartbeat():
+    """
+    Regression for #1454: observing a peer subscription must GRAFT into an
+    underfilled mesh without waiting for the next heartbeat.
+    """
+    topic = "test-mesh-on-subscription"
+
+    async with PubsubFactory.create_batch_with_gossipsub(
+        2,
+        degree=1,
+        degree_low=1,
+        degree_high=2,
+        heartbeat_interval=_HEARTBEAT_DISABLED,
+    ) as pubsubs:
+        await pubsubs[0].subscribe(topic)
+        await pubsubs[1].subscribe(topic)
+        await connect(pubsubs[0].host, pubsubs[1].host)
+
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+
+        router_0 = pubsubs[0].router
+        router_1 = pubsubs[1].router
+        assert isinstance(router_0, GossipSub)
+        assert isinstance(router_1, GossipSub)
+        assert pubsubs[1].my_id in router_0.mesh[topic]
+        assert pubsubs[0].my_id in router_1.mesh[topic]
 
 
 @pytest.mark.trio


### PR DESCRIPTION
## Summary
- GossipSub now GRAFTs into an underfilled mesh when a peer subscription is observed, so first mesh fill no longer waits on the next heartbeat (fixes subscribe-before-connect races with disabled/long heartbeats).
- Adds event-based `Pubsub.wait_for_mesh` / `GossipSub.wait_for_mesh` (`trio.Event` + `fail_after`), matching `wait_for_peer` / `wait_for_subscription`.
- De-flakes `test_publish_after_identify_still_works` and adds a regression test that mesh forms with heartbeats disabled.

Fixes #1454

## Test plan
- [x] `pytest tests/core/pubsub/test_gossipsub_identify_aware_publish.py` — 17 passed
- [x] `pytest tests/core/pubsub/test_gossipsub.py tests/core/pubsub/test_pubsub.py tests/core/pubsub/test_gossipsub_px_and_backoff.py` — 77 passed
- [x] `make lint` / `make typecheck` / `make linux-docs`
- [x] `make test` — pubsub green; 3 unrelated `tests/core/kad_dht/test_kad_dht.py` flakes observed locally (not touched by this PR)


Made with [Cursor](https://cursor.com)