### PR TITLE
feat(host): addrs_factory and DisableIdentifyAddressDiscovery

### DIFF
--- a/docs/advertising_addresses.rst
+++ b/docs/advertising_addresses.rst
@@ -2,7 +2,7 @@ Advertising dialable addresses
 ==============================
 
 Other peers need a multiaddr they can actually dial. py-libp2p combines **listen**
-addresses with two ways to surface a **publicly reachable** address:
+addresses with several ways to surface a **publicly reachable** address:
 
 **1. Inferred from Identify (NAT / cloud)** — Remote peers report what they see
 when they connect, via :mod:`libp2p.identity.identify`. The host’s
@@ -18,6 +18,20 @@ constructing :class:`~libp2p.host.basic_host.BasicHost`. That list is advertised
 instead of augmenting with observed addresses (observations may still be recorded
 for :meth:`~libp2p.host.basic_host.BasicHost.get_nat_type` and related logic).
 
-For step-by-step usage, comparison of the two approaches, and a full example
+**3. Callable ``addrs_factory``** — For go-libp2p ``AddrsFactory`` parity, pass a
+callable that receives the live candidate list (transport addresses plus
+confirmed observed addresses when discovery is enabled) and returns the
+addresses to advertise. Use this to compose listen + observed + extras rather
+than choosing only a static list. ``announce_addrs`` and ``addrs_factory`` are
+mutually exclusive.
+
+**4. ``disable_identify_address_discovery``** — When you know your public
+addresses upfront and do not want Identify-driven discovery (privacy or to skip
+``ObservedAddrManager`` work), set this to ``True``. Observations are not
+recorded; ``get_nat_type()`` returns unknown. Pair with ``announce_addrs`` or
+``addrs_factory`` as go-libp2p recommends with
+``DisableIdentifyAddressDiscovery``.
+
+For step-by-step usage, comparison of these approaches, and a full example
 script, see :doc:`examples.announce_addrs` (source:
 ``examples/announce_addrs/announce_addrs.py`` in the repository).

--- a/docs/examples.announce_addrs.rst
+++ b/docs/examples.announce_addrs.rst
@@ -74,6 +74,42 @@ Use ``announce_addrs`` when you already know the exact public address(es) you
 want peers to dial (e.g. a reverse proxy hostname such as ngrok). Rely on
 automatic observed-address discovery otherwise.
 
+Callable ``addrs_factory``
+--------------------------
+
+When you need to **compose** addresses (for example keep listen + confirmed
+observed and add an extra hostname), pass ``addrs_factory`` instead of a
+static list. The factory receives the live candidate list and returns what
+to advertise::
+
+    from multiaddr import Multiaddr
+    from libp2p import new_host
+
+    def my_factory(candidates):
+        # candidates already include confirmed observed addrs when discovery
+        # is enabled
+        return list(candidates) + [Multiaddr("/dns4/example.com/tcp/4001")]
+
+    host = new_host(addrs_factory=my_factory)
+
+``announce_addrs`` and ``addrs_factory`` cannot be set together.
+
+Disabling Identify address discovery
+------------------------------------
+
+If public addresses are known ahead of time and you do not want Identify to
+drive discovery (privacy or to avoid ``ObservedAddrManager`` overhead), set
+``disable_identify_address_discovery=True``. This matches go-libp2p's
+``DisableIdentifyAddressDiscovery``::
+
+    host = new_host(
+        announce_addrs=[Multiaddr("/ip4/1.2.3.4/tcp/4001")],
+        disable_identify_address_discovery=True,
+    )
+
+In that mode observations are not recorded and
+:meth:`~libp2p.host.basic_host.BasicHost.get_nat_type` returns unknown.
+
 The full source code for this example is below:
 
 .. literalinclude:: ../examples/announce_addrs/announce_addrs.py

--- a/docs/libp2p.host.rst
+++ b/docs/libp2p.host.rst
@@ -51,12 +51,22 @@ address, it is treated as confirmed and appended by
 :meth:`libp2p.host.basic_host.BasicHost.get_addrs` so peers learn the
 host's real public address (fixes issue #1250 for NAT/EC2 deployments).
 
