### PR TITLE
docs(filecoin): add network parity audit and interop matrix

### DIFF
--- a/artifacts/filecoin/network_parity_and_interop.v1.json
+++ b/artifacts/filecoin/network_parity_and_interop.v1.json
@@ -1,0 +1,389 @@
+{
+  "interop_matrix": [
+    {
+      "evidence_source": "examples/filecoin/filecoin_connect_demo.py",
+      "focus": "connectivity against Filecoin bootstrap peers",
+      "id": "public_filecoin_bootstrap_connect",
+      "notes": "Confirms runtime bootstrap dialing against public Filecoin peers.",
+      "reproducible_steps": [
+        "filecoin-connect-demo --network mainnet --resolve-dns --json"
+      ],
+      "result": "pass",
+      "target": "public_bootstrap_peers",
+      "workflow": "runtime_bootstrap_smoke"
+    },
+    {
+      "evidence_source": "examples/filecoin/filecoin_ping_identify_demo.py",
+      "focus": "identify advertisement and ping RTT",
+      "id": "public_filecoin_ping_identify",
+      "notes": "Confirms advertised Filecoin protocol IDs plus ping RTT summaries.",
+      "reproducible_steps": [
+        "filecoin-ping-identify-demo --network mainnet --resolve-dns --json"
+      ],
+      "result": "pass",
+      "target": "public_filecoin_peers",
+      "workflow": "runtime_bootstrap_smoke"
+    },
+    {
+      "evidence_source": "docs/filecoin_network_parity_and_interop.rst",
+      "focus": "identify and ping over an explicit Lotus multiaddr",
+      "id": "lotus_identify_ping_tcp",
+      "notes": "Reproducible by operators, but not launched in CI by this module.",
+      "reproducible_steps": [
+        "filecoin-connect-demo --peer /.../p2p/<lotus-peer-id> --json",
+        "filecoin-ping-identify-demo --peer /.../p2p/<lotus-peer-id> --json"
+      ],
+      "result": "partial",
+      "target": "operator_supplied_lotus_node",
+      "workflow": "controlled_explicit_peer"
+    },
+    {
+      "evidence_source": "docs/filecoin_network_parity_and_interop.rst",
+      "focus": "identify and ping over an explicit Forest multiaddr",
+      "id": "forest_identify_ping_tcp",
+      "notes": "Same probe path as Lotus, using the existing Filecoin examples.",
+      "reproducible_steps": [
+        "filecoin-connect-demo --peer /.../p2p/<forest-peer-id> --json",
+        "filecoin-ping-identify-demo --peer /.../p2p/<forest-peer-id> --json"
+      ],
+      "result": "partial",
+      "target": "operator_supplied_forest_node",
+      "workflow": "controlled_explicit_peer"
+    },
+    {
+      "evidence_source": "examples/filecoin/filecoin_ping_identify_demo.py",
+      "focus": "advertised Hello and ChainExchange protocol IDs",
+      "id": "lotus_protocol_advertisement",
+      "notes": "Checks protocol advertisement, not full runtime protocol exchange.",
+      "reproducible_steps": [
+        "filecoin-ping-identify-demo --peer /.../p2p/<lotus-peer-id> --json"
+      ],
+      "result": "partial",
+      "target": "operator_supplied_lotus_node",
+      "workflow": "controlled_explicit_peer"
+    },
+    {
+      "evidence_source": "examples/filecoin/filecoin_ping_identify_demo.py",
+      "focus": "advertised Hello and ChainExchange protocol IDs",
+      "id": "forest_protocol_advertisement",
+      "notes": "Checks protocol advertisement, not full runtime protocol exchange.",
+      "reproducible_steps": [
+        "filecoin-ping-identify-demo --peer /.../p2p/<forest-peer-id> --json"
+      ],
+      "result": "partial",
+      "target": "operator_supplied_forest_node",
+      "workflow": "controlled_explicit_peer"
+    },
+    {
+      "evidence_source": "examples/filecoin/filecoin_pubsub_demo.py",
+      "focus": "read-only observer mode over Filecoin topics",
+      "id": "filecoin_read_only_gossipsub_observer",
+      "notes": "Observer mode is intentionally safe/read-only and may log expected peer-specific failures.",
+      "reproducible_steps": [
+        "filecoin-pubsub-demo --network mainnet --seconds 5 --json"
+      ],
+      "result": "partial",
+      "target": "public_filecoin_gossip_peers",
+      "workflow": "runtime_bootstrap_smoke"
+    },
+    {
+      "evidence_source": "docs/filecoin_network_parity_and_interop.rst",
+      "focus": "runtime Hello request/response behavior",
+      "id": "hello_runtime_exchange",
+      "notes": "Module 1 documents the gap instead of shipping a stub implementation.",
+      "reproducible_steps": [],
+      "result": "expected_gap",
+      "target": "lotus_or_forest_nodes",
+      "workflow": "controlled_explicit_peer"
+    },
+    {
+      "evidence_source": "docs/filecoin_network_parity_and_interop.rst",
+      "focus": "runtime ChainExchange request/response behavior",
+      "id": "chain_exchange_request_response",
+      "notes": "Protocol IDs are present; request/response behavior remains follow-up work.",
+      "reproducible_steps": [],
+      "result": "expected_gap",
+      "target": "lotus_or_forest_nodes",
+      "workflow": "controlled_explicit_peer"
+    }
+  ],
+  "meta": {
+    "allowed_interop_results": [
+      "pass",
+      "partial",
+      "fail",
+      "expected_gap"
+    ],
+    "allowed_parity_statuses": [
+      "aligned",
+      "partial",
+      "different",
+      "out_of_scope"
+    ],
+    "format": "filecoin_network_parity_and_interop.v1",
+    "sources": {
+      "forest": {
+        "version": "0.32.2"
+      },
+      "lotus": {
+        "version": "v1.35.0"
+      }
+    }
+  },
+  "network_parity_audit": [
+    {
+      "concern": "Listen address defaults",
+      "forest_evidence": [
+        "src/libp2p/config.rs:29"
+      ],
+      "id": "listen_addresses",
+      "implication": "Generic py-libp2p defaults do not imply QUIC or WebTransport parity for Filecoin nodes.",
+      "lotus_evidence": [
+        "node/config/def.go:35",
+        "node/config/types.go:318"
+      ],
+      "priority": "P1",
+      "pylibp2p_evidence": [
+        "libp2p/__init__.py:434"
+      ],
+      "status": "different",
+      "suggested_change": "Document Filecoin-specific listen-address recommendations rather than changing the global host default in this module."
+    },
+    {
+      "concern": "Transport stack defaults",
+      "forest_evidence": [
+        "src/libp2p/config.rs:29",
+        "src/libp2p/discovery.rs:82"
+      ],
+      "id": "transport_stack",
+      "implication": "TCP interop is straightforward, but broader Filecoin transport defaults are not mirrored by a plain py-libp2p host.",
+      "lotus_evidence": [
+        "node/modules/lp2p/transport.go:14"
+      ],
+      "priority": "P1",
+      "pylibp2p_evidence": [
+        "libp2p/__init__.py:434",
+        "libp2p/transport/quic/transport.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Keep the transport metadata visible in interop probe outputs and document the Filecoin-oriented transport settings."
+    },
+    {
+      "concern": "Security stack ordering",
+      "forest_evidence": [
+        "src/libp2p/service.rs:271"
+      ],
+      "id": "security_stack_order",
+      "implication": "Noise-first operation interoperates, but exact ordering/config shape differs from Lotus configurability.",
+      "lotus_evidence": [
+        "node/modules/lp2p/transport.go:21"
+      ],
+      "priority": "P1",
+      "pylibp2p_evidence": [
+        "libp2p/__init__.py:532",
+        "libp2p/security/security_multistream.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Expose negotiated security protocol in probe output and recommend Filecoin-specific security choices in docs."
+    },
+    {
+      "concern": "Muxer defaults",
+      "forest_evidence": [
+        "src/libp2p/service.rs:283"
+      ],
+      "id": "muxer_defaults",
+      "implication": "Yamux-first aligns well for TCP, but py-libp2p still keeps a generic Mplex fallback path.",
+      "lotus_evidence": [
+        "node/modules/lp2p/smux.go:11"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/__init__.py:223",
+        "libp2p/stream_muxer/muxer_multistream.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Keep Yamux-first and capture the negotiated muxer during probes."
+    },
+    {
+      "concern": "Ping and identify host defaults",
+      "forest_evidence": [
+        "src/libp2p/discovery.rs:108"
+      ],
+      "id": "ping_identify_host_defaults",
+      "implication": "Ping and identify diagnostics already provide a good interoperability surface for Filecoin nodes.",
+      "lotus_evidence": [
+        "node/modules/lp2p/host.go:49"
+      ],
+      "priority": null,
+      "pylibp2p_evidence": [
+        "libp2p/host/basic_host.py",
+        "examples/filecoin/filecoin_ping_identify_demo.py"
+      ],
+      "status": "aligned",
+      "suggested_change": "None in this module."
+    },
+    {
+      "concern": "Connection manager thresholds and grace period",
+      "forest_evidence": [
+        "src/libp2p/config.rs:37"
+      ],
+      "id": "connection_manager_thresholds",
+      "implication": "py-libp2p defaults are looser than current Filecoin node expectations.",
+      "lotus_evidence": [
+        "node/modules/lp2p/libp2p.go:63",
+        "node/config/def.go:47"
+      ],
+      "priority": "P1",
+      "pylibp2p_evidence": [
+        "libp2p/network/config.py:17"
+      ],
+      "status": "different",
+      "suggested_change": "Publish Filecoin-specific recommended limits instead of mutating global defaults in this module."
+    },
+    {
+      "concern": "Resource manager behavior and scaling",
+      "forest_evidence": [
+        "src/libp2p/peer_manager.rs:121"
+      ],
+      "id": "resource_manager_defaults",
+      "implication": "Long-running Filecoin services need explicit resource planning in py-libp2p today.",
+      "lotus_evidence": [
+        "node/modules/lp2p/rcmgr.go:34"
+      ],
+      "priority": "P1",
+      "pylibp2p_evidence": [
+        "libp2p/rcmgr/manager.py"
+      ],
+      "status": "different",
+      "suggested_change": "Treat Lotus-style autoscaling/bootstrap allowlisting as a follow-up reliability/resource-management track."
+    },
+    {
+      "concern": "Bootstrap peer protection and allowlisting",
+      "forest_evidence": [
+        "src/libp2p/discovery.rs:65",
+        "src/libp2p/peer_manager.rs:221"
+      ],
+      "id": "bootstrap_protection",
+      "implication": "Bootstrap peers are not automatically protected/allowlisted in a Lotus-equivalent way.",
+      "lotus_evidence": [
+        "node/modules/lp2p/libp2p.go:82",
+        "node/modules/lp2p/rcmgr.go:129"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/network/tag_store.py",
+        "libp2p/network/swarm.py"
+      ],
+      "status": "different",
+      "suggested_change": "Document the gap and prefer application-level protection/tagging for long-lived Filecoin peers."
+    },
+    {
+      "concern": "Discovery stack and bootstrap dialing",
+      "forest_evidence": [
+        "src/libp2p/discovery.rs:82"
+      ],
+      "id": "discovery_stack",
+      "implication": "The Filecoin examples rely on runtime bootstrap dialing rather than Filecoin-shaped discovery lifecycle parity.",
+      "lotus_evidence": [
+        "node/modules/lp2p/discovery.go:13",
+        "node/modules/lp2p/nat.go:25"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "examples/filecoin/filecoin_connect_demo.py",
+        "libp2p/discovery"
+      ],
+      "status": "different",
+      "suggested_change": "Keep reproducible interop probe steps explicit and defer discovery-lifecycle parity to later work."
+    },
+    {
+      "concern": "Idle connection policy and redial assumptions",
+      "forest_evidence": [
+        "src/libp2p/service.rs:326"
+      ],
+      "id": "idle_connection_and_redial",
+      "implication": "py-libp2p can maintain peers, but its lifecycle heuristics are still generic rather than Filecoin-specific.",
+      "lotus_evidence": [
+        "node/modules/lp2p/libp2p.go:63"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/network/auto_connector.py",
+        "libp2p/network/connection_pruner.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Record parity notes now and treat deeper lifecycle tuning as a follow-up reliability task."
+    },
+    {
+      "concern": "Request/response stream concurrency assumptions",
+      "forest_evidence": [
+        "src/libp2p/service.rs:768"
+      ],
+      "id": "request_response_stream_concurrency",
+      "implication": "Filecoin request/response workloads should not assume Lotus/Forest-sized concurrency defaults in py-libp2p.",
+      "lotus_evidence": [
+        "node/modules/lp2p/rcmgr.go:70"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/transport/quic/config.py",
+        "libp2p/network/config.py"
+      ],
+      "status": "different",
+      "suggested_change": "Document the gap and keep future tuning tied to measured interop/perf work."
+    },
+    {
+      "concern": "Peer protection, bad-peer handling, and availability assumptions",
+      "forest_evidence": [
+        "src/libp2p/peer_manager.rs:121"
+      ],
+      "id": "peer_protection_and_bans",
+      "implication": "py-libp2p exposes building blocks, but not the same Filecoin peer-availability model.",
+      "lotus_evidence": [
+        "node/modules/lp2p/libp2p.go:72",
+        "node/modules/lp2p/conngater.go:10"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/network/tag_store.py",
+        "libp2p/network/connection_gate.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Keep the current gap visible and do not imply Lotus/Forest-grade peer availability semantics."
+    },
+    {
+      "concern": "DHT protocol naming and routing filters",
+      "forest_evidence": [
+        "src/libp2p/discovery.rs:82"
+      ],
+      "id": "dht_protocol_and_filters",
+      "implication": "The Filecoin DHT protocol helper exists, but Lotus-style routing-table/query filters are not mirrored.",
+      "lotus_evidence": [
+        "node/modules/lp2p/host.go:82"
+      ],
+      "priority": "P3",
+      "pylibp2p_evidence": [
+        "libp2p/filecoin/constants.py:34"
+      ],
+      "status": "partial",
+      "suggested_change": "Keep naming parity and document behavioural gaps."
+    },
+    {
+      "concern": "Pubsub and peer-scoring parity note",
+      "forest_evidence": [
+        "src/libp2p/gossip_params.rs:125"
+      ],
+      "id": "pubsub_peer_scoring_note",
+      "implication": "The Filecoin pubsub preset is useful today, but full scoring/gating parity remains a separate track.",
+      "lotus_evidence": [
+        "node/modules/lp2p/pubsub.go:31"
+      ],
+      "priority": "P2",
+      "pylibp2p_evidence": [
+        "libp2p/filecoin/pubsub.py"
+      ],
+      "status": "partial",
+      "suggested_change": "Point users to the existing Filecoin pubsub docs/examples and keep this module focused on network parity and interop."
+    }
+  ]
+}

--- a/docs/examples.filecoin.rst
+++ b/docs/examples.filecoin.rst
@@ -5,6 +5,7 @@ Read this first:
 
 - :doc:`filecoin_architecture_positioning`
 - :doc:`filecoin_protocol_support_matrix`
+- :doc:`filecoin_network_parity_and_interop`
 
 These examples show practical Filecoin-focused workflows using
 ``libp2p.filecoin``.

--- a/docs/filecoin/parity_matrix.md
+++ b/docs/filecoin/parity_matrix.md
@@ -3,6 +3,9 @@
 This page captures value/constant parity. For runtime protocol support, example
 coverage, and prioritized gaps, see the
 [`Filecoin protocol support matrix`](../filecoin_protocol_support_matrix.rst).
+For defaults parity, connection lifecycle notes, and reproducible interop probe
+workflows, see
+[`Filecoin network parity and interop`](../filecoin_network_parity_and_interop.rst).
 
 | Concern                                    | Lotus reference                              | Forest reference                                          | py-libp2p mapping                                  | Status      | Notes                                                                 |
 | ------------------------------------------ | -------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------- | ----------- | --------------------------------------------------------------------- |

--- a/docs/filecoin_architecture_positioning.rst
+++ b/docs/filecoin_architecture_positioning.rst
@@ -14,6 +14,9 @@ IDs, topic formats, bootstrap presets, and practical examples.
 For protocol-by-protocol implementation status and prioritized gaps, see
 :doc:`filecoin_protocol_support_matrix`.
 
+For defaults parity, connection lifecycle notes, and reproducible interop probe
+steps, see :doc:`filecoin_network_parity_and_interop`.
+
 Normative references:
 
 - `Filecoin Network Interface <https://spec.filecoin.io/systems/filecoin_nodes/network/>`_

--- a/docs/filecoin_network_parity_and_interop.rst
+++ b/docs/filecoin_network_parity_and_interop.rst
@@ -1,0 +1,225 @@
+Filecoin Network Parity and Interop for py-libp2p
+==================================================
+
+This page documents how ``py-libp2p`` currently lines up with Lotus and Forest
+networking behavior, and how to reproduce the current interoperability checks.
+
+Scope and evidence
+------------------
+
+This page is scoped to Filecoin-facing networking behavior, not full node
+consensus behavior. The evidence base for the audit comes from:
+
+- Lotus ``v1.35.0`` networking defaults and modules.
+- Forest ``0.32.2`` networking defaults and discovery/peer-management code.
+- The current ``py-libp2p`` branch state plus the Filecoin DX examples added in
+  Module 5.
+
+Normative references:
+
+- `Lotus libp2p host defaults <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/modules/lp2p/libp2p.go>`_
+- `Lotus config defaults <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/config/def.go>`_
+- `Forest libp2p configuration <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/config.rs>`_
+- `Forest discovery behaviour <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/discovery.rs>`_
+
+Network parity audit
+--------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Concern
+     - Lotus / Forest expectation
+     - py-libp2p state
+     - Parity status
+     - Practical implication
+     - Suggested next step
+   * - Listen address defaults
+     - Lotus listens on TCP, QUIC, and WebTransport by default; Forest listens on TCP and QUIC.
+     - ``py-libp2p`` defaults to TCP unless QUIC or another transport is explicitly selected.
+     - different
+     - Filecoin operators should not assume QUIC/WebTransport parity from generic host defaults.
+     - Document Filecoin-specific listen-address recommendations instead of changing the global default in this module.
+   * - Transport and security stack order
+     - Lotus offers Noise and TLS, with configurable preference; Forest composes TCP/QUIC with Noise and identify/discovery services.
+     - ``py-libp2p`` currently prefers Noise, keeps TLS as fallback. Capturing negotiated transport/security/muxer metadata in Filecoin demo JSON is tracked as a follow-up.
+     - partial
+     - Core interoperability works, but the stack breadth and ordering differ from Filecoin node defaults.
+     - Keep defaults stable and publish the recommended Filecoin-oriented transport/security settings.
+   * - Muxer defaults
+     - Lotus explicitly wires Yamux; Forest uses libp2p swarm configuration with long-lived connections and QUIC where available.
+     - ``py-libp2p`` prefers Yamux and retains Mplex fallback.
+     - partial
+     - TCP interop is fine, but generic fallback behavior still differs from narrower Filecoin defaults.
+     - Keep Yamux-first; record negotiated muxer metadata in interop outputs once the follow-up metadata wiring lands.
+   * - Connection manager thresholds and grace period
+     - Lotus defaults to ``low=150``, ``high=180``, ``grace=20s``; Forest defaults to ``target_peer_count=75``.
+     - ``py-libp2p`` defaults to ``min=50``, ``low=100``, ``high=550``, ``max=600``, ``grace=20s``.
+     - different
+     - Generic py-libp2p limits are much looser than current Filecoin expectations.
+     - Record the difference and propose Filecoin-specific recommended configs in docs/artifacts.
+   * - Resource manager behavior
+     - Lotus conditionally enables autoscaled resource limits and allowlists bootstrap addresses; Forest relies more on behaviour-level limits and peer management.
+     - ``py-libp2p`` has a simpler resource manager and does not mirror Lotus autoscaling or bootstrap allowlisting.
+     - different
+     - Long-running Filecoin services need explicit resource planning instead of assuming Lotus-like defaults.
+     - Treat this as a follow-up reliability/resource-management area rather than changing defaults here.
+   * - Discovery stack
+     - Lotus and Forest both rely on Kademlia and NAT-related behaviour; Forest also wires identify, AutoNAT, and UPnP directly into discovery.
+     - ``py-libp2p`` has discovery primitives, but the Filecoin examples currently use runtime bootstrap dialing as the primary interop workflow.
+     - different
+     - Public-network smoke testing is possible today, but full lifecycle parity is not implied.
+     - Keep discovery gaps explicit and focus this module on reproducible interop evidence.
+   * - Peer protection and bad-peer handling
+     - Lotus protects bootstrap/configured peers via the connection manager; Forest keeps protected peers and an explicit bad-peer/ban set in the peer manager.
+     - ``py-libp2p`` supports protected peers and connection tagging, but does not model Filecoin peer availability and bans the same way.
+     - partial
+     - Application code still needs to decide which peers are protected and how to treat degraded peers.
+     - Document the gap and keep the runtime probe outputs explicit about failure modes.
+   * - DHT protocol naming and filters
+     - Lotus uses Filecoin-specific DHT protocol naming and public query/routing-table filters; Forest configures Filecoin-specific Kademlia protocol strings.
+     - ``py-libp2p`` exposes the Filecoin DHT helper, but does not mirror Lotus routing-filter behavior.
+     - partial
+     - Filecoin DHT naming is available, but routing/filter parity is not complete.
+     - Keep the DHT helper and document the behavioural gap.
+
+Normative references:
+
+- `Lotus transport stack <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/modules/lp2p/transport.go>`_
+- `Lotus resource manager <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/modules/lp2p/rcmgr.go>`_
+- `Forest peer manager <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/peer_manager.rs>`_
+- `go-libp2p connection manager defaults <https://pkg.go.dev/github.com/libp2p/go-libp2p/p2p/net/connmgr>`_
+
+Preferred controlled workflow
+-----------------------------
+
+The preferred workflow is to run the Filecoin demos against a Lotus or Forest
+node whose multiaddr you control.
+
+1. Start Lotus or Forest with a reachable libp2p address.
+2. Capture an explicit ``/.../p2p/<peer-id>`` multiaddr for that node.
+3. Run the connect probe:
+
+   .. code-block:: console
+
+      $ filecoin-connect-demo --peer /ip4/203.0.113.10/tcp/24001/p2p/12D3KooW... --json
+
+4. Run the ping/identify probe:
+
+   .. code-block:: console
+
+      $ filecoin-ping-identify-demo --peer /ip4/203.0.113.10/tcp/24001/p2p/12D3KooW... --ping-count 3 --json
+
+5. If the node exposes Filecoin gossip on the public network, run the observer smoke test separately:
+
+   .. code-block:: console
+
+      $ filecoin-pubsub-demo --network mainnet --seconds 20 --json
+
+The controlled workflow is preferred because it gives stable evidence for
+connectivity, advertised Filecoin protocol support, and (once follow-up metadata
+wiring lands) negotiated transport/security/muxer details.
+
+Normative references:
+
+- `Lotus bootstrap and networking configuration <https://lotus.filecoin.io/lotus/configure/bootstrap/>`_
+- `Forest source tree <https://github.com/ChainSafe/forest/tree/v0.32.2/src/libp2p>`_
+
+Secondary public-network smoke workflow
+---------------------------------------
+
+When no controlled Lotus/Forest node is available, the Filecoin bootstrap set
+can still be used for quick public-network smoke checks.
+
+.. code-block:: console
+
+   $ filecoin-connect-demo --network mainnet --resolve-dns --json
+   $ filecoin-ping-identify-demo --network mainnet --resolve-dns --json
+   $ filecoin-pubsub-demo --network mainnet --seconds 5 --json
+
+This workflow is intentionally weaker evidence than the controlled workflow:
+public peers may refuse a stream, negotiate a different transport than the one
+observed on the previous run, or send malformed gossip control IDs that are
+handled defensively by the observer.
+
+Normative references:
+
+- `Filecoin node implementations overview <https://docs.filecoin.io/nodes/implementations>`_
+- `Filecoin network interface <https://spec.filecoin.io/systems/filecoin_nodes/network/>`_
+
+Interoperability matrix
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Case
+     - Target
+     - Current result
+     - Evidence path
+     - Notes
+   * - Public bootstrap connect
+     - Public Filecoin bootstrap peers
+     - pass
+     - ``filecoin-connect-demo`` JSON output
+     - Confirms runtime bootstrap dialing against public Filecoin peers.
+   * - Public ping + identify
+     - Public Filecoin peers that accept identify and ping
+     - pass
+     - ``filecoin-ping-identify-demo`` JSON output
+     - Confirms advertised Filecoin protocol IDs plus ping RTT summaries.
+   * - Lotus identify + ping (controlled)
+     - Operator-supplied Lotus node
+     - partial
+     - Explicit-peer probe steps from the controlled workflow
+     - Reproducible, but not launched in CI by this module.
+   * - Forest identify + ping (controlled)
+     - Operator-supplied Forest node
+     - partial
+     - Explicit-peer probe steps from the controlled workflow
+     - Reproducible, but not launched in CI by this module.
+   * - Read-only Filecoin gossipsub observer
+     - Public Filecoin gossip peers
+     - partial
+     - ``filecoin-pubsub-demo`` observer snapshot plus live logs
+     - Safe observer mode only; stream negotiation or malformed-control warnings are expected on some peers.
+   * - Hello runtime exchange
+     - Lotus / Forest nodes
+     - expected_gap
+     - Protocol constant and identify advertisement only
+     - The runtime Hello exchange is intentionally not implemented in this module.
+   * - ChainExchange request/response
+     - Lotus / Forest nodes
+     - expected_gap
+     - Protocol constant and identify advertisement only
+     - Full request/response behavior remains a follow-up item.
+
+Normative references:
+
+- `Lotus hello protocol <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/hello/hello.go>`_
+- `Lotus chain exchange protocol <https://github.com/filecoin-project/lotus/blob/v1.35.0/chain/exchange/protocol.go>`_
+- `Forest chain exchange behaviour <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/chain_exchange/behaviour.rs>`_
+
+Current gaps and expected failure modes
+---------------------------------------
+
+The immediate gaps that this module keeps explicit are:
+
+- Hello runtime behavior is still unimplemented.
+- ChainExchange request/response behavior is still unimplemented.
+- Generic ``py-libp2p`` connection/resource defaults do not match current
+  Filecoin node defaults.
+- Read-only gossipsub observation can succeed while still encountering
+  peer-specific stream negotiation failures or malformed control-message IDs.
+
+Expected failure modes recorded by the demos and artifact include:
+
+- connection or identify/ping failure against a specific remote peer.
+- gossipsub stream negotiation failure on a subset of public peers.
+- malformed IHAVE/IWANT control-message IDs being logged and skipped instead of crashing.
+
+Normative references:
+
+- `Lotus discovery timeout handling <https://github.com/filecoin-project/lotus/blob/v1.35.0/node/modules/lp2p/discovery.go>`_
+- `Forest discovery and peer availability handling <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/discovery.rs>`_
+- `Forest peer protection and bans <https://github.com/ChainSafe/forest/blob/v0.32.2/src/libp2p/peer_manager.rs>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ The Python implementation of the libp2p networking stack
     Connection Health Monitoring <connection_health_monitoring>
     Filecoin Architecture Positioning <filecoin_architecture_positioning>
     Filecoin Protocol Support Matrix <filecoin_protocol_support_matrix>
+    Filecoin Network Parity and Interop <filecoin_network_parity_and_interop>
     API <libp2p>
 
 .. toctree::

--- a/newsfragments/1481.docs.rst
+++ b/newsfragments/1481.docs.rst
@@ -1,0 +1,2 @@
+Document Filecoin network parity expectations versus Lotus/Forest and add a
+machine-readable interop matrix with reproducible Filecoin demo workflows.

--- a/tests/core/filecoin/test_network_parity_and_interop.py
+++ b/tests/core/filecoin/test_network_parity_and_interop.py
@@ -1,0 +1,106 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC_PATH = REPO_ROOT / "docs" / "filecoin_network_parity_and_interop.rst"
+ARTIFACT_PATH = (
+    REPO_ROOT / "artifacts" / "filecoin" / "network_parity_and_interop.v1.json"
+)
+
+REQUIRED_AUDIT_ROWS = {
+    "listen_addresses",
+    "transport_stack",
+    "security_stack_order",
+    "muxer_defaults",
+    "ping_identify_host_defaults",
+    "connection_manager_thresholds",
+    "resource_manager_defaults",
+    "bootstrap_protection",
+    "discovery_stack",
+    "idle_connection_and_redial",
+    "request_response_stream_concurrency",
+    "peer_protection_and_bans",
+    "dht_protocol_and_filters",
+    "pubsub_peer_scoring_note",
+}
+
+REQUIRED_INTEROP_CASES = {
+    "public_filecoin_bootstrap_connect",
+    "public_filecoin_ping_identify",
+    "lotus_identify_ping_tcp",
+    "forest_identify_ping_tcp",
+    "lotus_protocol_advertisement",
+    "forest_protocol_advertisement",
+    "filecoin_read_only_gossipsub_observer",
+    "hello_runtime_exchange",
+    "chain_exchange_request_response",
+}
+
+REQUIRED_HEADINGS = [
+    "Scope and evidence",
+    "Network parity audit",
+    "Preferred controlled workflow",
+    "Secondary public-network smoke workflow",
+    "Interoperability matrix",
+    "Current gaps and expected failure modes",
+]
+
+
+def _load_artifact() -> dict:
+    return json.loads(ARTIFACT_PATH.read_text(encoding="utf-8"))
+
+
+def _section_body(content: str, heading: str, next_heading: str | None) -> str:
+    start = content.index(heading) + len(heading)
+    end = content.index(next_heading, start) if next_heading else len(content)
+    return content[start:end]
+
+
+def test_network_parity_artifact_schema_and_enums() -> None:
+    artifact = _load_artifact()
+    assert artifact["meta"]["format"] == "filecoin_network_parity_and_interop.v1"
+    assert artifact["meta"]["sources"]["lotus"]["version"] == "v1.35.0"
+    assert artifact["meta"]["sources"]["forest"]["version"] == "0.32.2"
+    assert artifact["meta"]["allowed_parity_statuses"] == [
+        "aligned",
+        "partial",
+        "different",
+        "out_of_scope",
+    ]
+    assert artifact["meta"]["allowed_interop_results"] == [
+        "pass",
+        "partial",
+        "fail",
+        "expected_gap",
+    ]
+
+
+def test_network_parity_artifact_has_required_rows() -> None:
+    artifact = _load_artifact()
+    assert {
+        row["id"] for row in artifact["network_parity_audit"]
+    } == REQUIRED_AUDIT_ROWS
+    assert {row["id"] for row in artifact["interop_matrix"]} == REQUIRED_INTEROP_CASES
+
+
+def test_network_parity_doc_has_required_sections_and_links() -> None:
+    content = DOC_PATH.read_text(encoding="utf-8")
+    for heading in REQUIRED_HEADINGS:
+        assert heading in content
+
+    for index, heading in enumerate(REQUIRED_HEADINGS):
+        next_heading = (
+            REQUIRED_HEADINGS[index + 1] if index + 1 < len(REQUIRED_HEADINGS) else None
+        )
+        body = _section_body(content, heading, next_heading)
+        assert "https://" in body, f"missing normative link in section: {heading}"
+
+
+def test_network_parity_artifact_evidence_paths_exist() -> None:
+    artifact = _load_artifact()
+    for row in artifact["network_parity_audit"]:
+        for evidence in row["pylibp2p_evidence"]:
+            path = evidence.split(":")[0]
+            assert (REPO_ROOT / path).exists(), (
+                f"missing evidence path for {row['id']}: {path}"
+            )


### PR DESCRIPTION
## What was wrong?

Fixes #1481

Filecoin DX tooling landed in #1260, but Module 1 outcomes were still missing on `libp2p/py-libp2p`: defaults/lifecycle differences vs Lotus/Forest were not documented in-tree, and there was no machine-readable interop matrix with reproducible probe workflows.

Upstream Module 1 intent: [seetadev/py-libp2p#29](https://github.com/seetadev/py-libp2p/issues/29), [seetadev/py-libp2p#30](https://github.com/seetadev/py-libp2p/issues/30).

Draft [#1278](https://github.com/libp2p/py-libp2p/pull/1278) attempted this but was stale/conflicting and entangled with obsolete swarm/pubsub changes. It is superseded by this docs/artifact transplant onto current `main` (after [#1480](https://github.com/libp2p/py-libp2p/pull/1480)).

## How was it fixed?

### Summary

- Add `docs/filecoin_network_parity_and_interop.rst` covering Lotus `v1.35.0` / Forest `0.32.2` defaults parity and connection lifecycle notes.
- Add machine-readable `artifacts/filecoin/network_parity_and_interop.v1.json` with interop matrix cases and pass/partial/fail/expected_gap classification.
- Add focused schema/link tests in `tests/core/filecoin/test_network_parity_and_interop.py`.
- Wire the new page into docs index, architecture positioning, examples, and parity matrix.

### Non-goals

- Negotiated transport/security/muxer metadata in Filecoin demo JSON — tracked as [#1482](https://github.com/libp2p/py-libp2p/issues/1482)
- No changes to `libp2p/pubsub/*`, swarm, security/muxer multistream, or demo negotiated-metadata fields

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md) (`newsfragments/1481.docs.rst`)

## Test plan

- [x] `pytest tests/core/filecoin/test_network_parity_and_interop.py`
- [x] `make lint` / `make typecheck`
- [x] `make linux-docs` (includes `filecoin_network_parity_and_interop.html`)
- [ ] CI green on this PR

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/640px-Cat03.jpg)


Made with [Cursor](https://cursor.com)