### PR TITLE
docs(examples): extend announce_addrs for addrs_factory and disable discovery

### DIFF
--- a/docs/advertising_addresses.rst
+++ b/docs/advertising_addresses.rst
@@ -26,9 +26,11 @@ than choosing only a static list. ``announce_addrs`` and ``addrs_factory`` are
 mutually exclusive.
 
 **4. ``disable_identify_address_discovery``** — When you know your public
-addresses upfront and do not want Identify-driven discovery (privacy or to skip
-``ObservedAddrManager`` work), set this to ``True``. Observations are not
-recorded; ``get_nat_type()`` returns unknown. Pair with ``announce_addrs`` or
+addresses upfront and do not want Identify-driven **address** discovery
+(privacy or to skip ``ObservedAddrManager`` work), set this to ``True``.
+Observations are not recorded; ``get_nat_type()`` returns unknown. Identify
+itself still runs for peer metadata; only ``observed_addr`` consumption for
+local discovery is disabled. Pair with ``announce_addrs`` or
 ``addrs_factory`` as go-libp2p recommends with
 ``DisableIdentifyAddressDiscovery``.
 

--- a/docs/examples.announce_addrs.rst
+++ b/docs/examples.announce_addrs.rst
@@ -114,9 +114,9 @@ Disabling Identify address discovery
 ------------------------------------
 
 If public addresses are known ahead of time and you do not want Identify to