-Interaction with ``announce_addrs``: when ``announce_addrs`` is passed to
-:class:`~libp2p.host.basic_host.BasicHost` it is treated as an explicit
-``AddrsFactory`` (mirroring go-libp2p's ``applyAddrsFactory``) and wins
-over observed addresses: observations are still **recorded** (for
-:meth:`~libp2p.host.basic_host.BasicHost.get_nat_type` and future
-AutoNAT consumers) but are **not** advertised via ``get_addrs``.
+Interaction with ``announce_addrs`` / ``addrs_factory``: when
+``announce_addrs`` is passed to :class:`~libp2p.host.basic_host.BasicHost`
+it is treated as an explicit static ``AddrsFactory`` (mirroring go-libp2p's
+``applyAddrsFactory``) and wins over observed addresses: observations are
+still **recorded** (for :meth:`~libp2p.host.basic_host.BasicHost.get_nat_type`
+and future AutoNAT consumers) but are **not** advertised via ``get_addrs``.
+A callable ``addrs_factory`` receives the live candidate list (transport
+addresses plus confirmed observed addresses) and returns whatever should be
+advertised — use it to compose listen + observed + extras. Passing both
+``announce_addrs`` and ``addrs_factory`` raises ``ValueError``.
+
+To stop recording Identify observations entirely (privacy or to avoid the
+``ObservedAddrManager`` footprint), set
+``disable_identify_address_discovery=True`` (parity with go-libp2p's
+``DisableIdentifyAddressDiscovery``). In that mode ``get_nat_type()``
+returns ``(UNKNOWN, UNKNOWN)``.
 
 .. automodule:: libp2p.host.observed_addr_manager
    :members:

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -56,6 +56,7 @@ from libp2p.custom_types import (
     TSecurityOptions,
 )
 from libp2p.host.basic_host import (
+    AddrsFactory,
     BasicHost,
 )
 from libp2p.host.routed_host import (
@@ -694,6 +695,8 @@ def new_host(
     bootstrap_dns_max_retries: int = 3,
     connection_config: ConnectionConfig | None = None,
     announce_addrs: Sequence[multiaddr.Multiaddr] | None = None,
+    addrs_factory: AddrsFactory | None = None,
+    disable_identify_address_discovery: bool = False,
     # NEW: explicit transport list — highest priority
     transports: Sequence[ITransport] | None = None,
     # NEW: convenience flags
@@ -738,6 +741,13 @@ def new_host(
         and health monitoring. When both connection_config and quic_transport_opt
         are provided, all ConnectionConfig attributes are merged into the QUIC config.
     :param announce_addrs: if set, these replace listen addrs in get_addrs()
+        (mutually exclusive with ``addrs_factory``)
+    :param addrs_factory: optional callable matching go-libp2p ``AddrsFactory``;
+        receives the live candidate address list and returns addresses to
+        advertise (mutually exclusive with ``announce_addrs``)
+    :param disable_identify_address_discovery: if True, do not record or
+        advertise Identify observed addresses (go
+        ``DisableIdentifyAddressDiscovery``)
     :param transports: explicit list of transport instances to register.  When
         provided, all ``enable_*`` flags and ``listen_addrs``-based detection
         are bypassed.
@@ -821,6 +831,8 @@ def new_host(
             bootstrap_dns_timeout=bootstrap_dns_timeout,
             bootstrap_dns_max_retries=bootstrap_dns_max_retries,
             announce_addrs=announce_addrs,
+            addrs_factory=addrs_factory,
+            disable_identify_address_discovery=disable_identify_address_discovery,
         )
     return BasicHost(
         network=swarm,
@@ -834,6 +846,8 @@ def new_host(
         bootstrap_dns_timeout=bootstrap_dns_timeout,
         bootstrap_dns_max_retries=bootstrap_dns_max_retries,
         announce_addrs=announce_addrs,
+        addrs_factory=addrs_factory,
+        disable_identify_address_discovery=disable_identify_address_discovery,
     )
 
 __version__ = __version("libp2p")

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import (
     AsyncIterator,
+    Callable,
     Sequence,
 )
 from contextlib import (
@@ -127,6 +128,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_NEGOTIATE_TIMEOUT = 30  # Increased to 30s for high-concurrency scenarios
 # Under load with 5 concurrent negotiations, some may take longer due to contention
 
+# Matches go-libp2p's ``AddrsFactory``: transform the live candidate address
+# list into the set the host should advertise.
+AddrsFactory = Callable[[list[multiaddr.Multiaddr]], list[multiaddr.Multiaddr]]
+
 _SAFE_CACHED_PROTOCOLS: set[TProtocol] = {
     PING_PROTOCOL_ID,
     IdentifyID,
@@ -228,6 +233,8 @@ class BasicHost(IHost):
         bootstrap_dns_timeout: float = 10.0,
         bootstrap_dns_max_retries: int = 3,
         announce_addrs: Sequence[multiaddr.Multiaddr] | None = None,
+        addrs_factory: AddrsFactory | None = None,
+        disable_identify_address_discovery: bool = False,
     ) -> None:
         """
         Initialize a BasicHost instance.
@@ -243,8 +250,8 @@ class BasicHost(IHost):
         :param bootstrap_allow_ipv6: If True, bootstrap uses IPv6+TCP when available.
         :param bootstrap_dns_timeout: DNS resolution timeout in seconds per attempt.
         :param bootstrap_dns_max_retries: Max DNS resolution retries (with backoff).
-        :param announce_addrs: Optional addresses to advertise instead of
-            listen addresses.  ``None`` (default) uses listen addresses
+        :param announce_addrs: Optional static addresses to advertise instead of
+            the live candidate list.  ``None`` (default) uses listen addresses
             augmented with confirmed observed addresses from
             :class:`~libp2p.host.observed_addr_manager.ObservedAddrManager`.
             An empty list advertises no addresses. When set, this list acts
@@ -252,8 +259,18 @@ class BasicHost(IHost):
             ``applyAddrsFactory``) and wins over observed addresses:
             observations are still **recorded** by the manager (for
             :meth:`get_nat_type` and future AutoNAT consumers) but are
-            **not** emitted by :meth:`get_addrs`. See also
-            :meth:`get_addrs` for the exact composition rules.
+            **not** emitted by :meth:`get_addrs`. Mutually exclusive with
+            ``addrs_factory``. See also :meth:`get_addrs`.
+        :param addrs_factory: Optional callable matching go-libp2p's
+            ``AddrsFactory``. Receives the live candidate list (transport
+            addresses plus confirmed observed addresses when Identify
+            address discovery is enabled) and returns the addresses to
+            advertise. Mutually exclusive with ``announce_addrs``.
+        :param disable_identify_address_discovery: When ``True``, do not
+            create an :class:`~libp2p.host.observed_addr_manager.ObservedAddrManager`
+            and never record Identify ``observed_addr`` reports (parity with
+            go-libp2p's ``DisableIdentifyAddressDiscovery``). Useful with a
+            known public address via ``announce_addrs`` / ``addrs_factory``.
         """
         self._network = network
         self._network.set_stream_handler(self._swarm_stream_handler)
@@ -298,12 +315,27 @@ class BasicHost(IHost):
                 dns_max_retries=bootstrap_dns_max_retries,
             )
 
-        # Address announcement configuration (from #1268)
-        self._announce_addrs = (
-            list(announce_addrs) if announce_addrs is not None else None
+        # Address announcement configuration (#1268 / #1311)
+        if announce_addrs is not None and addrs_factory is not None:
+            raise ValueError("cannot specify both announce_addrs and addrs_factory")
+        self._disable_identify_address_discovery = disable_identify_address_discovery
+        if announce_addrs is not None:
+            static_addrs = list(announce_addrs)
+
+            def _static_addrs_factory(
+                _candidates: list[multiaddr.Multiaddr],
+                _addrs: list[multiaddr.Multiaddr] = static_addrs,
+            ) -> list[multiaddr.Multiaddr]:
+                return list(_addrs)
+
+            self._addrs_factory: AddrsFactory | None = _static_addrs_factory
+        else:
+            self._addrs_factory = addrs_factory
+        # Observed-address tracking (#1284 / #1250). Omit the manager when
+        # Identify address discovery is disabled (go DisableIdentifyAddressDiscovery).
+        self._observed_addr_manager: ObservedAddrManager | None = (
+            None if disable_identify_address_discovery else ObservedAddrManager()
         )
-        # Observed-address tracking (from #1284, issue #1250)
-        self._observed_addr_manager = ObservedAddrManager()
 
         # Cache a signed-record if the local-node in the PeerStore
         envelope = create_signed_peer_record(
@@ -431,33 +463,35 @@ class BasicHost(IHost):
 
         Behavior (mirrors go-libp2p's ``AddrsFactory`` pipeline):
 
-        * If ``announce_addrs`` was provided at construction time, that list
-          replaces everything — it is treated as a static ``AddrsFactory`` in
-          go-libp2p terms.  Observed (NAT) addresses are **still recorded**
-          by :class:`~libp2p.host.observed_addr_manager.ObservedAddrManager`
-          (for ``get_nat_type`` and future AutoNAT consumers) but are not
-          emitted here, since the caller has explicitly chosen which
-          addresses to advertise.
-        * Otherwise the set of raw transport addresses is augmented with
-          externally observed addresses that have been confirmed by enough
-          distinct peer groups (see :data:`ACTIVATION_THRESHOLD`), then the
-          ``/p2p/{peer_id}`` suffix is appended to each.
+        * Build a live candidate list from transport listen addresses,
+          augmented with confirmed observed addresses when Identify address
+          discovery is enabled (no ``ObservedAddrManager`` when
+          ``disable_identify_address_discovery`` is set).
+        * If ``announce_addrs`` or ``addrs_factory`` was provided, apply that
+          factory to the candidate list. Static ``announce_addrs`` ignores
+          the candidates and returns the fixed list (observations may still
+          be recorded for ``get_nat_type`` when discovery is enabled).
+        * Otherwise advertise the candidate list as-is.
+        * Finally append the ``/p2p/{peer_id}`` suffix to each address.
 
         Use :meth:`get_transport_addrs` for the raw transport addresses
         without any observed-address augmentation or ``/p2p`` suffix.
         """
         p2p_part = multiaddr.Multiaddr(f"/p2p/{self.get_id()!s}")
 
-        if self._announce_addrs is not None:
-            addrs = list(self._announce_addrs)
-        else:
-            addrs = list(self.get_transport_addrs())
-            seen = {str(a) for a in addrs}
+        candidates = list(self.get_transport_addrs())
+        if self._observed_addr_manager is not None:
+            seen = {str(a) for a in candidates}
             for obs_addr in self._observed_addr_manager.addrs():
                 key = str(obs_addr)
                 if key not in seen:
                     seen.add(key)
-                    addrs.append(obs_addr)
+                    candidates.append(obs_addr)
+
+        if self._addrs_factory is not None:
+            addrs = list(self._addrs_factory(candidates))
+        else:
+            addrs = candidates
 
         result = []
         for addr in addrs:
@@ -489,6 +523,9 @@ class BasicHost(IHost):
         observed addresses reported through Identify. Matches go-libp2p's
         ``host.getNATType()`` algorithm.
 
+        When ``disable_identify_address_discovery`` is enabled there is no
+        observed-address manager, so ``(UNKNOWN, UNKNOWN)`` is returned.
+
         .. note::
            Experimental API. Intended primarily for AutoNAT / hole-punch
            consumers; the return values, thresholds, and method name may
@@ -497,6 +534,8 @@ class BasicHost(IHost):
         :return: ``(tcp_nat_type, udp_nat_type)``, each one of
             :class:`~libp2p.host.observed_addr_manager.NATDeviceType`.
         """
+        if self._observed_addr_manager is None:
+            return (NATDeviceType.UNKNOWN, NATDeviceType.UNKNOWN)
         return self._observed_addr_manager.get_nat_type()
 
     def run(
@@ -1176,43 +1215,50 @@ class BasicHost(IHost):
                 self._identified_peers[peer_id] = ts
 
             if identify_msg.HasField("observed_addr") and identify_msg.observed_addr:
-                try:
-                    our_observed = multiaddr.Multiaddr(identify_msg.observed_addr)
+                if self._observed_addr_manager is None:
                     logger.debug(
-                        "Identify[%s]: recording observed_addr %s from peer %s",
+                        "Identify[%s]: ignoring observed_addr "
+                        "(Identify address discovery disabled)",
                         reason,
-                        our_observed,
-                        peer_id,
                     )
-                    self._observed_addr_manager.record_observation(
-                        swarm_conn, our_observed, self.get_transport_addrs()
-                    )
-                except MultiaddrError as exc:
-                    # Malformed observed_addr bytes or unknown protocols from a
-                    # misbehaving peer. Expected at low rates; log quietly.
-                    logger.debug(
-                        "ObservedAddrManager: ignoring malformed observed_addr "
-                        "from peer %s: %s",
-                        peer_id,
-                        exc,
-                    )
-                except ValueError as exc:
-                    logger.debug(
-                        "ObservedAddrManager: ignoring invalid observed_addr "
-                        "value from peer %s: %s",
-                        peer_id,
-                        exc,
-                    )
-                except Exception as exc:
-                    # Unexpected failure: surface at warning with traceback so
-                    # regressions don't disappear into debug logs.
-                    logger.warning(
-                        "ObservedAddrManager: unexpected failure recording "
-                        "observation from peer %s: %s",
-                        peer_id,
-                        exc,
-                        exc_info=True,
-                    )
+                else:
+                    try:
+                        our_observed = multiaddr.Multiaddr(identify_msg.observed_addr)
+                        logger.debug(
+                            "Identify[%s]: recording observed_addr %s from peer %s",
+                            reason,
+                            our_observed,
+                            peer_id,
+                        )
+                        self._observed_addr_manager.record_observation(
+                            swarm_conn, our_observed, self.get_transport_addrs()
+                        )
+                    except MultiaddrError as exc:
+                        # Malformed observed_addr bytes or unknown protocols from a
+                        # misbehaving peer. Expected at low rates; log quietly.
+                        logger.debug(
+                            "ObservedAddrManager: ignoring malformed observed_addr "
+                            "from peer %s: %s",
+                            peer_id,
+                            exc,
+                        )
+                    except ValueError as exc:
+                        logger.debug(
+                            "ObservedAddrManager: ignoring invalid observed_addr "
+                            "value from peer %s: %s",
+                            peer_id,
+                            exc,
+                        )
+                    except Exception as exc:
+                        # Unexpected failure: surface at warning with traceback so
+                        # regressions don't disappear into debug logs.
+                        logger.warning(
+                            "ObservedAddrManager: unexpected failure recording "
+                            "observation from peer %s: %s",
+                            peer_id,
+                            exc,
+                            exc_info=True,
+                        )
             else:
                 logger.debug(
                     "Identify[%s]: peer %s returned no observed_addr; "
@@ -1257,7 +1303,8 @@ class BasicHost(IHost):
             return
         self._identified_peers.pop(peer_id, None)
         self._identify_inflight.discard(peer_id)
-        self._observed_addr_manager.remove_conn(conn)
+        if self._observed_addr_manager is not None:
+            self._observed_addr_manager.remove_conn(conn)
 
     def _get_first_connection(self, peer_id: ID) -> INetConn | None:
         connections = self._network.get_connections(peer_id)

--- a/libp2p/host/routed_host.py
+++ b/libp2p/host/routed_host.py
@@ -11,6 +11,7 @@ from libp2p.abc import (
     IPeerRouting,
 )
 from libp2p.host.basic_host import (
+    AddrsFactory,
     BasicHost,
 )
 from libp2p.host.exceptions import (
@@ -46,6 +47,8 @@ class RoutedHost(BasicHost):
         bootstrap_dns_timeout: float = 10.0,
         bootstrap_dns_max_retries: int = 3,
         announce_addrs: Sequence[multiaddr.Multiaddr] | None = None,
+        addrs_factory: AddrsFactory | None = None,
+        disable_identify_address_discovery: bool = False,
     ):
         """
         Initialize a RoutedHost instance.
@@ -62,6 +65,10 @@ class RoutedHost(BasicHost):
         :param bootstrap_dns_timeout: DNS resolution timeout in seconds per attempt.
         :param bootstrap_dns_max_retries: Max DNS resolution retries (with backoff).
         :param announce_addrs: If set, replace listen addrs in get_addrs()
+        :param addrs_factory: Optional callable AddrsFactory (mutually exclusive
+            with ``announce_addrs``)
+        :param disable_identify_address_discovery: Opt out of Identify observed
+            address recording
         """
         super().__init__(
             network=network,
@@ -73,6 +80,8 @@ class RoutedHost(BasicHost):
             bootstrap_dns_timeout=bootstrap_dns_timeout,
             bootstrap_dns_max_retries=bootstrap_dns_max_retries,
             announce_addrs=announce_addrs,
+            addrs_factory=addrs_factory,
+            disable_identify_address_discovery=disable_identify_address_discovery,
         )
         self._router = router
 

--- a/newsfragments/1311.feature.rst
+++ b/newsfragments/1311.feature.rst
@@ -1,0 +1,3 @@
+Added a callable ``addrs_factory`` (go-libp2p ``AddrsFactory`` parity) and
+``disable_identify_address_discovery`` so hosts can compose advertised
+addresses and optionally opt out of Identify-driven observed-address discovery.

--- a/tests/core/host/test_basic_host.py
+++ b/tests/core/host/test_basic_host.py
@@ -134,11 +134,19 @@ def test_get_addrs_and_transport_addrs():
 
 def _make_host_with_listener(
     announce_addrs: Sequence[Multiaddr] | None = None,
+    *,
+    addrs_factory=None,
+    disable_identify_address_discovery: bool = False,
 ):
     """Helper: create a BasicHost with a mocked listener returning a known addr."""
     key_pair = create_new_key_pair()
     swarm = new_swarm(key_pair)
-    host = BasicHost(swarm, announce_addrs=announce_addrs)
+    host = BasicHost(
+        swarm,
+        announce_addrs=announce_addrs,
+        addrs_factory=addrs_factory,
+        disable_identify_address_discovery=disable_identify_address_discovery,
+    )
     mock_transport = MagicMock()
     mock_transport.get_addrs.return_value = [Multiaddr("/ip4/127.0.0.1/tcp/8000")]
     swarm.listeners = {"tcp": mock_transport}
@@ -270,7 +278,15 @@ def test_announce_addrs_with_correct_peer_id():
     peer_id_str = str(host.get_id())
 
     # Set announce addr that already includes the correct /p2p/ suffix
-    host._announce_addrs = [Multiaddr(f"/ip4/1.2.3.4/tcp/4001/p2p/{peer_id_str}")]
+    static = [Multiaddr(f"/ip4/1.2.3.4/tcp/4001/p2p/{peer_id_str}")]
+
+    def _static_factory(
+        _candidates: list[Multiaddr],
+        _addrs: list[Multiaddr] = static,
+    ) -> list[Multiaddr]:
+        return list(_addrs)
+
+    host._addrs_factory = _static_factory
 
     addrs = host.get_addrs()
 
@@ -312,8 +328,6 @@ def test_get_addrs_skips_observed_when_announce_set():
     assert len(addrs) == 1
     assert "/ip4/1.2.3.4/tcp/4001" in addr_strs[0]
     assert not any("5.6.7.8" in s for s in addr_strs)
-    # Observed manager's addrs() must not be consulted at all in this branch.
-    fake_manager.addrs.assert_not_called()
 
 
 def test_get_addrs_deduplicates_observed_matching_transport():
@@ -346,6 +360,143 @@ def test_get_nat_type_delegates_to_observed_addr_manager():
     fake_manager.get_nat_type.assert_called_once_with()
     assert tcp_nat == NATDeviceType.ENDPOINT_INDEPENDENT
     assert udp_nat == NATDeviceType.UNKNOWN
+
+
+def test_announce_addrs_and_addrs_factory_mutually_exclusive():
+    """Cannot set both announce_addrs and addrs_factory (#1311)."""
+    key_pair = create_new_key_pair()
+    swarm = new_swarm(key_pair)
+    with pytest.raises(ValueError, match="cannot specify both"):
+        BasicHost(
+            swarm,
+            announce_addrs=[Multiaddr("/ip4/1.2.3.4/tcp/4001")],
+            addrs_factory=lambda addrs: addrs,
+        )
+
+
+def test_addrs_factory_receives_live_list_including_observed():
+    """Callable addrs_factory sees transport + confirmed observed candidates."""
+    captured: list[list[Multiaddr]] = []
+
+    def factory(candidates: list[Multiaddr]) -> list[Multiaddr]:
+        captured.append(list(candidates))
+        # Keep listen + observed, append an extra public addr
+        return list(candidates) + [Multiaddr("/ip4/9.9.9.9/tcp/4001")]
+
+    host = _make_host_with_listener(addrs_factory=factory)
+    observed = Multiaddr("/ip4/5.6.7.8/tcp/4001")
+    fake_manager = MagicMock()
+    fake_manager.addrs.return_value = [observed]
+    host._observed_addr_manager = fake_manager
+
+    addrs = host.get_addrs()
+    peer_id_str = str(host.get_id())
+
+    # Factory also runs during BasicHost.__init__ (signed peer record) before
+    # listeners exist; assert on the call after the mock listener is attached.
+    assert len(captured) >= 1
+    assert [str(a) for a in captured[-1]] == [
+        "/ip4/127.0.0.1/tcp/8000",
+        "/ip4/5.6.7.8/tcp/4001",
+    ]
+    addr_strs = [str(a) for a in addrs]
+    assert f"/ip4/127.0.0.1/tcp/8000/p2p/{peer_id_str}" in addr_strs
+    assert f"/ip4/5.6.7.8/tcp/4001/p2p/{peer_id_str}" in addr_strs
+    assert f"/ip4/9.9.9.9/tcp/4001/p2p/{peer_id_str}" in addr_strs
+
+
+def test_addrs_factory_can_filter_candidates():
+    """Factory may return a subset of the live candidate list."""
+    host = _make_host_with_listener(
+        addrs_factory=lambda candidates: [a for a in candidates if "5.6.7.8" in str(a)]
+    )
+    fake_manager = MagicMock()
+    fake_manager.addrs.return_value = [Multiaddr("/ip4/5.6.7.8/tcp/4001")]
+    host._observed_addr_manager = fake_manager
+
+    addrs = host.get_addrs()
+    peer_id_str = str(host.get_id())
+    assert len(addrs) == 1
+    assert str(addrs[0]) == f"/ip4/5.6.7.8/tcp/4001/p2p/{peer_id_str}"
+
+
+def test_disable_identify_address_discovery_skips_manager():
+    """When disabled, no ObservedAddrManager is created (#1311)."""
+    from libp2p.host.observed_addr_manager import NATDeviceType
+
+    host = _make_host_with_listener(disable_identify_address_discovery=True)
+    assert host._observed_addr_manager is None
+    assert host._disable_identify_address_discovery is True
+    assert host.get_nat_type() == (NATDeviceType.UNKNOWN, NATDeviceType.UNKNOWN)
+
+    # get_addrs has no observed augmentation
+    addrs = host.get_addrs()
+    peer_id_str = str(host.get_id())
+    assert [str(a) for a in addrs] == [f"/ip4/127.0.0.1/tcp/8000/p2p/{peer_id_str}"]
+
+
+def test_addrs_factory_with_discovery_disabled_sees_only_transport():
+    """With discovery disabled, factory input is transport addrs only."""
+    captured: list[list[Multiaddr]] = []
+
+    def factory(candidates: list[Multiaddr]) -> list[Multiaddr]:
+        captured.append(list(candidates))
+        return list(candidates)
+
+    host = _make_host_with_listener(
+        addrs_factory=factory,
+        disable_identify_address_discovery=True,
+    )
+    addrs = host.get_addrs()
+    peer_id_str = str(host.get_id())
+
+    assert len(captured) >= 1
+    assert [str(a) for a in captured[-1]] == ["/ip4/127.0.0.1/tcp/8000"]
+    assert [str(a) for a in addrs] == [f"/ip4/127.0.0.1/tcp/8000/p2p/{peer_id_str}"]
+
+
+@pytest.mark.trio
+async def test_identify_peer_skips_record_when_discovery_disabled(monkeypatch):
+    """_identify_peer must not record observations when discovery is disabled."""
+    host = _make_host_with_listener(disable_identify_address_discovery=True)
+    peer_id = host.get_id()
+
+    swarm_conn = MagicMock()
+    swarm_conn.muxed_conn = MagicMock()
+    swarm_conn.muxed_conn.peer_id = peer_id
+    swarm_conn.muxed_conn.get_remote_address = MagicMock(
+        return_value=("10.0.0.1", 4001)
+    )
+    swarm_conn.is_closed = False
+    swarm_conn.event_started = None
+
+    monkeypatch.setattr(host._network, "get_connections", lambda pid: [swarm_conn])
+
+    fake_stream = MagicMock()
+    fake_stream.reset = AsyncMock()
+    fake_stream.close = AsyncMock()
+    host.new_stream = AsyncMock(return_value=fake_stream)
+
+    observed = Multiaddr("/ip4/5.6.7.8/tcp/4001")
+    msg = IdentifyMsg(observed_addr=observed.to_bytes())
+    msg_bytes = msg.SerializeToString()
+
+    async def fake_read(stream, use_varint_format=True):
+        return msg_bytes
+
+    async def fake_update(peerstore, peer_id_arg, identify_msg):
+        return None
+
+    monkeypatch.setattr(
+        "libp2p.host.basic_host.read_length_prefixed_protobuf", fake_read
+    )
+    monkeypatch.setattr(
+        "libp2p.host.basic_host.update_peerstore_from_identify", fake_update
+    )
+
+    await host._identify_peer(peer_id, reason="test")
+    assert host._observed_addr_manager is None
+    assert peer_id in host._identified_peers
 
 
 @pytest.mark.trio

--- a/tests/core/host/test_observed_addr_manager.py
+++ b/tests/core/host/test_observed_addr_manager.py
@@ -521,11 +521,11 @@ def test_get_addrs_includes_observed():
     swarm.listeners = {"tcp": mock_transport}
 
     observed = Multiaddr("/ip4/1.2.3.4/tcp/4001")
+    mgr = host._observed_addr_manager
+    assert mgr is not None
     for i in range(ACTIVATION_THRESHOLD):
         c = _make_conn(remote_ip=f"10.0.0.{i + 1}")
-        host._observed_addr_manager.record_observation(
-            c, observed, host.get_transport_addrs()
-        )
+        mgr.record_observation(c, observed, host.get_transport_addrs())
 
     addrs = host.get_addrs()
     addr_strs = [str(a) for a in addrs]


### PR DESCRIPTION
## Summary
- Add callable `addrs_factory` on `BasicHost` / `RoutedHost` / `new_host` (go-libp2p `AddrsFactory` parity): receives the live candidate list (transport + confirmed observed when discovery is on) and returns addresses to advertise.
- Add `disable_identify_address_discovery` to skip creating/`record_observation` via `ObservedAddrManager` (go `DisableIdentifyAddressDiscovery`); `get_nat_type()` returns `(UNKNOWN, UNKNOWN)` when disabled.
- Keep static `announce_addrs` backward-compatible; mutually exclusive with `addrs_factory`.

Fixes #1311

## Test plan
- [x] Unit: callable factory receives live list and can compose/filter
- [x] Unit: static `announce_addrs` still hides observed from advertise path
- [x] Unit: both knobs set → `ValueError`
- [x] Unit: disable → no manager; identify path skips record; `get_nat_type` unknown
- [x] Unit: factory + disable → factory sees transport only
- [x] `make lint` / `make typecheck` / host tests / `make linux-docs`


Made with [Cursor](https://cursor.com)