-drive discovery (privacy or to avoid ``ObservedAddrManager`` overhead), set
-``disable_identify_address_discovery=True``. This matches go-libp2p's
-``DisableIdentifyAddressDiscovery``::
+drive **address** discovery (privacy or to avoid ``ObservedAddrManager``
+overhead), set ``disable_identify_address_discovery=True``. This matches
+go-libp2p's ``DisableIdentifyAddressDiscovery``::
 
     host = new_host(
         announce_addrs=[Multiaddr("/ip4/1.2.3.4/tcp/4001")],
@@ -125,6 +125,9 @@ drive discovery (privacy or to avoid ``ObservedAddrManager`` overhead), set
 
 In that mode observations are not recorded and
 :meth:`~libp2p.host.basic_host.BasicHost.get_nat_type` returns unknown.
+The Identify protocol itself still runs (peer metadata is still exchanged);
+only consumption of Identify ``observed_addr`` for local address discovery
+is skipped.
 
 The full source code for this example is below:
 

--- a/docs/examples.announce_addrs.rst
+++ b/docs/examples.announce_addrs.rst
@@ -74,6 +74,14 @@ Use ``announce_addrs`` when you already know the exact public address(es) you
 want peers to dial (e.g. a reverse proxy hostname such as ngrok). Rely on
 automatic observed-address discovery otherwise.
 
+**CLI (static announce + optional Identify opt-out):**
+
+.. code-block:: console
+
+    $ python examples/announce_addrs/announce_addrs.py --listen-port 9001 \
+        --announce /ip4/1.2.3.4/tcp/4001 \
+        --disable-identify-address-discovery
+
 Callable ``addrs_factory``
 --------------------------
 
@@ -93,6 +101,14 @@ to advertise::
     host = new_host(addrs_factory=my_factory)
 
 ``announce_addrs`` and ``addrs_factory`` cannot be set together.
+
+**CLI (factory compose mode)** -- keep live candidates and append extras via
+``--factory-extra`` (mutually exclusive with ``--announce``):
+
+.. code-block:: console
+
+    $ python examples/announce_addrs/announce_addrs.py --listen-port 9001 \
+        --factory-extra /dns4/example.ngrok-free.app/tcp/9001
 
 Disabling Identify address discovery
 ------------------------------------

--- a/docs/libp2p.host.rst
+++ b/docs/libp2p.host.rst
@@ -66,7 +66,9 @@ To stop recording Identify observations entirely (privacy or to avoid the
 ``ObservedAddrManager`` footprint), set
 ``disable_identify_address_discovery=True`` (parity with go-libp2p's
 ``DisableIdentifyAddressDiscovery``). In that mode ``get_nat_type()``
-returns ``(UNKNOWN, UNKNOWN)``.
+returns ``(UNKNOWN, UNKNOWN)``. The Identify protocol itself still runs
+(peer metadata is still exchanged); only consumption of Identify
+``observed_addr`` for local address discovery is skipped.
 
 .. automodule:: libp2p.host.observed_addr_manager
    :members:

--- a/examples/announce_addrs/announce_addrs.py
+++ b/examples/announce_addrs/announce_addrs.py
@@ -199,9 +199,10 @@ def main() -> None:
         "--disable-identify-address-discovery",
         action="store_true",
         help=(
-            "Do not record Identify observed addresses "
-            "(go-libp2p DisableIdentifyAddressDiscovery). "
-            "Useful with --announce when public addresses are known upfront."
+            "Do not record Identify observed addresses for local discovery "
+            "(go-libp2p DisableIdentifyAddressDiscovery). Identify still runs "
+            "for peer metadata. Useful with --announce when public addresses "
+            "are known upfront."
         ),
     )
     parser.add_argument(

--- a/examples/announce_addrs/announce_addrs.py
+++ b/examples/announce_addrs/announce_addrs.py
@@ -1,20 +1,39 @@
 """
 Announce Addresses Example for py-libp2p
 
-Demonstrates how to use announce addresses so that a node behind NAT
-or a reverse proxy (e.g. ngrok) advertises its publicly reachable
-address instead of its local listen address.
+Demonstrates how to advertise publicly reachable addresses when a node is
+behind NAT or a reverse proxy (e.g. ngrok), including the go-libp2p parity
+knobs from issue #1311 / #1478:
 
-Node A (listener):
+* static ``--announce`` / ``announce_addrs``
+* callable ``addrs_factory`` via ``--factory-extra`` (compose live candidates
+  + extra multiaddrs)
+* ``--disable-identify-address-discovery`` (opt out of Identify observations)
+
+Static announce and factory mode are mutually exclusive (same as the API).
+
+Node A (listener, static announce):
     python announce_addrs.py --listen-port 9001 \
         --announce /dns4/example.ngrok-free.app/tcp/9001 /ip4/1.2.3.4/tcp/4001
+
+Node A (listener, static announce + disable Identify discovery):
+    python announce_addrs.py --listen-port 9001 \
+        --announce /ip4/1.2.3.4/tcp/4001 \
+        --disable-identify-address-discovery
+
+Node A (listener, addrs_factory compose mode):
+    python announce_addrs.py --listen-port 9001 \
+        --factory-extra /dns4/example.ngrok-free.app/tcp/9001
 
 Node B (dialer):
     python announce_addrs.py --listen-port 9002 \
         --dial /dns4/example.ngrok-free.app/tcp/9001/p2p/<PEER_ID_OF_A>
 """
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Callable, Sequence
 import logging
 import secrets
 
@@ -35,21 +54,58 @@ logger = logging.getLogger("announce_addrs_example")
 logging.getLogger("multiaddr").setLevel(logging.WARNING)
 
 
-async def run_listener(port: int, announce_addrs: list[str]) -> None:
-    """Start a node that listens locally and announces external addresses."""
-    key_pair = create_new_key_pair(secrets.token_bytes(32))
+def _make_compose_factory(
+    extra_addrs: Sequence[multiaddr.Multiaddr],
+) -> Callable[[list[multiaddr.Multiaddr]], list[multiaddr.Multiaddr]]:
+    """Build an AddrsFactory that keeps live candidates and appends extras."""
+    extras = list(extra_addrs)
 
+    def factory(candidates: list[multiaddr.Multiaddr]) -> list[multiaddr.Multiaddr]:
+        seen = {str(a) for a in candidates}
+        result = list(candidates)
+        for addr in extras:
+            key = str(addr)
+            if key not in seen:
+                seen.add(key)
+                result.append(addr)
+        return result
+
+    return factory
+
+
+async def run_listener(
+    port: int,
+    announce_addrs: list[str] | None,
+    factory_extra: list[str] | None,
+    disable_identify_address_discovery: bool = False,
+) -> None:
+    """Start a node that listens locally and advertises configured addresses."""
+    key_pair = create_new_key_pair(secrets.token_bytes(32))
     listen_addrs = [multiaddr.Multiaddr(f"/ip4/0.0.0.0/tcp/{port}")]
 
-    parsed_announce = [multiaddr.Multiaddr(a) for a in announce_addrs]
+    host_kwargs: dict = {
+        "key_pair": key_pair,
+        "disable_identify_address_discovery": disable_identify_address_discovery,
+    }
+    if announce_addrs is not None:
+        host_kwargs["announce_addrs"] = [multiaddr.Multiaddr(a) for a in announce_addrs]
+    elif factory_extra is not None:
+        extras = [multiaddr.Multiaddr(a) for a in factory_extra]
+        host_kwargs["addrs_factory"] = _make_compose_factory(extras)
 
-    host = new_host(key_pair=key_pair, announce_addrs=parsed_announce)
+    host = new_host(**host_kwargs)
 
     async with host.run(listen_addrs=listen_addrs):
         peer_id = host.get_id().to_string()
 
         logger.info("Node started")
         logger.info(f"Peer ID: {peer_id}")
+        if disable_identify_address_discovery:
+            logger.info("Identify address discovery: disabled")
+        if announce_addrs is not None:
+            logger.info("Mode: static announce_addrs")
+        elif factory_extra is not None:
+            logger.info("Mode: addrs_factory (compose live candidates + extras)")
 
         logger.info("Transport (local) addresses:")
         for addr in host.get_transport_addrs():
@@ -93,8 +149,26 @@ async def run_dialer(port: int, dial_addr: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Announce Addresses Example",
+        description=(
+            "Announce Addresses Example — static announce_addrs, "
+            "addrs_factory compose mode, and optional Identify discovery opt-out."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  Static announce:\n"
+            "    %(prog)s --listen-port 9001 "
+            "--announce /dns4/example.ngrok-free.app/tcp/9001\n"
+            "  Static announce + disable Identify discovery:\n"
+            "    %(prog)s --listen-port 9001 --announce /ip4/1.2.3.4/tcp/4001 "
+            "--disable-identify-address-discovery\n"
+            "  Factory compose (live candidates + extras):\n"
+            "    %(prog)s --listen-port 9001 "
+            "--factory-extra /dns4/example.ngrok-free.app/tcp/9001\n"
+            "  Dialer:\n"
+            "    %(prog)s --listen-port 9002 "
+            "--dial /dns4/example.ngrok-free.app/tcp/9001/p2p/<PEER_ID>\n"
+        ),
     )
     parser.add_argument(
         "--listen-port",
@@ -105,7 +179,30 @@ def main() -> None:
     parser.add_argument(
         "--announce",
         nargs="+",
-        help="Announce addresses (e.g. /dns4/example.ngrok-free.app/tcp/443)",
+        help=(
+            "Static announce addresses "
+            "(e.g. /dns4/example.ngrok-free.app/tcp/443). "
+            "Mutually exclusive with --factory-extra."
+        ),
+    )
+    parser.add_argument(
+        "--factory-extra",
+        nargs="+",
+        metavar="MULTIADDR",
+        help=(
+            "Use addrs_factory: advertise live candidates "
+            "(listen + confirmed observed, unless discovery is disabled) "
+            "plus these extra multiaddrs. Mutually exclusive with --announce."
+        ),
+    )
+    parser.add_argument(
+        "--disable-identify-address-discovery",
+        action="store_true",
+        help=(
+            "Do not record Identify observed addresses "
+            "(go-libp2p DisableIdentifyAddressDiscovery). "
+            "Useful with --announce when public addresses are known upfront."
+        ),
     )
     parser.add_argument(
         "--dial",
@@ -117,10 +214,27 @@ def main() -> None:
 
     if args.dial:
         trio.run(run_dialer, args.listen_port, args.dial)
-    elif args.announce:
-        trio.run(run_listener, args.listen_port, args.announce)
-    else:
-        parser.error("Provide --announce to listen, or --dial to connect to a peer.")
+        return
+
+    if args.announce and args.factory_extra:
+        parser.error(
+            "cannot combine --announce and --factory-extra "
+            "(same mutual exclusion as announce_addrs vs addrs_factory)"
+        )
+
+    if not args.announce and not args.factory_extra:
+        parser.error(
+            "Provide --announce or --factory-extra to listen, "
+            "or --dial to connect to a peer."
+        )
+
+    trio.run(
+        run_listener,
+        args.listen_port,
+        args.announce,
+        args.factory_extra,
+        args.disable_identify_address_discovery,
+    )
 
 
 if __name__ == "__main__":

--- a/libp2p/__init__.py
+++ b/libp2p/__init__.py
@@ -745,9 +745,10 @@ def new_host(
     :param addrs_factory: optional callable matching go-libp2p ``AddrsFactory``;
         receives the live candidate address list and returns addresses to
         advertise (mutually exclusive with ``announce_addrs``)
-    :param disable_identify_address_discovery: if True, do not record or
-        advertise Identify observed addresses (go
-        ``DisableIdentifyAddressDiscovery``)
+    :param disable_identify_address_discovery: if True, do not record Identify
+        observed addresses for local discovery (go
+        ``DisableIdentifyAddressDiscovery``). Identify itself still runs for
+        peer metadata; only observed-address discovery is skipped.
     :param transports: explicit list of transport instances to register.  When
         provided, all ``enable_*`` flags and ``listen_addrs``-based detection
         are bypassed.

--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -269,8 +269,10 @@ class BasicHost(IHost):
         :param disable_identify_address_discovery: When ``True``, do not
             create an :class:`~libp2p.host.observed_addr_manager.ObservedAddrManager`
             and never record Identify ``observed_addr`` reports (parity with
-            go-libp2p's ``DisableIdentifyAddressDiscovery``). Useful with a
-            known public address via ``announce_addrs`` / ``addrs_factory``.
+            go-libp2p's ``DisableIdentifyAddressDiscovery``). The Identify
+            protocol itself still runs for peer metadata; only observed-address
+            discovery is skipped. Useful with a known public address via
+            ``announce_addrs`` / ``addrs_factory``.
         """
         self._network = network
         self._network.set_stream_handler(self._swarm_stream_handler)
@@ -525,6 +527,7 @@ class BasicHost(IHost):
 
         When ``disable_identify_address_discovery`` is enabled there is no
         observed-address manager, so ``(UNKNOWN, UNKNOWN)`` is returned.
+        Identify itself still runs; only observed-address discovery is skipped.
 
         .. note::
            Experimental API. Intended primarily for AutoNAT / hole-punch

--- a/newsfragments/1478.docs.rst
+++ b/newsfragments/1478.docs.rst
@@ -1,0 +1,2 @@
+Extended the announce-addrs example CLI with ``--factory-extra``
+(``addrs_factory`` compose mode) and ``--disable-identify-address-discovery``.

--- a/newsfragments/1478.docs.rst
+++ b/newsfragments/1478.docs.rst
@@ -1,2 +1,4 @@
 Extended the announce-addrs example CLI with ``--factory-extra``
-(``addrs_factory`` compose mode) and ``--disable-identify-address-discovery``.
+(``addrs_factory`` compose mode) and ``--disable-identify-address-discovery``,
+and clarified that the flag skips observed-address discovery only (Identify
+itself still runs for peer metadata).


### PR DESCRIPTION
## Summary
- Extend `examples/announce_addrs/announce_addrs.py` with `--factory-extra` (`addrs_factory` compose mode) and `--disable-identify-address-discovery`.
- Enforce CLI mutual exclusion between `--announce` and `--factory-extra` (mirrors the API).
- Update `docs/examples.announce_addrs.rst` with matching CLI usage.

Fixes #1478

## Test plan
- [x] `--help` documents the new flags and examples
- [x] Combining `--announce` + `--factory-extra` errors clearly
- [x] Compose factory unit smoke check
- [x] `make lint` / `make typecheck` / `make linux-docs`


Made with [Cursor](https://cursor.com)