### PR TITLE
test(pubsub): replace trio.sleep readiness waits with event-driven helpers

### DIFF
--- a/newsfragments/1493.internal.rst
+++ b/newsfragments/1493.internal.rst
@@ -1,0 +1,2 @@
+De-flaked pubsub tests by replacing fixed ``trio.sleep`` readiness waits with
+``wait_for_peer`` / ``wait_for_subscription`` / ``wait_for_mesh`` / payload helpers.

--- a/tests/core/pubsub/test_floodsub.py
+++ b/tests/core/pubsub/test_floodsub.py
@@ -1,7 +1,6 @@
 import functools
 
 import pytest
-import trio
 
 from libp2p.peer.id import (
     ID,
@@ -16,6 +15,10 @@ from tests.utils.pubsub.floodsub_integration_test_settings import (
     floodsub_protocol_pytest_params,
     perform_test_from_obj,
 )
+from tests.utils.pubsub.wait import (
+    wait_for,
+    wait_for_pubsub_payload,
+)
 
 
 @pytest.mark.trio
@@ -25,15 +28,15 @@ async def test_simple_two_nodes():
         data = b"some data"
 
         await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
-        await trio.sleep(0.25)
+        await pubsubs_fsub[0].wait_for_peer(pubsubs_fsub[1].my_id)
+        await pubsubs_fsub[1].wait_for_peer(pubsubs_fsub[0].my_id)
 
         sub_b = await pubsubs_fsub[1].subscribe(topic)
-        # Sleep to let a know of b's subscription
-        await trio.sleep(0.25)
+        await pubsubs_fsub[0].wait_for_subscription(pubsubs_fsub[1].my_id, topic)
 
         await pubsubs_fsub[0].publish(topic, data)
 
-        res_b = await sub_b.get()
+        res_b = await wait_for_pubsub_payload(sub_b, data)
 
         # Check that the msg received by node_b is the same
         # as the message sent by node_a
@@ -57,10 +60,11 @@ async def test_timed_cache_two_nodes():
         topic = "my_topic"
 
         await connect(pubsubs_fsub[0].host, pubsubs_fsub[1].host)
-        await trio.sleep(0.25)
+        await pubsubs_fsub[0].wait_for_peer(pubsubs_fsub[1].my_id)
+        await pubsubs_fsub[1].wait_for_peer(pubsubs_fsub[0].my_id)
 
         sub_b = await pubsubs_fsub[1].subscribe(topic)
-        await trio.sleep(0.25)
+        await pubsubs_fsub[0].wait_for_subscription(pubsubs_fsub[1].my_id, topic)
 
         def _make_testing_data(i: int) -> bytes:
             num_int_bytes = 4
@@ -70,10 +74,9 @@ async def test_timed_cache_two_nodes():
 
         for index in message_indices:
             await pubsubs_fsub[0].publish(topic, _make_testing_data(index))
-        await trio.sleep(0.25)
 
         for index in expected_received_indices:
-            res_b = await sub_b.get()
+            res_b = await wait_for_pubsub_payload(sub_b, _make_testing_data(index))
             assert res_b.data == _make_testing_data(index)
 
 
@@ -97,23 +100,29 @@ async def test_floodsub_peer_churn_subscription_resync():
         data = b"msg"
 
         sub_b = await B.subscribe(topic)
-        await trio.sleep(0.1)
 
         # Connect
         await connect(A.host, B.host)
-        await trio.sleep(0.2)
+        await A.wait_for_peer(B.my_id)
+        await B.wait_for_peer(A.my_id)
+        await A.wait_for_subscription(B.my_id, topic)
 
         # Disconnect
         await B.host.disconnect(A.host.get_id())
-        await trio.sleep(0.1)
+        await wait_for(
+            lambda: B.my_id not in A.peers and A.my_id not in B.peers,
+            fail_msg="Peers still present after disconnect",
+        )
 
         # Reconnect
         await connect(A.host, B.host)
-        await trio.sleep(0.2)
+        await A.wait_for_peer(B.my_id)
+        await B.wait_for_peer(A.my_id)
+        await A.wait_for_subscription(B.my_id, topic)
 
         # After reconnect, A must know B is subscribed
         await A.publish(topic, data)
-        msg_b = await sub_b.get()
+        msg_b = await wait_for_pubsub_payload(sub_b, data)
 
         assert msg_b.data == data
 
@@ -131,16 +140,26 @@ async def test_floodsub_dedup_loop_topology():
         await connect(A.host, B.host)
         await connect(B.host, C.host)
         await connect(C.host, A.host)
-        await trio.sleep(0.4)
+
+        await A.wait_for_peer(B.my_id)
+        await B.wait_for_peer(A.my_id)
+        await B.wait_for_peer(C.my_id)
+        await C.wait_for_peer(B.my_id)
+        await C.wait_for_peer(A.my_id)
+        await A.wait_for_peer(C.my_id)
+
+        await A.wait_for_subscription(B.my_id, topic)
+        await B.wait_for_subscription(A.my_id, topic)
+        await C.wait_for_subscription(A.my_id, topic)
+        await C.wait_for_subscription(B.my_id, topic)
 
         # publish twice
         await C.publish(topic, data)
         await C.publish(topic, data)
-        await trio.sleep(0.2)
 
         # A and B should get EXACTLY one message
-        msg_a = await sub_a.get()
-        msg_b = await sub_b.get()
+        msg_a = await wait_for_pubsub_payload(sub_a, data)
+        msg_b = await wait_for_pubsub_payload(sub_b, data)
 
         assert msg_a.data == data
         assert msg_b.data == data
@@ -155,14 +174,20 @@ async def test_subscription_sync_on_late_joiner():
         # B and C subscribe before connecting
         sub_c = await C.subscribe(topic)
         await B.subscribe(topic)
-        await trio.sleep(0.1)
 
         # Connect them AFTER subscription
         await connect(A.host, B.host)
         await connect(A.host, C.host)
-        await trio.sleep(0.3)
+
+        await A.wait_for_peer(B.my_id)
+        await B.wait_for_peer(A.my_id)
+        await A.wait_for_peer(C.my_id)
+        await C.wait_for_peer(A.my_id)
+
+        await A.wait_for_subscription(B.my_id, topic)
+        await A.wait_for_subscription(C.my_id, topic)
 
         await A.publish(topic, data)
-        msg_c = await sub_c.get()
+        msg_c = await wait_for_pubsub_payload(sub_c, data)
 
         assert msg_c.data == data

--- a/tests/core/pubsub/test_gossipsub.py
+++ b/tests/core/pubsub/test_gossipsub.py
@@ -729,6 +729,8 @@ async def test_sparse_connect():
                     f"scalability."
                 )
 
+            for pubsub in pubsubs_gsub:
+                await pubsub.unsubscribe(topic)
             nursery.cancel_scope.cancel()
 
 

--- a/tests/core/pubsub/test_gossipsub.py
+++ b/tests/core/pubsub/test_gossipsub.py
@@ -1,4 +1,5 @@
 import random
+from typing import cast
 from unittest.mock import (
     AsyncMock,
     MagicMock,
@@ -30,6 +31,10 @@ from tests.utils.pubsub.utils import (
     one_to_all_connect,
     sparse_connect,
 )
+from tests.utils.pubsub.wait import (
+    wait_for,
+    wait_for_pubsub_payload,
+)
 
 
 @pytest.mark.trio
@@ -59,15 +64,24 @@ async def test_join():
         # Connect central host to all other hosts
         await one_to_all_connect(hosts, central_node_index)
 
-        # Wait 1 seconds for heartbeat to allow mesh to connect
-        await trio.sleep(1)
+        # Wait for pubsub streams and subscriptions from subscribed peers
+        for i in subscribed_peer_indices:
+            await pubsubs_gsub[central_node_index].wait_for_peer(hosts[i].get_id())
+            await pubsubs_gsub[i].wait_for_peer(hosts[central_node_index].get_id())
+            await pubsubs_gsub[central_node_index].wait_for_subscription(
+                hosts[i].get_id(), topic
+            )
 
         # Central node publish to the topic so that this topic
         # is added to central node's fanout
         # publish from the randomly chosen host
         await pubsubs_gsub[central_node_index].publish(topic, b"data")
         await pubsubs_gsub[central_node_index].publish(to_drop_topic, b"data")
-        await trio.sleep(0.5)
+        await wait_for(
+            lambda: topic in gossipsubs[central_node_index].fanout,
+            timeout=10.0,
+            fail_msg="Fanout entry for subscribed topic not created after publish",
+        )
         # Check that the gossipsub of central node has fanout for the topics
         assert topic, to_drop_topic in gossipsubs[central_node_index].fanout
         # Check that the gossipsub of central node does not have a mesh for the topics
@@ -77,13 +91,20 @@ async def test_join():
         assert topic in gossipsubs[central_node_index].time_since_last_publish
         assert to_drop_topic in gossipsubs[central_node_index].time_since_last_publish
 
+        # Explicit TTL expiry: time_to_live=1 on the gossipsub batch
         await trio.sleep(1)
         # Check that after ttl the to_drop_topic is no more in fanout of central node
         assert to_drop_topic not in gossipsubs[central_node_index].fanout
         # Central node subscribes the topic
         await pubsubs_gsub[central_node_index].subscribe(topic)
 
-        await trio.sleep(1)
+        for i in subscribed_peer_indices:
+            await pubsubs_gsub[central_node_index].wait_for_mesh(
+                hosts[i].get_id(), topic
+            )
+            await pubsubs_gsub[i].wait_for_mesh(
+                hosts[central_node_index].get_id(), topic
+            )
 
         # Check that the gossipsub of central node no longer has fanout for the topic
         assert topic not in gossipsubs[central_node_index].fanout
@@ -134,8 +155,8 @@ async def test_handle_graft(monkeypatch):
         id_bob = pubsubs_gsub[index_bob].my_id
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
 
-        # Wait 2 seconds for heartbeat to allow mesh to connect
-        await trio.sleep(2)
+        await pubsubs_gsub[index_alice].wait_for_peer(id_bob)
+        await pubsubs_gsub[index_bob].wait_for_peer(id_alice)
 
         topic = "test_handle_graft"
         # Only lice subscribe to the topic
@@ -167,7 +188,7 @@ async def test_handle_graft(monkeypatch):
 
         await gossipsubs[index_bob].emit_graft(topic, id_alice)
 
-        await trio.sleep(1)
+        await pubsubs_gsub[index_alice].wait_for_mesh(id_bob, topic)
 
         # Check that bob is now alice's mesh peer
         assert id_bob in gossipsubs[index_alice].mesh[topic]
@@ -195,9 +216,13 @@ async def test_handle_prune():
 
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
 
-        # Wait for heartbeat to allow mesh to connect
-        # With heartbeat_interval=3, we need to wait longer for mesh establishment
-        await trio.sleep(3.5)
+        # Wait for mesh to form (heartbeat_interval=3; event wait replaces fixed sleep)
+        await pubsubs_gsub[index_alice].wait_for_peer(id_bob, timeout=10)
+        await pubsubs_gsub[index_bob].wait_for_peer(id_alice, timeout=10)
+        await pubsubs_gsub[index_alice].wait_for_subscription(id_bob, topic, timeout=10)
+        await pubsubs_gsub[index_bob].wait_for_subscription(id_alice, topic, timeout=10)
+        await pubsubs_gsub[index_alice].wait_for_mesh(id_bob, topic, timeout=10)
+        await pubsubs_gsub[index_bob].wait_for_mesh(id_alice, topic, timeout=10)
 
         # Check that they are each other's mesh peer
         assert id_alice in gossipsubs[index_bob].mesh[topic]
@@ -211,8 +236,12 @@ async def test_handle_prune():
 
         # NOTE: We increase `heartbeat_interval` to 3 seconds so that bob will not
         # add alice back to his mesh after heartbeat.
-        # Wait for bob to `handle_prune` - increased wait time for Windows compatibility
-        await trio.sleep(0.5)
+        # Wait for bob to `handle_prune`
+        await wait_for(
+            lambda: id_alice not in gossipsubs[index_bob].mesh[topic],
+            timeout=10.0,
+            fail_msg="Alice was not pruned from Bob's mesh",
+        )
 
         # Check that alice is no longer bob's mesh peer
         assert id_alice not in gossipsubs[index_bob].mesh[topic]
@@ -223,15 +252,28 @@ async def test_dense():
     async with PubsubFactory.create_batch_with_gossipsub(10) as pubsubs_gsub:
         hosts = [pubsub.host for pubsub in pubsubs_gsub]
         num_msgs = 5
+        topic = "foobar"
+        routers = [cast(GossipSub, pubsub.router) for pubsub in pubsubs_gsub]
 
         # All pubsub subscribe to foobar
-        queues = [await pubsub.subscribe("foobar") for pubsub in pubsubs_gsub]
+        queues = [await pubsub.subscribe(topic) for pubsub in pubsubs_gsub]
 
         # Densely connect libp2p hosts in a random way
         await dense_connect(hosts)
 
-        # Wait 2 seconds for heartbeat to allow mesh to connect
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(len(ps.peers) == len(hosts) - 1 for ps in pubsubs_gsub),
+            timeout=10.0,
+            fail_msg="Dense connect did not establish all peer streams",
+        )
+        await wait_for(
+            lambda: all(
+                topic in router.mesh and len(router.mesh[topic]) > 0
+                for router in routers
+            ),
+            timeout=10.0,
+            fail_msg="Dense mesh did not form",
+        )
 
         for i in range(num_msgs):
             msg_content = b"foo " + i.to_bytes(1, "big")
@@ -240,12 +282,11 @@ async def test_dense():
             origin_idx = random.randint(0, len(hosts) - 1)
 
             # publish from the randomly chosen host
-            await pubsubs_gsub[origin_idx].publish("foobar", msg_content)
+            await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-            await trio.sleep(0.5)
             # Assert that all blocking queues receive the message
             for queue in queues:
-                msg = await queue.get()
+                msg = await wait_for_pubsub_payload(queue, msg_content)
                 assert msg.data == msg_content
 
 
@@ -254,17 +295,29 @@ async def test_fanout():
     async with PubsubFactory.create_batch_with_gossipsub(10) as pubsubs_gsub:
         hosts = [pubsub.host for pubsub in pubsubs_gsub]
         num_msgs = 5
+        topic = "foobar"
+        routers = [cast(GossipSub, pubsub.router) for pubsub in pubsubs_gsub[1:]]
 
         # All pubsub subscribe to foobar except for `pubsubs_gsub[0]`
-        subs = [await pubsub.subscribe("foobar") for pubsub in pubsubs_gsub[1:]]
+        subs = [await pubsub.subscribe(topic) for pubsub in pubsubs_gsub[1:]]
 
-        # Sparsely connect libp2p hosts in random way
+        # Densely connect libp2p hosts in random way
         await dense_connect(hosts)
 
-        # Wait 2 seconds for heartbeat to allow mesh to connect
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(len(ps.peers) == len(hosts) - 1 for ps in pubsubs_gsub),
+            timeout=10.0,
+            fail_msg="Fanout dense connect did not establish all peer streams",
+        )
+        await wait_for(
+            lambda: all(
+                topic in router.mesh and len(router.mesh[topic]) > 0
+                for router in routers
+            ),
+            timeout=10.0,
+            fail_msg="Fanout mesh did not form on subscribed peers",
+        )
 
-        topic = "foobar"
         # Send messages with origin not subscribed
         for i in range(num_msgs):
             msg_content = b"foo " + i.to_bytes(1, "big")
@@ -275,14 +328,19 @@ async def test_fanout():
             # publish from the randomly chosen host
             await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-            await trio.sleep(0.5)
             # Assert that all blocking queues receive the message
             for sub in subs:
-                msg = await sub.get()
+                msg = await wait_for_pubsub_payload(sub, msg_content)
                 assert msg.data == msg_content
 
         # Subscribe message origin
         subs.insert(0, await pubsubs_gsub[0].subscribe(topic))
+        await wait_for(
+            lambda: topic in cast(GossipSub, pubsubs_gsub[0].router).mesh
+            and len(cast(GossipSub, pubsubs_gsub[0].router).mesh[topic]) > 0,
+            timeout=10.0,
+            fail_msg="Origin peer mesh did not form after subscribe",
+        )
 
         # Send messages again
         for i in range(num_msgs):
@@ -294,10 +352,9 @@ async def test_fanout():
             # publish from the randomly chosen host
             await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-            await trio.sleep(0.5)
             # Assert that all blocking queues receive the message
             for sub in subs:
-                msg = await sub.get()
+                msg = await wait_for_pubsub_payload(sub, msg_content)
                 assert msg.data == msg_content
 
 
@@ -313,17 +370,29 @@ async def test_fanout_maintenance():
         # All pubsub subscribe to foobar
         queues = []
         topic = "foobar"
+        routers = [cast(GossipSub, pubsub.router) for pubsub in pubsubs_gsub]
         for i in range(1, len(pubsubs_gsub)):
             q = await pubsubs_gsub[i].subscribe(topic)
 
             # Add each blocking queue to an array of blocking queues
             queues.append(q)
 
-        # Sparsely connect libp2p hosts in random way
+        # Densely connect libp2p hosts in random way
         await dense_connect(hosts)
 
-        # Wait 2 seconds for heartbeat to allow mesh to connect
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(len(ps.peers) == len(hosts) - 1 for ps in pubsubs_gsub),
+            timeout=10.0,
+            fail_msg="Fanout maintenance dense connect incomplete",
+        )
+        await wait_for(
+            lambda: all(
+                topic in routers[i].mesh and len(routers[i].mesh[topic]) > 0
+                for i in range(1, len(routers))
+            ),
+            timeout=10.0,
+            fail_msg="Fanout maintenance mesh did not form",
+        )
 
         # Send messages with origin not subscribed
         for i in range(num_msgs):
@@ -335,10 +404,9 @@ async def test_fanout_maintenance():
             # publish from the randomly chosen host
             await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-            await trio.sleep(0.5)
             # Assert that all blocking queues receive the message
             for queue in queues:
-                msg = await queue.get()
+                msg = await wait_for_pubsub_payload(queue, msg_content)
                 assert msg.data == msg_content
 
         for sub in pubsubs_gsub:
@@ -346,7 +414,14 @@ async def test_fanout_maintenance():
 
         queues = []
 
-        await trio.sleep(2)
+        # Wait until meshes are cleared after unsubscribe
+        await wait_for(
+            lambda: all(topic not in router.mesh for router in routers),
+            timeout=10.0,
+            fail_msg="Meshes not cleared after unsubscribe",
+        )
+        # unsubscribe_back_off=1: allow backoff window to expire before resubscribe
+        await trio.sleep(1)
 
         # Resub and repeat
         for i in range(1, len(pubsubs_gsub)):
@@ -355,7 +430,14 @@ async def test_fanout_maintenance():
             # Add each blocking queue to an array of blocking queues
             queues.append(q)
 
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(
+                topic in routers[i].mesh and len(routers[i].mesh[topic]) > 0
+                for i in range(1, len(routers))
+            ),
+            timeout=10.0,
+            fail_msg="Fanout maintenance mesh did not reform after resubscribe",
+        )
 
         # Check messages can still be sent
         for i in range(num_msgs):
@@ -367,10 +449,9 @@ async def test_fanout_maintenance():
             # publish from the randomly chosen host
             await pubsubs_gsub[origin_idx].publish(topic, msg_content)
 
-            await trio.sleep(0.5)
             # Assert that all blocking queues receive the message
             for queue in queues:
-                msg = await queue.get()
+                msg = await wait_for_pubsub_payload(queue, msg_content)
                 assert msg.data == msg_content
 
 
@@ -388,9 +469,8 @@ async def test_gossip_propagation():
         # publish from the randomly chosen host
         await pubsubs_gsub[0].publish(topic, msg_content)
 
-        await trio.sleep(0.5)
         # Assert that the blocking queues receive the message
-        msg = await queue_0.get()
+        msg = await wait_for_pubsub_payload(queue_0, msg_content)
         assert msg.data == msg_content
 
 
@@ -540,7 +620,11 @@ async def test_dense_connect_fallback():
         await sparse_connect(hosts, degree)
 
         # Wait for connections to be established
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(len(ps.peers) == len(hosts) - 1 for ps in pubsubs_gsub),
+            timeout=10.0,
+            fail_msg="Dense-fallback connections incomplete",
+        )
 
         # Verify dense topology (all nodes connected to each other)
         for i, pubsub in enumerate(pubsubs_gsub):
@@ -564,7 +648,13 @@ async def test_sparse_connect():
         await sparse_connect(hosts, degree)
 
         # Wait for connections to be established
-        await trio.sleep(2)
+        await wait_for(
+            lambda: all(
+                degree <= len(ps.peers) < len(hosts) - 1 for ps in pubsubs_gsub
+            ),
+            timeout=10.0,
+            fail_msg="Sparse connect topology not established",
+        )
 
         # Verify sparse topology
         for i, pubsub in enumerate(pubsubs_gsub):
@@ -575,39 +665,71 @@ async def test_sparse_connect():
             )
 
         # Test message propagation
-        queues = [await pubsub.subscribe(topic) for pubsub in pubsubs_gsub]
-        await trio.sleep(2)
+        received_messages: list[list] = [[] for _ in pubsubs_gsub]
+        routers = [cast(GossipSub, pubsub.router) for pubsub in pubsubs_gsub]
 
-        # Publish and verify message propagation
-        msg_content = b"test_msg"
-        await pubsubs_gsub[0].publish(topic, msg_content)
-        await trio.sleep(2)
+        async with trio.open_nursery() as nursery:
+            for i, pubsub in enumerate(pubsubs_gsub):
+                queue = await pubsub.subscribe(topic)
 
-        # Verify message propagation - ideally all nodes should receive it
-        received_count = 0
-        for queue in queues:
-            try:
-                msg = await queue.get()
-                if msg.data == msg_content:
-                    received_count += 1
-            except Exception:
-                continue
+                async def collect(idx: int, sub) -> None:
+                    try:
+                        async for message in sub:
+                            received_messages[idx].append(message)
+                    except trio.Cancelled:
+                        pass
 
-        total_nodes = len(pubsubs_gsub)
+                nursery.start_soon(collect, i, queue)
 
-        # Ideally all nodes should receive the message for optimal scalability
-        if received_count == total_nodes:
-            # Perfect propagation achieved
-            pass
-        else:
-            # require more than half for acceptable scalability
-            min_required = (total_nodes + 1) // 2
-            assert received_count >= min_required, (
-                f"Message propagation insufficient: "
-                f"{received_count}/{total_nodes} nodes "
-                f"received the message. Ideally all nodes should receive it, but at "
-                f"minimum {min_required} required for sparse network scalability."
+            await wait_for(
+                lambda: all(
+                    topic in router.mesh and len(router.mesh[topic]) > 0
+                    for router in routers
+                ),
+                timeout=10.0,
+                fail_msg="Sparse mesh did not form",
             )
+
+            # Publish and verify message propagation
+            msg_content = b"test_msg"
+            await pubsubs_gsub[0].publish(topic, msg_content)
+
+            total_nodes = len(pubsubs_gsub)
+            min_required = (total_nodes + 1) // 2
+            await wait_for(
+                lambda: sum(
+                    1
+                    for msgs in received_messages
+                    if any(msg.data == msg_content for msg in msgs)
+                )
+                >= min_required,
+                timeout=10.0,
+                fail_msg=(
+                    f"Sparse propagation below minimum {min_required}/{total_nodes}"
+                ),
+            )
+
+            received_count = sum(
+                1
+                for msgs in received_messages
+                if any(msg.data == msg_content for msg in msgs)
+            )
+
+            # Ideally all nodes should receive the message for optimal scalability
+            if received_count == total_nodes:
+                # Perfect propagation achieved
+                pass
+            else:
+                # require more than half for acceptable scalability
+                assert received_count >= min_required, (
+                    f"Message propagation insufficient: "
+                    f"{received_count}/{total_nodes} nodes "
+                    f"received the message. Ideally all nodes should receive it, "
+                    f"but at minimum {min_required} required for sparse network "
+                    f"scalability."
+                )
+
+            nursery.cancel_scope.cancel()
 
 
 @pytest.mark.trio
@@ -619,7 +741,11 @@ async def test_connect_some_with_fewer_hosts_than_degree():
         degree = 5
 
         await connect_some(hosts, degree)
-        await trio.sleep(0.1)  # Allow connections to establish
+        await wait_for(
+            lambda: all(len(ps.peers) == len(hosts) - 1 for ps in pubsubs_fsub),
+            timeout=10.0,
+            fail_msg="connect_some did not connect all peers when n < degree",
+        )
 
         # Each host should connect to all other hosts (since there are only 2 others)
         for i, pubsub in enumerate(pubsubs_fsub):
@@ -640,7 +766,11 @@ async def test_connect_some_degree_limit_enforced():
         degree = 2
 
         await connect_some(hosts, degree)
-        await trio.sleep(0.1)
+        await wait_for(
+            lambda: len(pubsubs_fsub[0].peers) == degree,
+            timeout=10.0,
+            fail_msg="connect_some degree limit not reflected in peer map",
+        )
 
         # With 6 hosts and degree=2, expected connections:
         # Host 0 → connects to hosts 1,2 (2 peers total)
@@ -688,7 +818,12 @@ async def test_connect_some_degree_zero():
         degree = 0
 
         await connect_some(hosts, degree)
-        await trio.sleep(0.1)  # Allow any potential connections to establish
+        # degree=0 should leave peer maps empty (no readiness sleep needed)
+        await wait_for(
+            lambda: all(len(ps.peers) == 0 for ps in pubsubs_fsub),
+            timeout=5.0,
+            fail_msg="Unexpected peers after degree=0 connect_some",
+        )
 
         # Verify no connections were made
         for i, pubsub in enumerate(pubsubs_fsub):
@@ -708,7 +843,11 @@ async def test_connect_some_negative_degree():
         degree = -1
 
         await connect_some(hosts, degree)
-        await trio.sleep(0.1)  # Allow any potential connections to establish
+        await wait_for(
+            lambda: all(len(ps.peers) == 0 for ps in pubsubs_fsub),
+            timeout=5.0,
+            fail_msg="Unexpected peers after negative-degree connect_some",
+        )
 
         # Verify no connections were made (negative degree should behave like 0)
         for i, pubsub in enumerate(pubsubs_fsub):
@@ -727,7 +866,12 @@ async def test_sparse_connect_degree_zero():
         degree = 0
 
         await sparse_connect(hosts, degree)
-        await trio.sleep(0.1)  # Allow connections to establish
+        expected_neighbors = 2  # previous and next in ring
+        await wait_for(
+            lambda: all(len(ps.peers) >= expected_neighbors for ps in pubsubs_fsub),
+            timeout=10.0,
+            fail_msg="sparse_connect degree=0 neighbor links missing",
+        )
 
         # With degree=0, sparse_connect should still create neighbor connections
         # for connectivity (this is part of the algorithm design)
@@ -735,7 +879,6 @@ async def test_sparse_connect_degree_zero():
             connected_peers = len(pubsub.peers)
             # Should have some connections due to neighbor connectivity
             # (each node connects to immediate neighbors)
-            expected_neighbors = 2  # previous and next in ring
             assert connected_peers >= expected_neighbors, (
                 f"Host {i} has {connected_peers} connections, "
                 f"expected at least {expected_neighbors} neighbor connections"
@@ -788,7 +931,8 @@ async def test_handle_ihave(monkeypatch):
 
         # Connect Alice and Bob
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
-        await trio.sleep(0.1)  # Allow connections to establish
+        await pubsubs_gsub[index_alice].wait_for_peer(id_bob)
+        await pubsubs_gsub[index_bob].wait_for_peer(pubsubs_gsub[index_alice].my_id)
 
         # Mock emit_iwant to capture calls
         mock_emit_iwant = AsyncMock()
@@ -851,13 +995,8 @@ async def test_handle_iwant(monkeypatch):
         # Connect Alice and Bob
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
 
-        # Test stability fix: use wait_until_ready() and poll for peer
-        # registration instead of a fixed sleep to avoid flaky failures.
-        await pubsubs_gsub[index_bob].wait_until_ready()
-
-        with trio.fail_after(2.0):
-            while id_alice not in pubsubs_gsub[index_bob].peers:
-                await trio.sleep(0.01)
+        # Wait for peer registration (event-driven; replaces fixed sleep / poll loop)
+        await pubsubs_gsub[index_bob].wait_for_peer(id_alice)
 
         # Mock mcache.get to return a message
         test_message = rpc_pb2.Message(data=b"test_data")
@@ -919,7 +1058,7 @@ async def test_handle_iwant_invalid_msg_id(monkeypatch):
         id_alice = pubsubs_gsub[index_alice].my_id
 
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
-        await trio.sleep(0.1)
+        await pubsubs_gsub[index_bob].wait_for_peer(id_alice)
 
         mock_send_rpc = MagicMock()
         monkeypatch.setattr(gossipsubs[index_bob], "send_rpc", mock_send_rpc)
@@ -969,11 +1108,7 @@ async def test_handle_iwant_mixed_valid_and_invalid_msg_ids(monkeypatch):
         id_alice = pubsubs_gsub[index_alice].my_id
 
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
-        await pubsubs_gsub[index_bob].wait_until_ready()
-
-        with trio.fail_after(2.0):
-            while id_alice not in pubsubs_gsub[index_bob].peers:
-                await trio.sleep(0.01)
+        await pubsubs_gsub[index_bob].wait_for_peer(id_alice)
 
         test_message = rpc_pb2.Message(data=b"test_data")
         test_seqno = b"1234"
@@ -1023,7 +1158,8 @@ async def test_handle_ihave_empty_message_ids(monkeypatch):
 
         # Connect Alice and Bob
         await connect(pubsubs_gsub[index_alice].host, pubsubs_gsub[index_bob].host)
-        await trio.sleep(0.1)  # Allow connections to establish
+        await pubsubs_gsub[index_alice].wait_for_peer(id_bob)
+        await pubsubs_gsub[index_bob].wait_for_peer(pubsubs_gsub[index_alice].my_id)
 
         # Mock emit_iwant to capture calls
         mock_emit_iwant = AsyncMock()

--- a/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
+++ b/tests/core/pubsub/test_gossipsub_identify_aware_publish.py
@@ -582,15 +582,13 @@ async def test_three_nodes_publish_before_full_mesh():
         # Publish immediately from A
         await pubsubs[0].publish(topic, data)
 
-        # Wait for propagation through the chain
-        await trio.sleep(4)
-
+        # Wait for multi-hop propagation through the chain (event-driven)
         received = False
-        with trio.move_on_after(3):
-            async for msg in sub_c:
-                if msg.data == data:
-                    received = True
-                    break
+        try:
+            await wait_for_pubsub_payload(sub_c, data, timeout=10.0)
+            received = True
+        except AssertionError:
+            received = False
 
         # Note: multi-hop propagation before full mesh is timing-dependent.
         # We intentionally do NOT assert here; the primary regression test

--- a/tests/core/pubsub/test_gossipsub_px_and_backoff.py
+++ b/tests/core/pubsub/test_gossipsub_px_and_backoff.py
@@ -10,6 +10,7 @@ from libp2p.tools.utils import (
 from tests.utils.factories import (
     PubsubFactory,
 )
+from tests.utils.pubsub.wait import wait_for
 
 
 @pytest.mark.trio
@@ -28,35 +29,40 @@ async def test_prune_backoff():
 
         # connect hosts
         await connect(host_0, host_1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host_1.get_id())
+        await pubsubs[1].wait_for_peer(host_0.get_id())
 
         # both join the topic
         await gsub0.join(topic)
         await gsub1.join(topic)
         await gsub0.emit_graft(topic, host_1.get_id())
-        await trio.sleep(0.5)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic)
 
         # ensure peer is registered in mesh
         assert host_0.get_id() in gsub1.mesh[topic]
 
         # prune host_1 from gsub0's mesh
         await gsub0.emit_prune(topic, host_1.get_id(), False, False)
-        await trio.sleep(0.5)
+        await wait_for(
+            lambda: host_0.get_id() not in gsub1.mesh.get(topic, set()),
+            fail_msg="peer should leave mesh after prune",
+        )
 
         # host_0 should not be in gsub1's mesh
         assert host_0.get_id() not in gsub1.mesh[topic]
 
         # try to graft again immediately (should be rejected due to backoff)
         await gsub0.emit_graft(topic, host_1.get_id())
+        # Negative-assert race window: allow rejected GRAFT/PRUNE to settle
         await trio.sleep(0.5)
         assert host_0.get_id() not in gsub1.mesh[topic], (
             "peer should be backoffed and not re-added"
         )
 
         # try to graft again (should succeed after backoff)
-        await trio.sleep(2)
+        await trio.sleep(2)  # prune_back_off expiry
         await gsub0.emit_graft(topic, host_1.get_id())
-        await trio.sleep(1)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic)
         assert host_0.get_id() in gsub1.mesh[topic], (
             "peer should be able to rejoin after backoff"
         )
@@ -78,29 +84,29 @@ async def test_unsubscribe_backoff():
 
         # connect hosts
         await connect(host_0, host_1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host_1.get_id())
+        await pubsubs[1].wait_for_peer(host_0.get_id())
 
         # both join the topic
         await gsub0.join(topic)
         await gsub1.join(topic)
         await gsub0.emit_graft(topic, host_1.get_id())
-        await trio.sleep(0.5)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic)
 
         # ensure peer is registered in mesh
         assert host_0.get_id() in gsub1.mesh[topic]
 
         # host_1 unsubscribes from the topic
         await gsub1.leave(topic)
-        await trio.sleep(0.5)
         assert topic not in gsub1.mesh
 
         # host_1 resubscribes to the topic
         await gsub1.join(topic)
-        await trio.sleep(0.5)
         assert topic in gsub1.mesh
 
         # try to graft again immediately (should be rejected due to backoff)
         await gsub0.emit_graft(topic, host_1.get_id())
+        # Negative-assert race window: allow rejected GRAFT/PRUNE to settle
         await trio.sleep(0.5)
         assert host_0.get_id() not in gsub1.mesh[topic], (
             "peer should be backoffed and not re-added"
@@ -110,7 +116,7 @@ async def test_unsubscribe_backoff():
         # Wait longer than unsubscribe_back_off (4 seconds) + some buffer
         await trio.sleep(4.5)
         await gsub0.emit_graft(topic, host_1.get_id())
-        await trio.sleep(1)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic)
         assert host_0.get_id() in gsub1.mesh[topic], (
             "peer should be able to rejoin after backoff"
         )
@@ -140,17 +146,23 @@ async def test_peer_exchange():
         await connect(host_1, host_0)
         await connect(host_1, host_2)
         await connect(host_0, host_2)  # Add connection so host_0 knows about host_2
-        await trio.sleep(0.5)
+        for i, j in ((0, 1), (1, 2), (0, 2)):
+            await pubsubs[i].wait_for_peer(pubsubs[j].my_id)
+            await pubsubs[j].wait_for_peer(pubsubs[i].my_id)
 
         # all join the topic and 0 <-> 1 and 1 <-> 2 graft
         await pubsubs[1].subscribe(topic)
         await pubsubs[0].subscribe(topic)
         await pubsubs[2].subscribe(topic)
+        for i, j in ((0, 1), (1, 2), (0, 2)):
+            await pubsubs[i].wait_for_subscription(pubsubs[j].my_id, topic)
+            await pubsubs[j].wait_for_subscription(pubsubs[i].my_id, topic)
         await gsub1.emit_graft(topic, host_0.get_id())
         await gsub1.emit_graft(topic, host_2.get_id())
         await gsub0.emit_graft(topic, host_1.get_id())
         await gsub2.emit_graft(topic, host_1.get_id())
-        await trio.sleep(1)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic)
+        await pubsubs[1].wait_for_mesh(host_2.get_id(), topic)
 
         # ensure peer is registered in mesh
         assert host_0.get_id() in gsub1.mesh[topic]
@@ -158,7 +170,10 @@ async def test_peer_exchange():
 
         # Disconnect host_0 and host_2 to simulate PX scenario
         await host_0.disconnect(host_2.get_id())
-        await trio.sleep(0.5)
+        await wait_for(
+            lambda: host_2.get_id() not in pubsubs[0].peers,
+            fail_msg="host_2 should leave pubsub peers after disconnect",
+        )
 
         # Remove host_2 from host_0's mesh if it exists
         if host_2.get_id() in gsub0.mesh.get(topic, set()):
@@ -170,11 +185,10 @@ async def test_peer_exchange():
 
         # host_1 unsubscribes from the topic
         await gsub1.leave(topic)
-        await trio.sleep(1)  # Wait for heartbeat to update mesh
         assert topic not in gsub1.mesh
 
         # Wait for gsub0 to graft host_2 into its mesh via PX
-        await trio.sleep(1)
+        await pubsubs[0].wait_for_mesh(host_2.get_id(), topic)
         assert host_2.get_id() in gsub0.mesh[topic]
 
 
@@ -195,7 +209,8 @@ async def test_topics_are_isolated():
 
         # connect hosts
         await connect(host_0, host_1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host_1.get_id())
+        await pubsubs[1].wait_for_peer(host_0.get_id())
 
         # both peers join both the topics
         await gsub0.join(topic1)
@@ -203,14 +218,17 @@ async def test_topics_are_isolated():
         await gsub0.join(topic2)
         await gsub1.join(topic2)
         await gsub0.emit_graft(topic1, host_1.get_id())
-        await trio.sleep(0.5)
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic1)
 
         # ensure topic1 for peer is registered in mesh
         assert host_0.get_id() in gsub1.mesh[topic1]
 
         # prune topic1 for host_1 from gsub0's mesh
         await gsub0.emit_prune(topic1, host_1.get_id(), False, False)
-        await trio.sleep(0.5)
+        await wait_for(
+            lambda: host_0.get_id() not in gsub1.mesh.get(topic1, set()),
+            fail_msg="peer should leave topic1 mesh after prune",
+        )
 
         # topic1 for host_0 should not be in gsub1's mesh
         assert host_0.get_id() not in gsub1.mesh[topic1]
@@ -218,6 +236,8 @@ async def test_topics_are_isolated():
         # try to regraft topic1 and graft new topic2
         await gsub0.emit_graft(topic1, host_1.get_id())
         await gsub0.emit_graft(topic2, host_1.get_id())
+        await pubsubs[1].wait_for_mesh(host_0.get_id(), topic2)
+        # Negative-assert race window for backoffed topic1
         await trio.sleep(0.5)
         assert host_0.get_id() not in gsub1.mesh[topic1], (
             "peer should be backoffed and not re-added"
@@ -250,12 +270,18 @@ async def test_stress_churn():
         for i in range(NUM_PEERS):
             for j in range(i + 1, NUM_PEERS):
                 await connect(hosts[i], hosts[j])
-        await trio.sleep(1)
+        for i in range(NUM_PEERS):
+            for j in range(i + 1, NUM_PEERS):
+                await pubsubs[i].wait_for_peer(hosts[j].get_id())
+                await pubsubs[j].wait_for_peer(hosts[i].get_id())
 
         # all peers join the topic
         for router in routers:
             await router.join(TOPIC)
-        await trio.sleep(1)
+        await wait_for(
+            lambda: all(TOPIC in router.mesh for router in routers),
+            fail_msg="all routers should have joined the topic",
+        )
 
         # rapid join/prune cycles
         for cycle in range(CHURN_CYCLES):
@@ -264,12 +290,14 @@ async def test_stress_churn():
                 for j, peer_host in enumerate(hosts):
                     if i != j:
                         await router.emit_prune(TOPIC, peer_host.get_id(), False, False)
+            # Churn pacing between prune and graft bursts
             await trio.sleep(0.1)
             for i, router in enumerate(routers):
                 # graft all other peers back
                 for j, peer_host in enumerate(hosts):
                     if i != j:
                         await router.emit_graft(TOPIC, peer_host.get_id())
+            # Churn pacing between cycles
             await trio.sleep(0.1)
 
         # wait for backoff entries to expire and cleanup

--- a/tests/core/pubsub/test_gossipsub_v12_integration.py
+++ b/tests/core/pubsub/test_gossipsub_v12_integration.py
@@ -2,7 +2,6 @@ from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID_V12,
@@ -15,6 +14,7 @@ from libp2p.tools.utils import (
 from tests.utils.factories import (
     PubsubFactory,
 )
+from tests.utils.pubsub.wait import wait_for
 
 
 @pytest.mark.trio
@@ -40,23 +40,33 @@ async def test_idontwant_message_exchange():
         for router in routers:
             assert isinstance(router, GossipSub)
 
-        # Connect all nodes
-        await connect(pubsubs[0].host, pubsubs[1].host)
-        await connect(pubsubs[1].host, pubsubs[2].host)
-        await connect(pubsubs[0].host, pubsubs[2].host)
-        await trio.sleep(0.1)  # Allow connections to establish
-
-        # Subscribe all nodes to the test topic
-        for pubsub in pubsubs:
-            await pubsub.subscribe(topic)
-        await trio.sleep(0.5)  # Allow mesh to form
-
-        # Set up the mesh manually to ensure a specific topology
-        # Node 0 and 1 are in Node 2's mesh
         peer0_id = pubsubs[0].host.get_id()
         peer1_id = pubsubs[1].host.get_id()
         peer2_id = pubsubs[2].host.get_id()
 
+        # Connect all nodes
+        await connect(pubsubs[0].host, pubsubs[1].host)
+        await connect(pubsubs[1].host, pubsubs[2].host)
+        await connect(pubsubs[0].host, pubsubs[2].host)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer2_id, timeout=10)
+        await pubsubs[2].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[0].wait_for_peer(peer2_id, timeout=10)
+        await pubsubs[2].wait_for_peer(peer0_id, timeout=10)
+
+        # Subscribe all nodes to the test topic
+        for pubsub in pubsubs:
+            await pubsub.subscribe(topic)
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[0].wait_for_subscription(peer2_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer2_id, topic, timeout=10)
+        await pubsubs[2].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[2].wait_for_subscription(peer1_id, topic, timeout=10)
+
+        # Set up the mesh manually to ensure a specific topology
+        # Node 0 and 1 are in Node 2's mesh
         for router in routers:
             router.mesh[topic] = set()
 
@@ -96,7 +106,11 @@ async def test_idontwant_message_exchange():
             await routers[1].publish(peer0_id, msg)
 
             # Verify Node 1 emitted IDONTWANT to its mesh peers
-            await trio.sleep(0.1)  # Allow async operations to complete
+            await wait_for(
+                lambda: mock_emit.called,
+                timeout=10.0,
+                fail_msg="emit_idontwant was not called after publish",
+            )
 
             # Check that emit_idontwant was called for Node 2
             mock_emit.assert_called()
@@ -137,11 +151,20 @@ async def test_idontwant_integration_with_end_to_end_message():
     ) as pubsubs:
         topic = "test_topic"
 
+        peer0_id = pubsubs[0].host.get_id()
+        peer1_id = pubsubs[1].host.get_id()
+        peer2_id = pubsubs[2].host.get_id()
+
         # Connect all nodes
         await connect(pubsubs[0].host, pubsubs[1].host)
         await connect(pubsubs[1].host, pubsubs[2].host)
         await connect(pubsubs[0].host, pubsubs[2].host)
-        await trio.sleep(0.1)  # Allow connections to establish
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer2_id, timeout=10)
+        await pubsubs[2].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[0].wait_for_peer(peer2_id, timeout=10)
+        await pubsubs[2].wait_for_peer(peer0_id, timeout=10)
 
         # Set protocol versions for all peers
         for i, pubsub in enumerate(pubsubs):
@@ -167,9 +190,6 @@ async def test_idontwant_integration_with_end_to_end_message():
         msg_id = pubsubs[0].get_message_id(msg)
 
         # Manually add the message ID to Node 0's don't_send list for Node 2
-        peer1_id = pubsubs[1].host.get_id()
-        peer2_id = pubsubs[2].host.get_id()
-
         # Cast to GossipSub to access implementation-specific attributes
         gossipsub_router = cast(GossipSub, pubsubs[0].router)
         if peer2_id not in gossipsub_router.dont_send_message_ids:

--- a/tests/core/pubsub/test_gossipsub_v14_adaptive_gossip.py
+++ b/tests/core/pubsub/test_gossipsub_v14_adaptive_gossip.py
@@ -11,7 +11,6 @@ This module tests the adaptive gossip dissemination features in v1.4, including:
 import time
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID_V14,
@@ -20,6 +19,7 @@ from libp2p.pubsub.gossipsub import (
 from libp2p.pubsub.score import ScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for
 
 
 @pytest.mark.trio
@@ -61,13 +61,23 @@ async def test_network_health_calculation():
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
         await connect(pubsubs[1].host, pubsubs[2].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
 
         # Subscribe to topic to form mesh
         topic = "health-test"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_mesh(pubsubs[1].my_id, topic)
 
         # Trigger health update
         router0 = routers[0]
@@ -92,13 +102,21 @@ async def test_connectivity_health_calculation():
         # Connect all peers
         for i in range(1, 10):
             await connect(pubsubs[0].host, pubsubs[i].host)
-        await trio.sleep(0.5)
+            await pubsubs[0].wait_for_peer(pubsubs[i].my_id)
+            await pubsubs[i].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe to topic
         topic = "connectivity-test"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)
+        for i in range(1, 10):
+            await pubsubs[0].wait_for_subscription(pubsubs[i].my_id, topic)
+            await pubsubs[i].wait_for_subscription(pubsubs[0].my_id, topic)
+        # Mesh degree is bounded; wait until host0 has some mesh peers
+        await wait_for(
+            lambda: len(router.mesh.get(topic, set())) > 0,
+            fail_msg="mesh should form for connectivity health test",
+        )
 
         # Calculate health with good connectivity
         # Force health update by resetting the timer
@@ -137,13 +155,17 @@ async def test_peer_score_health_calculation():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe to topic
         topic = "score-health-test"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
         # Calculate health with good scores
         router._update_network_health()
@@ -276,13 +298,26 @@ async def test_mesh_degree_adaptation_in_heartbeat():
         # Connect all peers
         for i in range(1, 5):
             await connect(pubsubs[0].host, pubsubs[i].host)
-        await trio.sleep(0.5)
+            await pubsubs[0].wait_for_peer(pubsubs[i].my_id)
+            await pubsubs[i].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe to topic
         topic = "adaptive-mesh-test"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)
+        for i in range(1, 5):
+            await pubsubs[0].wait_for_subscription(pubsubs[i].my_id, topic)
+            await pubsubs[i].wait_for_subscription(pubsubs[0].my_id, topic)
+
+        degree_low = router.degree_low
+
+        def _mesh_at_degree_low() -> bool:
+            return len(router.mesh.get(topic, set())) >= degree_low
+
+        await wait_for(
+            _mesh_at_degree_low,
+            fail_msg="mesh should reach at least degree_low peers",
+        )
 
         # Set poor health to trigger adaptation
         router.network_health_score = 0.2
@@ -292,11 +327,22 @@ async def test_mesh_degree_adaptation_in_heartbeat():
         assert router.adaptive_degree_low > router.degree_low
         assert router.adaptive_degree_high > router.degree_high
 
-        # Let heartbeat run with adaptive parameters
-        await trio.sleep(2.0)
+        # Let heartbeat run with adaptive parameters; mesh should stay within
+        # the adapted high bound (or available peer count).
+        adaptive_high = router.adaptive_degree_high
 
-        # Mesh should adapt to use new parameters
-        # (Exact verification depends on peer availability and mesh formation)
+        def _mesh_within_adaptive_bounds() -> bool:
+            if topic not in router.mesh:
+                return False
+            mesh_size = len(router.mesh[topic])
+            return mesh_size <= adaptive_high and mesh_size >= min(
+                degree_low, mesh_size
+            )
+
+        await wait_for(
+            _mesh_within_adaptive_bounds,
+            fail_msg="mesh should settle under adaptive degree bounds",
+        )
 
 
 @pytest.mark.trio
@@ -310,18 +356,31 @@ async def test_message_delivery_tracking():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe to topic
         topic = "delivery-tracking-test"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
         # Publish messages to track deliveries
         for i in range(3):
             await pubsubs[0].publish(topic, f"message {i}".encode())
-            await trio.sleep(0.2)
+
+        deliveries = router.recent_message_deliveries
+
+        def _deliveries_tracked() -> bool:
+            return len(deliveries.get(topic, [])) > 0
+
+        await wait_for(
+            _deliveries_tracked,
+            fail_msg="message deliveries should be tracked",
+        )
 
         # Verify delivery tracking
         assert topic in router.recent_message_deliveries

--- a/tests/core/pubsub/test_gossipsub_v14_core_functionality.py
+++ b/tests/core/pubsub/test_gossipsub_v14_core_functionality.py
@@ -8,7 +8,6 @@ This module tests the core functionality of GossipSub v1.4, including:
 """
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID_V13,
@@ -18,6 +17,7 @@ from libp2p.pubsub.gossipsub import (
 from libp2p.pubsub.score import ScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for_pubsub_payload
 
 
 @pytest.mark.trio
@@ -53,20 +53,21 @@ async def test_v14_protocol_feature_detection():
         router = pubsubs_gsub[0].router
         assert isinstance(router, GossipSub)
 
+        peer0_id = pubsubs_gsub[0].host.get_id()
+        peer1_id = pubsubs_gsub[1].host.get_id()
+
         # Connect peers
         await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
-        await trio.sleep(0.5)
-
-        # Get peer ID
-        peer_id = pubsubs_gsub[1].host.get_id()
+        await pubsubs_gsub[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs_gsub[1].wait_for_peer(peer0_id, timeout=10)
 
         # Test v1.4 feature detection
-        assert router.supports_protocol_feature(peer_id, "extensions")
-        assert router.supports_protocol_feature(peer_id, "adaptive_gossip")
-        assert router.supports_protocol_feature(peer_id, "extended_scoring")
-        assert router.supports_protocol_feature(peer_id, "idontwant")
-        assert router.supports_protocol_feature(peer_id, "scoring")
-        assert router.supports_protocol_feature(peer_id, "px")
+        assert router.supports_protocol_feature(peer1_id, "extensions")
+        assert router.supports_protocol_feature(peer1_id, "adaptive_gossip")
+        assert router.supports_protocol_feature(peer1_id, "extended_scoring")
+        assert router.supports_protocol_feature(peer1_id, "idontwant")
+        assert router.supports_protocol_feature(peer1_id, "scoring")
+        assert router.supports_protocol_feature(peer1_id, "px")
 
 
 @pytest.mark.trio
@@ -78,20 +79,21 @@ async def test_v13_protocol_feature_detection():
         router = pubsubs_gsub[0].router
         assert isinstance(router, GossipSub)
 
+        peer0_id = pubsubs_gsub[0].host.get_id()
+        peer1_id = pubsubs_gsub[1].host.get_id()
+
         # Connect peers
         await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
-        await trio.sleep(0.5)
-
-        # Get peer ID
-        peer_id = pubsubs_gsub[1].host.get_id()
+        await pubsubs_gsub[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs_gsub[1].wait_for_peer(peer0_id, timeout=10)
 
         # Test v1.3 feature detection
-        assert router.supports_protocol_feature(peer_id, "extensions")
-        assert not router.supports_protocol_feature(peer_id, "adaptive_gossip")
-        assert not router.supports_protocol_feature(peer_id, "extended_scoring")
-        assert router.supports_protocol_feature(peer_id, "idontwant")
-        assert router.supports_protocol_feature(peer_id, "scoring")
-        assert router.supports_protocol_feature(peer_id, "px")
+        assert router.supports_protocol_feature(peer1_id, "extensions")
+        assert not router.supports_protocol_feature(peer1_id, "adaptive_gossip")
+        assert not router.supports_protocol_feature(peer1_id, "extended_scoring")
+        assert router.supports_protocol_feature(peer1_id, "idontwant")
+        assert router.supports_protocol_feature(peer1_id, "scoring")
+        assert router.supports_protocol_feature(peer1_id, "px")
 
 
 @pytest.mark.trio
@@ -103,11 +105,14 @@ async def test_supports_scoring_includes_v13_v14():
         router = pubsubs_gsub[0].router
         assert isinstance(router, GossipSub)
 
-        await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
-        await trio.sleep(0.5)
+        peer0_id = pubsubs_gsub[0].host.get_id()
+        peer1_id = pubsubs_gsub[1].host.get_id()
 
-        peer_id = pubsubs_gsub[1].host.get_id()
-        assert router.supports_scoring(peer_id), "v1.3 peers must support scoring"
+        await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
+        await pubsubs_gsub[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs_gsub[1].wait_for_peer(peer0_id, timeout=10)
+
+        assert router.supports_scoring(peer1_id), "v1.3 peers must support scoring"
 
     async with PubsubFactory.create_batch_with_gossipsub(
         2, protocols=[PROTOCOL_ID_V14]
@@ -115,11 +120,14 @@ async def test_supports_scoring_includes_v13_v14():
         router = pubsubs_gsub[0].router
         assert isinstance(router, GossipSub)
 
-        await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
-        await trio.sleep(0.5)
+        peer0_id = pubsubs_gsub[0].host.get_id()
+        peer1_id = pubsubs_gsub[1].host.get_id()
 
-        peer_id = pubsubs_gsub[1].host.get_id()
-        assert router.supports_scoring(peer_id), "v1.4 peers must support scoring"
+        await connect(pubsubs_gsub[0].host, pubsubs_gsub[1].host)
+        await pubsubs_gsub[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs_gsub[1].wait_for_peer(peer0_id, timeout=10)
+
+        assert router.supports_scoring(peer1_id), "v1.4 peers must support scoring"
 
 
 @pytest.mark.trio
@@ -146,10 +154,17 @@ async def test_message_propagation_with_v14_features():
         for gsub in gsubs:
             assert isinstance(gsub, GossipSub)
 
+        peer0_id = hosts[0].get_id()
+        peer1_id = hosts[1].get_id()
+        peer2_id = hosts[2].get_id()
+
         # Connect hosts in a line: 0 -- 1 -- 2
         await connect(hosts[0], hosts[1])
         await connect(hosts[1], hosts[2])
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer2_id, timeout=10)
+        await pubsubs[2].wait_for_peer(peer1_id, timeout=10)
 
         # All hosts subscribe to the same topic
         topic = "test_v14_propagation"
@@ -157,7 +172,14 @@ async def test_message_propagation_with_v14_features():
         for pubsub in pubsubs:
             queue = await pubsub.subscribe(topic)
             queues.append(queue)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer2_id, topic, timeout=10)
+        await pubsubs[2].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer2_id, topic, timeout=10)
+        await pubsubs[2].wait_for_mesh(peer1_id, topic, timeout=10)
 
         # Verify that mesh has been formed
         for i, gsub in enumerate(gsubs):
@@ -168,13 +190,9 @@ async def test_message_propagation_with_v14_features():
         test_message = b"test v1.4 message"
         await pubsubs[0].publish(topic, test_message)
 
-        # Wait for message propagation
-        await trio.sleep(1.0)
-
         # Verify all peers received the message
-        for i, queue in enumerate(queues):
-            msg = await queue.get()
-            assert msg.data == test_message
+        for queue in queues:
+            await wait_for_pubsub_payload(queue, test_message, timeout=10.0)
 
 
 @pytest.mark.trio
@@ -185,24 +203,29 @@ async def test_backward_compatibility_v14_to_v12():
     async with PubsubFactory.create_batch_with_gossipsub(
         2, protocols=[PROTOCOL_ID_V14, PROTOCOL_ID_V12]
     ) as pubsubs:
+        peer0_id = pubsubs[0].host.get_id()
+        peer1_id = pubsubs[1].host.get_id()
+
         # Connect the peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
 
         # Subscribe to topic
         topic = "compatibility_test"
         queue1 = await pubsubs[1].subscribe(topic)
         await pubsubs[0].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
 
         # Publish message from v1.4 peer
         test_message = b"v1.4 to v1.2 message"
         await pubsubs[0].publish(topic, test_message)
-        await trio.sleep(0.5)
 
         # Verify v1.2 peer received the message
-        msg = await queue1.get()
-        assert msg.data == test_message
+        await wait_for_pubsub_payload(queue1, test_message, timeout=10.0)
 
 
 @pytest.mark.trio

--- a/tests/core/pubsub/test_gossipsub_v14_extensions.py
+++ b/tests/core/pubsub/test_gossipsub_v14_extensions.py
@@ -76,7 +76,8 @@ async def test_extension_message_handling():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Get peer IDs
         peer1_id = pubsubs[1].host.get_id()
@@ -86,8 +87,8 @@ async def test_extension_message_handling():
         test_data = b"test extension data"
         await router0.emit_extension("test-ext", test_data, peer1_id)
 
-        # Wait for message processing
-        await trio.sleep(0.5)
+        # No observable delivery side-effect (emit is a no-op); brief settle
+        await trio.sleep(0.1)
 
         # No extension data is delivered over the wire (only hello carries
         # control.extensions), so the handler is never called.
@@ -107,7 +108,8 @@ async def test_extension_message_to_unsupported_peer():
 
         # Connect peers (one v1.4, one v1.1)
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Try to send extension to v1.1 peer (should be ignored)
         peer1_id = pubsubs[1].host.get_id()
@@ -144,14 +146,15 @@ async def test_extension_handler_error_handling():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # emit_extension is a no-op; should complete without raising
         peer1_id = pubsubs[1].host.get_id()
         await router0.emit_extension("failing-ext", b"data", peer1_id)
 
-        # Wait for processing
-        await trio.sleep(0.5)
+        # No observable side-effect; brief settle before negative assert
+        await trio.sleep(0.1)
 
         # Handler is never called (no extension data is sent over the wire)
         assert error_count[0] == 0
@@ -170,14 +173,16 @@ async def test_unregistered_extension_handling():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Send extension message for unregistered extension
         peer1_id = pubsubs[1].host.get_id()
 
         # This should not raise an error, just log a debug message
         await router0.emit_extension("unregistered-ext", b"data", peer1_id)
-        await trio.sleep(0.5)
+        # emit_extension is a no-op; brief settle with no observable flag
+        await trio.sleep(0.1)
 
 
 @pytest.mark.trio
@@ -195,8 +200,11 @@ async def test_extension_message_from_unsupported_peer():
             v14_router = v14_pubsubs[0].router
             assert isinstance(v14_router, GossipSub)
 
+            # Distinct protocol sets may not negotiate a pubsub stream, so
+            # wait_for_peer can hang; network connect + brief settle is enough
+            # because this test injects peer_protocol and calls handle_rpc.
             await connect(v14_pubsubs[0].host, v11_pubsubs[0].host)
-            await trio.sleep(0.5)
+            await trio.sleep(0.1)
 
             # Simulate v1.1 peer: router thinks this peer speaks v1.1 only
             v11_peer_id = v11_pubsubs[0].host.get_id()
@@ -250,15 +258,16 @@ async def test_multiple_extension_handlers():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # emit_extension is a no-op for both; should complete without raising
         peer1_id = pubsubs[1].host.get_id()
         await router0.emit_extension("ext1", b"data1", peer1_id)
         await router0.emit_extension("ext2", b"data2", peer1_id)
 
-        # Wait for processing
-        await trio.sleep(0.5)
+        # No observable delivery; brief settle before negative assert
+        await trio.sleep(0.1)
 
         # No extension data is delivered, so neither handler is called
         assert len(received_messages) == 0
@@ -291,15 +300,16 @@ async def test_extension_v13_compatibility():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # emit_extension is a no-op; should complete without raising
         peer1_id = pubsubs[1].host.get_id()
         test_data = b"v1.3 extension data"
         await router0.emit_extension("v13-ext", test_data, peer1_id)
 
-        # Wait for processing
-        await trio.sleep(0.5)
+        # No observable delivery; brief settle before negative assert
+        await trio.sleep(0.1)
 
         # No extension data is delivered over the wire
         assert len(received_extensions) == 0

--- a/tests/core/pubsub/test_gossipsub_v14_message_id.py
+++ b/tests/core/pubsub/test_gossipsub_v14_message_id.py
@@ -12,7 +12,6 @@ import base64
 import hashlib
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID_V14,
@@ -29,6 +28,7 @@ from libp2p.pubsub.pubsub import (
 )
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for_pubsub_payload
 
 
 def create_test_message() -> rpc_pb2.Message:
@@ -162,24 +162,29 @@ async def test_pubsub_with_message_id_generator():
     async with PubsubFactory.create_batch_with_gossipsub(
         2, protocols=[PROTOCOL_ID_V14], msg_id_constructor=generator
     ) as pubsubs:
+        peer0_id = pubsubs[0].host.get_id()
+        peer1_id = pubsubs[1].host.get_id()
+
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
 
         # Subscribe to topic
         topic = "generator-test"
         queue1 = await pubsubs[1].subscribe(topic)
         await pubsubs[0].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
 
         # Publish message
         test_data = b"test message for generator"
         await pubsubs[0].publish(topic, test_data)
-        await trio.sleep(0.5)
 
         # Verify message was received
-        msg = await queue1.get()
-        assert msg.data == test_data
+        await wait_for_pubsub_payload(queue1, test_data, timeout=10.0)
 
 
 @pytest.mark.trio
@@ -192,24 +197,29 @@ async def test_pubsub_with_callable_msg_id():
     async with PubsubFactory.create_batch_with_gossipsub(
         2, protocols=[PROTOCOL_ID_V14], msg_id_constructor=custom_msg_id
     ) as pubsubs:
+        peer0_id = pubsubs[0].host.get_id()
+        peer1_id = pubsubs[1].host.get_id()
+
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
 
         # Subscribe to topic
         topic = "callable-test"
         queue1 = await pubsubs[1].subscribe(topic)
         await pubsubs[0].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
 
         # Publish message
         test_data = b"test message for callable"
         await pubsubs[0].publish(topic, test_data)
-        await trio.sleep(0.5)
 
         # Verify message was received
-        msg = await queue1.get()
-        assert msg.data == test_data
+        await wait_for_pubsub_payload(queue1, test_data, timeout=10.0)
 
 
 @pytest.mark.trio
@@ -278,25 +288,30 @@ async def test_message_id_deduplication():
     async with PubsubFactory.create_batch_with_gossipsub(
         2, protocols=[PROTOCOL_ID_V14], msg_id_constructor=content_gen
     ) as pubsubs:
+        peer0_id = pubsubs[0].host.get_id()
+        peer1_id = pubsubs[1].host.get_id()
+
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+        await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
 
         # Subscribe to topic
         topic = "dedup-test"
         queue1 = await pubsubs[1].subscribe(topic)
         await pubsubs[0].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+        await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+        await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
 
         # Publish same message twice
         test_data = b"duplicate message"
         await pubsubs[0].publish(topic, test_data)
         await pubsubs[0].publish(topic, test_data)
-        await trio.sleep(0.5)
 
         # With content-addressed IDs, should receive at least one message
-        msg = await queue1.get()
-        assert msg.data == test_data
+        await wait_for_pubsub_payload(queue1, test_data, timeout=10.0)
         # Note: Exact deduplication behavior depends on implementation details
 
 

--- a/tests/core/pubsub/test_gossipsub_v14_rate_limiting.py
+++ b/tests/core/pubsub/test_gossipsub_v14_rate_limiting.py
@@ -20,6 +20,7 @@ from libp2p.pubsub.gossipsub import (
 from libp2p.pubsub.pb import rpc_pb2
 from libp2p.tools.utils import connect
 from tests.utils.factories import IDFactory, PubsubFactory
+from tests.utils.pubsub.wait import wait_for
 
 
 @pytest.mark.trio
@@ -157,24 +158,46 @@ async def test_iwant_rate_limiting_integration():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe to topic
         topic = "rate-limit-test"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
         # Publish several messages quickly to trigger IWANT requests
         for i in range(5):
             await pubsubs[0].publish(topic, f"message {i}".encode())
+            # Rate-limit pacing window under test
             await trio.sleep(0.1)
 
-        # Wait for processing
-        await trio.sleep(1.0)
+        peer0_id = pubsubs[0].host.get_id()
+
+        # Wait for IWANT rate-limit tracking to observe requests (if any)
+        # Mesh delivery may not always produce IWANTs; preserve original
+        # conditional assert by only waiting briefly then checking.
+        iwant_limits = router1.iwant_request_limits
+
+        def _iwant_tracked() -> bool:
+            return (
+                peer0_id in iwant_limits and len(iwant_limits[peer0_id]["requests"]) > 0
+            )
+
+        try:
+            await wait_for(
+                _iwant_tracked,
+                timeout=3.0,
+                fail_msg="IWANT rate-limit tracking not observed",
+            )
+        except TimeoutError:
+            pass
 
         # Check if rate limiting was applied
-        peer0_id = pubsubs[0].host.get_id()
         if peer0_id in router1.iwant_request_limits:
             # Some requests should have been made
             assert len(router1.iwant_request_limits[peer0_id]["requests"]) > 0
@@ -196,21 +219,38 @@ async def test_ihave_rate_limiting_integration():
         # Connect in a line: 0 -- 1 -- 2
         await connect(pubsubs[0].host, pubsubs[1].host)
         await connect(pubsubs[1].host, pubsubs[2].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
 
-        # Subscribe to topic
+        # Subscribe to topic (peer 1 stays unsubscribed to force gossip)
         topic = "ihave-rate-test"
         await pubsubs[0].subscribe(topic)
-        await pubsubs[2].subscribe(topic)  # Don't subscribe peer 1 to force gossip
-        await trio.sleep(1.0)
+        await pubsubs[2].subscribe(topic)
 
         # Publish several messages to trigger IHAVE gossip
         for i in range(5):
             await pubsubs[0].publish(topic, f"gossip message {i}".encode())
+            # Rate-limit pacing window under test
             await trio.sleep(0.2)
 
-        # Wait for gossip processing
-        await trio.sleep(2.0)
+        # Wait for gossip / IHAVE rate-limit bookkeeping if it appears
+        def _any_ihave_tracked() -> bool:
+            for router in routers:
+                assert isinstance(router, GossipSub)
+                if router.ihave_message_limits:
+                    return True
+            return False
+
+        try:
+            await wait_for(
+                _any_ihave_tracked,
+                timeout=5.0,
+                fail_msg="IHAVE rate-limit tracking not observed",
+            )
+        except TimeoutError:
+            pass
 
         # Rate limiting should have been applied during gossip
         # (Exact verification depends on gossip timing)
@@ -232,13 +272,17 @@ async def test_graft_flood_protection_integration():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Subscribe and form mesh
         topic = "graft-flood-test"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
         # Manually trigger PRUNE to set up flood protection
         peer0_id = pubsubs[0].host.get_id()

--- a/tests/core/pubsub/test_gossipsub_v14_scoring.py
+++ b/tests/core/pubsub/test_gossipsub_v14_scoring.py
@@ -9,7 +9,6 @@ This module tests the enhanced peer scoring system in v1.4, including:
 """
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import (
     PROTOCOL_ID_V14,
@@ -236,7 +235,8 @@ async def test_scoring_integration_with_rate_limiting():
 
         # Connect peers
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].host.get_id())
+        await pubsubs[1].wait_for_peer(pubsubs[0].host.get_id())
 
         peer0_id = pubsubs[0].host.get_id()
 

--- a/tests/core/pubsub/test_gossipsub_v1_1_core_functionality.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_core_functionality.py
@@ -7,12 +7,12 @@ This module tests the core functionality of GossipSub v1.1, including:
 """
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.pubsub.score import ScoreParams, TopicScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for_pubsub_payload
 
 
 @pytest.mark.trio
@@ -32,13 +32,24 @@ async def test_message_propagation_normal_mesh():
         # Connect hosts in a line: 0 -- 1 -- 2
         await connect(hosts[0], hosts[1])
         await connect(hosts[1], hosts[2])
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
 
         # All hosts subscribe to the same topic
         topic = "test_message_propagation"
+        subs = []
         for pubsub in pubsubs:
-            await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+            subs.append(await pubsub.subscribe(topic))
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_mesh(pubsubs[1].my_id, topic)
 
         # Verify that mesh has been formed
         for i, gsub in enumerate(gsubs):
@@ -48,12 +59,14 @@ async def test_message_propagation_normal_mesh():
         # Host 0 publishes a message
         test_message = b"test message from host 0"
         await pubsubs[0].publish(topic, test_message)
-        await trio.sleep(1.0)
+        await wait_for_pubsub_payload(subs[1], test_message)
+        await wait_for_pubsub_payload(subs[2], test_message)
 
         # Host 2 publishes a message
         test_message_2 = b"test message from host 2"
         await pubsubs[2].publish(topic, test_message_2)
-        await trio.sleep(1.0)
+        await wait_for_pubsub_payload(subs[1], test_message_2)
+        await wait_for_pubsub_payload(subs[0], test_message_2)
 
         # Verify mesh is still intact
         for i, gsub in enumerate(gsubs):
@@ -83,13 +96,17 @@ async def test_interop_with_gossipsub_v1_0():
 
             # Connect v1.0 and v1.1 hosts
             await connect(v1_0_host, v1_1_host)
-            await trio.sleep(0.5)
+            await v1_0_pubsubs[0].wait_for_peer(v1_1_pubsubs[0].my_id)
+            await v1_1_pubsubs[0].wait_for_peer(v1_0_pubsubs[0].my_id)
 
             # Both subscribe to the same topic
             topic = "test_interop"
-            await v1_0_pubsubs[0].subscribe(topic)
-            await v1_1_pubsubs[0].subscribe(topic)
-            await trio.sleep(1.0)  # Allow time for mesh formation
+            sub_v1_0 = await v1_0_pubsubs[0].subscribe(topic)
+            sub_v1_1 = await v1_1_pubsubs[0].subscribe(topic)
+            await v1_0_pubsubs[0].wait_for_subscription(v1_1_pubsubs[0].my_id, topic)
+            await v1_1_pubsubs[0].wait_for_subscription(v1_0_pubsubs[0].my_id, topic)
+            await v1_0_pubsubs[0].wait_for_mesh(v1_1_pubsubs[0].my_id, topic)
+            await v1_1_pubsubs[0].wait_for_mesh(v1_0_pubsubs[0].my_id, topic)
 
             # Verify that they've formed a mesh
             assert v1_1_host.get_id() in v1_0_gsub.mesh.get(topic, set())
@@ -98,12 +115,12 @@ async def test_interop_with_gossipsub_v1_0():
             # Test message exchange from v1.0 to v1.1
             test_message = b"test message from v1.0"
             await v1_0_pubsubs[0].publish(topic, test_message)
-            await trio.sleep(0.5)
+            await wait_for_pubsub_payload(sub_v1_1, test_message)
 
             # Test message exchange from v1.1 to v1.0
             test_message_2 = b"test message from v1.1"
             await v1_1_pubsubs[0].publish(topic, test_message_2)
-            await trio.sleep(0.5)
+            await wait_for_pubsub_payload(sub_v1_0, test_message_2)
 
 
 @pytest.mark.trio
@@ -135,13 +152,17 @@ async def test_graceful_fallback_with_v1_0_peers():
 
             # Connect v1.0 and v1.1 hosts
             await connect(v1_0_host, v1_1_host)
-            await trio.sleep(0.5)
+            await v1_0_pubsubs[0].wait_for_peer(v1_1_pubsubs[0].my_id)
+            await v1_1_pubsubs[0].wait_for_peer(v1_0_pubsubs[0].my_id)
 
             # Both subscribe to the same topic
             topic = "test_fallback"
-            await v1_0_pubsubs[0].subscribe(topic)
-            await v1_1_pubsubs[0].subscribe(topic)
-            await trio.sleep(1.0)  # Allow time for mesh formation
+            sub_v1_0 = await v1_0_pubsubs[0].subscribe(topic)
+            sub_v1_1 = await v1_1_pubsubs[0].subscribe(topic)
+            await v1_0_pubsubs[0].wait_for_subscription(v1_1_pubsubs[0].my_id, topic)
+            await v1_1_pubsubs[0].wait_for_subscription(v1_0_pubsubs[0].my_id, topic)
+            await v1_0_pubsubs[0].wait_for_mesh(v1_1_pubsubs[0].my_id, topic)
+            await v1_1_pubsubs[0].wait_for_mesh(v1_0_pubsubs[0].my_id, topic)
 
             # Verify that they've formed a mesh
             assert v1_1_host.get_id() in v1_0_gsub.mesh.get(topic, set())
@@ -161,13 +182,20 @@ async def test_graceful_fallback_with_v1_0_peers():
                 new_score = v1_1_gsub.scorer.score(v1_0_host.get_id(), [topic])
                 assert new_score > initial_score
 
+                # push_msg applies allow_publish to the local forwarder (self).
+                # With publish_threshold=0.5 an unscored self is rejected, so
+                # credit the local peer before exercising publish.
+                v1_1_gsub.scorer.on_join_mesh(v1_1_pubsubs[0].my_id, topic)
+                assert v1_1_gsub.scorer.allow_publish(v1_1_pubsubs[0].my_id, [topic])
+                assert v1_1_gsub.scorer.allow_publish(v1_0_host.get_id(), [topic])
+
             # Test message exchange works in both directions
             # v1.0 to v1.1
             test_message = b"test message from v1.0"
             await v1_0_pubsubs[0].publish(topic, test_message)
-            await trio.sleep(0.5)
+            await wait_for_pubsub_payload(sub_v1_1, test_message)
 
             # v1.1 to v1.0
             test_message_2 = b"test message from v1.1"
             await v1_1_pubsubs[0].publish(topic, test_message_2)
-            await trio.sleep(0.5)
+            await wait_for_pubsub_payload(sub_v1_0, test_message_2)

--- a/tests/core/pubsub/test_gossipsub_v1_1_flood_publishing.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_flood_publishing.py
@@ -255,67 +255,50 @@ async def test_flood_publish_with_high_frequency():
                 await connect(hosts[i], hosts[j])
         await _wait_full_mesh_peers(pubsubs)
 
-        # All peers subscribe to the topic
         topic = "test_flood_publish_high_frequency"
-        received_messages = [[] for _ in range(len(pubsubs))]
+        # Publisher also subscribes so mesh forms symmetrically; receivers keep
+        # subscription handles for delivery waits (avoid background nursery cancel
+        # races that close the Swarm service nursery under CI load).
+        await pubsubs[0].subscribe(topic)
+        subs = []
+        for i in range(1, len(pubsubs)):
+            subs.append(await pubsubs[i].subscribe(topic))
+
+        edges = [
+            (i, j) for i in range(len(pubsubs)) for j in range(i + 1, len(pubsubs))
+        ]
+        await _wait_topic_ready(pubsubs, topic, edges)
+
+        # Publish multiple messages in rapid succession
+        num_messages = 10
+        messages = [f"rapid_message_{i}".encode() for i in range(num_messages)]
+        for message_data in messages:
+            await pubsubs[0].publish(topic, message_data)
+
+        # We don't expect perfect delivery under high load — require >= 70%.
+        min_needed = int(num_messages * 0.7)
+        expected = set(messages)
+
+        async def _wait_peer_enough(sub, peer_index: int) -> None:
+            got: set[bytes] = set()
+            try:
+                with trio.fail_after(10.0):
+                    async for msg in sub:
+                        if msg.data in expected:
+                            got.add(msg.data)
+                            if len(got) >= min_needed:
+                                return
+            except trio.TooSlowError as exc:
+                raise AssertionError(
+                    f"Peer {peer_index} received too few high-frequency messages "
+                    f"(need >= {min_needed}/{num_messages}, got {len(got)})"
+                ) from exc
 
         async with trio.open_nursery() as nursery:
-            # Subscribe all peers to the topic
-            for i in range(len(pubsubs)):
-                subscription = await pubsubs[i].subscribe(topic)
+            for i, sub in enumerate(subs, start=1):
+                nursery.start_soon(_wait_peer_enough, sub, i)
 
-                # Create a task to collect messages
-                async def collect_messages(index, sub):
-                    try:
-                        async for message in sub:
-                            received_messages[index].append(message)
-                    except trio.Cancelled:
-                        pass
-
-                # Start the collection task in the background
-                nursery.start_soon(collect_messages, i, subscription)
-
-            edges = [
-                (i, j) for i in range(len(pubsubs)) for j in range(i + 1, len(pubsubs))
-            ]
-            await _wait_topic_ready(pubsubs, topic, edges)
-
-            # Publish multiple messages in rapid succession
-            num_messages = 10
-            messages = []
-            for i in range(num_messages):
-                message_data = f"rapid_message_{i}".encode()
-                messages.append(message_data)
-                await pubsubs[0].publish(topic, message_data)
-                # No delay between publishes to test high frequency
-
-            # Verify that peers received most of the messages
-            # We don't expect perfect delivery under high load
-            for i in range(1, len(pubsubs)):
-                peer_msgs = received_messages[i]
-                threshold = num_messages * 0.7
-
-                def _enough_received(
-                    msgs: list = peer_msgs,
-                    need: float = threshold,
-                ) -> bool:
-                    return (
-                        sum(
-                            1
-                            for msg_data in messages
-                            if any(msg.data == msg_data for msg in msgs)
-                        )
-                        >= need
-                    )
-
-                await wait_for(
-                    _enough_received,
-                    timeout=10.0,
-                    fail_msg=(
-                        f"Peer {i} received too few high-frequency messages "
-                        f"(need >= {num_messages * 0.7:.0f}/{num_messages})"
-                    ),
-                )
-
-            # Cancel all background tasks before exiting
-            nursery.cancel_scope.cancel()
+        # Stop pubsub delivery before factory teardown so late messages cannot
+        # schedule push_msg on an already-closing Swarm nursery.
+        for ps in pubsubs:
+            await ps.unsubscribe(topic)

--- a/tests/core/pubsub/test_gossipsub_v1_1_flood_publishing.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_flood_publishing.py
@@ -10,6 +10,58 @@ import trio
 
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import (
+    wait_for,
+    wait_for_pubsub_payload,
+    wait_for_pubsub_payloads,
+)
+
+
+async def _wait_star_peers(pubsubs) -> None:
+    """Wait until hub peer 0 has pubsub streams with every spoke."""
+    for i in range(1, len(pubsubs)):
+        await pubsubs[0].wait_for_peer(pubsubs[i].my_id)
+        await pubsubs[i].wait_for_peer(pubsubs[0].my_id)
+
+
+async def _wait_line_peers(pubsubs) -> None:
+    """Wait until each adjacent pair in a line topology is connected."""
+    for i in range(len(pubsubs) - 1):
+        await pubsubs[i].wait_for_peer(pubsubs[i + 1].my_id)
+        await pubsubs[i + 1].wait_for_peer(pubsubs[i].my_id)
+
+
+async def _wait_full_mesh_peers(pubsubs) -> None:
+    """Wait until every pair has a pubsub stream."""
+    for i in range(len(pubsubs)):
+        for j in range(i + 1, len(pubsubs)):
+            await pubsubs[i].wait_for_peer(pubsubs[j].my_id)
+            await pubsubs[j].wait_for_peer(pubsubs[i].my_id)
+
+
+async def _wait_topic_ready(pubsubs, topic: str, edges: list[tuple[int, int]]) -> None:
+    """Wait for peer subscriptions on each edge, then non-empty local meshes."""
+    for i, j in edges:
+        await pubsubs[i].wait_for_subscription(pubsubs[j].my_id, topic)
+        await pubsubs[j].wait_for_subscription(pubsubs[i].my_id, topic)
+
+    subscribed = [ps for ps in pubsubs if topic in ps.topic_ids]
+    if not subscribed:
+        return
+
+    await wait_for(
+        lambda: all(
+            topic in cast_mesh(ps) and len(cast_mesh(ps)[topic]) > 0
+            for ps in subscribed
+        ),
+        timeout=10.0,
+        fail_msg=f"Mesh for {topic!r} did not form on subscribed peers",
+    )
+
+
+def cast_mesh(pubsub):
+    """Return router.mesh for mesh-readiness predicates."""
+    return pubsub.router.mesh
 
 
 @pytest.mark.trio
@@ -25,46 +77,28 @@ async def test_publish_from_non_mesh_peer():
         # but others don't connect to each other directly
         for i in range(1, len(hosts)):
             await connect(hosts[0], hosts[i])
-        await trio.sleep(0.5)
+        await _wait_star_peers(pubsubs)
 
         # Only peers 1-4 subscribe to the topic
         topic = "test_flood_publish"
-        received_messages = [[] for _ in range(len(pubsubs))]
+        subs = []
+        for i in range(1, len(pubsubs)):
+            subs.append(await pubsubs[i].subscribe(topic))
 
-        async with trio.open_nursery() as nursery:
-            # Subscribe peers 1-4 to the topic
-            subscriptions = []
-            for i in range(1, len(pubsubs)):
-                subscription = await pubsubs[i].subscribe(topic)
-                subscriptions.append(subscription)
+        # Publisher is not subscribed; wait until it sees spoke subscriptions.
+        for i in range(1, len(pubsubs)):
+            await pubsubs[0].wait_for_subscription(pubsubs[i].my_id, topic)
 
-                # Create a task to collect messages
-                async def collect_messages(index, sub):
-                    try:
-                        async for message in sub:
-                            received_messages[index].append(message)
-                    except trio.Cancelled:
-                        pass
+        # Peer 0 is not subscribed but will publish to the topic
+        message_data = b"flood published message"
+        await pubsubs[0].publish(topic, message_data)
 
-                # Start the collection task in the background
-                nursery.start_soon(collect_messages, i, subscription)
-
-            await trio.sleep(1.0)  # Allow time for mesh formation
-
-            # Peer 0 is not subscribed but will publish to the topic
-            message_data = b"flood published message"
-            await pubsubs[0].publish(topic, message_data)
-
-            # Allow time for message propagation
-            await trio.sleep(2.0)
-
-            # Verify that all subscribed peers received the message
-            for i in range(1, len(pubsubs)):
-                assert len(received_messages[i]) > 0
-                assert any(msg.data == message_data for msg in received_messages[i])
-
-            # Cancel all background tasks before exiting
-            nursery.cancel_scope.cancel()
+        for i, sub in enumerate(subs, start=1):
+            await wait_for_pubsub_payload(
+                sub,
+                message_data,
+                fail_msg=f"Peer {i} did not receive flood-published message",
+            )
 
 
 @pytest.mark.trio
@@ -79,52 +113,27 @@ async def test_flood_publish_with_mesh_formation():
         # Connect in a line topology: 0 - 1 - 2 - 3
         for i in range(len(hosts) - 1):
             await connect(hosts[i], hosts[i + 1])
-        await trio.sleep(0.5)
+        await _wait_line_peers(pubsubs)
 
         # All peers subscribe to the topic
         topic = "test_flood_publish_mesh_formation"
-        received_messages = [[] for _ in range(len(pubsubs))]
+        subs = []
+        for pubsub in pubsubs:
+            subs.append(await pubsub.subscribe(topic))
 
-        # Start collecting messages in the background
-        async with trio.open_nursery() as nursery:
-            # Subscribe all peers to the topic
-            subscriptions = []
-            for i in range(len(pubsubs)):
-                subscription = await pubsubs[i].subscribe(topic)
-                subscriptions.append(subscription)
+        edges = [(i, i + 1) for i in range(len(pubsubs) - 1)]
+        await _wait_topic_ready(pubsubs, topic, edges)
 
-                # Start a background task to collect messages for this peer
-                async def collect_messages(peer_index, sub):
-                    try:
-                        async for message in sub:
-                            received_messages[peer_index].append(message)
-                    except trio.Cancelled:
-                        pass
+        # Publish after mesh readiness on the line
+        message_data = b"early message"
+        await pubsubs[0].publish(topic, message_data)
 
-                nursery.start_soon(collect_messages, i, subscription)
-
-            # Wait for subscriptions to be processed and mesh to form
-            await trio.sleep(1.0)
-
-            # Publish after allowing some time for initial mesh formation
-            message_data = b"early message"
-            await pubsubs[0].publish(topic, message_data)
-
-            # Allow time for message propagation
-            await trio.sleep(2.0)
-
-            # Verify that peers received the message
-            # In a line topology (0-1-2-3), with gossipsub mesh, at least the publisher
-            # and its direct neighbors should receive the message
-            received_count = sum(
-                1
-                for msgs in received_messages
-                if any(msg.data == message_data for msg in msgs)
-            )
-            assert received_count >= 1  # At least the publisher should receive it
-
-            # Cancel all background tasks before exiting
-            nursery.cancel_scope.cancel()
+        # In a line topology, at least the publisher should receive the message
+        await wait_for_pubsub_payload(
+            subs[0],
+            message_data,
+            fail_msg="Publisher did not receive its own early message",
+        )
 
 
 @pytest.mark.trio
@@ -143,52 +152,37 @@ async def test_flood_publish_reliability():
         await connect(hosts[1], hosts[2])
         await connect(hosts[3], hosts[4])
         await connect(hosts[4], hosts[5])
-        await trio.sleep(0.5)
+        await _wait_star_peers(pubsubs)
+        await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[3].wait_for_peer(pubsubs[4].my_id)
+        await pubsubs[4].wait_for_peer(pubsubs[3].my_id)
+        await pubsubs[4].wait_for_peer(pubsubs[5].my_id)
+        await pubsubs[5].wait_for_peer(pubsubs[4].my_id)
 
         # All peers subscribe to the topic
         topic = "test_flood_publish_reliability"
-        received_messages = [[] for _ in range(len(pubsubs))]
+        subs = []
+        for pubsub in pubsubs:
+            subs.append(await pubsub.subscribe(topic))
 
-        async with trio.open_nursery() as nursery:
-            # Subscribe all peers to the topic
-            subscriptions = []
-            for i in range(len(pubsubs)):
-                subscription = await pubsubs[i].subscribe(topic)
-                subscriptions.append(subscription)
+        edges = [(0, i) for i in range(1, len(pubsubs))] + [(1, 2), (3, 4), (4, 5)]
+        await _wait_topic_ready(pubsubs, topic, edges)
 
-                # Create a task to collect messages
-                async def collect_messages(index, sub):
-                    try:
-                        async for message in sub:
-                            received_messages[index].append(message)
-                    except trio.Cancelled:
-                        pass
+        # Publish multiple messages from different peers
+        messages = []
+        for i in range(3):
+            message_data = f"message_{i}".encode()
+            messages.append(message_data)
+            await pubsubs[i].publish(topic, message_data)
 
-                # Start the collection task in the background
-                nursery.start_soon(collect_messages, i, subscription)
-
-            await trio.sleep(1.0)  # Allow time for mesh formation
-
-            # Publish multiple messages from different peers
-            messages = []
-            for i in range(3):
-                message_data = f"message_{i}".encode()
-                messages.append(message_data)
-                await pubsubs[i].publish(topic, message_data)
-                await trio.sleep(0.2)  # Small delay between publishes
-
-            # Allow time for message propagation
-            await trio.sleep(2.0)
-
-            # Verify that all peers received all messages
-            for peer_msgs in received_messages:
-                for msg_data in messages:
-                    assert any(msg.data == msg_data for msg in peer_msgs), (
-                        f"Message {msg_data} not received by a peer"
-                    )
-
-            # Cancel all background tasks before exiting
-            nursery.cancel_scope.cancel()
+        # Verify that all peers received all messages
+        for i, sub in enumerate(subs):
+            await wait_for_pubsub_payloads(
+                sub,
+                messages,
+                fail_msg=f"Peer {i} missing one or more reliability messages",
+            )
 
 
 @pytest.mark.trio
@@ -206,62 +200,44 @@ async def test_flood_publish_with_disconnected_peers():
         await connect(hosts[0], hosts[2])
         await connect(hosts[3], hosts[2])
         await connect(hosts[3], hosts[4])
-        await trio.sleep(0.5)
+        for i, j in [(0, 1), (0, 2), (3, 2), (3, 4)]:
+            await pubsubs[i].wait_for_peer(pubsubs[j].my_id)
+            await pubsubs[j].wait_for_peer(pubsubs[i].my_id)
 
         # All peers subscribe to the topic
         topic = "test_flood_publish_disconnected"
-        received_messages = [[] for _ in range(len(pubsubs))]
+        subs = []
+        for pubsub in pubsubs:
+            subs.append(await pubsub.subscribe(topic))
 
-        async with trio.open_nursery() as nursery:
-            # Subscribe all peers to the topic
-            subscriptions = []
-            for i in range(len(pubsubs)):
-                subscription = await pubsubs[i].subscribe(topic)
-                subscriptions.append(subscription)
+        edges = [(0, 1), (0, 2), (3, 2), (3, 4)]
+        await _wait_topic_ready(pubsubs, topic, edges)
 
-                # Create a task to collect messages
-                async def collect_messages(index, sub):
-                    try:
-                        async for message in sub:
-                            received_messages[index].append(message)
-                    except trio.Cancelled:
-                        pass
+        # Publish from peer 0
+        message_data = b"message from peer 0"
+        await pubsubs[0].publish(topic, message_data)
 
-                # Start the collection task in the background
-                nursery.start_soon(collect_messages, i, subscription)
+        # Verify that peers 0, 1, 2 received the message
+        # (peers 3, 4 might not receive it due to network topology)
+        for i in range(3):
+            await wait_for_pubsub_payload(
+                subs[i],
+                message_data,
+                fail_msg=f"Peer {i} did not receive the message",
+            )
 
-            await trio.sleep(1.0)  # Allow time for mesh formation
+        # Publish from peer 4
+        message_data = b"message from peer 4"
+        await pubsubs[4].publish(topic, message_data)
 
-            # Publish from peer 0
-            message_data = b"message from peer 0"
-            await pubsubs[0].publish(topic, message_data)
-
-            # Allow time for message propagation
-            await trio.sleep(2.0)
-
-            # Verify that peers 0, 1, 2 received the message
-            # (peers 3, 4 might not receive it due to network topology)
-            for i in range(3):
-                assert any(msg.data == message_data for msg in received_messages[i]), (
-                    f"Peer {i} did not receive the message"
-                )
-
-            # Publish from peer 4
-            message_data = b"message from peer 4"
-            await pubsubs[4].publish(topic, message_data)
-
-            # Allow time for message propagation
-            await trio.sleep(2.0)
-
-            # Verify that peers 2, 3, 4 received the message
-            # (peers 0, 1 might not receive it due to network topology)
-            for i in [2, 3, 4]:
-                assert any(msg.data == message_data for msg in received_messages[i]), (
-                    f"Peer {i} did not receive the message"
-                )
-
-            # Cancel all background tasks before exiting
-            nursery.cancel_scope.cancel()
+        # Verify that peers 2, 3, 4 received the message
+        # (peers 0, 1 might not receive it due to network topology)
+        for i in [2, 3, 4]:
+            await wait_for_pubsub_payload(
+                subs[i],
+                message_data,
+                fail_msg=f"Peer {i} did not receive the message",
+            )
 
 
 @pytest.mark.trio
@@ -277,7 +253,7 @@ async def test_flood_publish_with_high_frequency():
         for i in range(len(hosts)):
             for j in range(i + 1, len(hosts)):
                 await connect(hosts[i], hosts[j])
-        await trio.sleep(0.5)
+        await _wait_full_mesh_peers(pubsubs)
 
         # All peers subscribe to the topic
         topic = "test_flood_publish_high_frequency"
@@ -285,10 +261,8 @@ async def test_flood_publish_with_high_frequency():
 
         async with trio.open_nursery() as nursery:
             # Subscribe all peers to the topic
-            subscriptions = []
             for i in range(len(pubsubs)):
                 subscription = await pubsubs[i].subscribe(topic)
-                subscriptions.append(subscription)
 
                 # Create a task to collect messages
                 async def collect_messages(index, sub):
@@ -301,7 +275,10 @@ async def test_flood_publish_with_high_frequency():
                 # Start the collection task in the background
                 nursery.start_soon(collect_messages, i, subscription)
 
-            await trio.sleep(1.0)  # Allow time for mesh formation
+            edges = [
+                (i, j) for i in range(len(pubsubs)) for j in range(i + 1, len(pubsubs))
+            ]
+            await _wait_topic_ready(pubsubs, topic, edges)
 
             # Publish multiple messages in rapid succession
             num_messages = 10
@@ -312,21 +289,32 @@ async def test_flood_publish_with_high_frequency():
                 await pubsubs[0].publish(topic, message_data)
                 # No delay between publishes to test high frequency
 
-            # Allow time for message propagation
-            await trio.sleep(3.0)
-
             # Verify that peers received most of the messages
             # We don't expect perfect delivery under high load
             for i in range(1, len(pubsubs)):
-                received_count = 0
-                for msg_data in messages:
-                    if any(msg.data == msg_data for msg in received_messages[i]):
-                        received_count += 1
+                peer_msgs = received_messages[i]
+                threshold = num_messages * 0.7
 
-                # At least 70% of messages should be received
-                assert received_count >= num_messages * 0.7, (
-                    f"Peer {i} received too few messages: "
-                    f"{received_count}/{num_messages}"
+                def _enough_received(
+                    msgs: list = peer_msgs,
+                    need: float = threshold,
+                ) -> bool:
+                    return (
+                        sum(
+                            1
+                            for msg_data in messages
+                            if any(msg.data == msg_data for msg in msgs)
+                        )
+                        >= need
+                    )
+
+                await wait_for(
+                    _enough_received,
+                    timeout=10.0,
+                    fail_msg=(
+                        f"Peer {i} received too few high-frequency messages "
+                        f"(need >= {num_messages * 0.7:.0f}/{num_messages})"
+                    ),
                 )
 
             # Cancel all background tasks before exiting

--- a/tests/core/pubsub/test_gossipsub_v1_1_ihave_iwant.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_ihave_iwant.py
@@ -10,12 +10,20 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.pubsub.pb import rpc_pb2
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+
+
+async def _wait_pair_ready(pubsubs, topic: str) -> None:
+    await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+    await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+    await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+    await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
 
 @pytest.mark.trio
@@ -29,13 +37,14 @@ async def test_ihave_triggers_iwant_for_missing_messages():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Both subscribe to the same topic
         topic = "test_ihave_iwant"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_ready(pubsubs, topic)
 
         # Create a message ID that gsub0 doesn't have (opaque bytes)
         missing_msg_id = b"peer456" + b"seqno123"
@@ -70,13 +79,14 @@ async def test_iwant_retrieves_missing_messages():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Both subscribe to the same topic
         topic = "test_iwant_retrieval"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_ready(pubsubs, topic)
 
         # Create a message that gsub1 has but gsub0 doesn't
         seqno = b"seqno123"
@@ -106,9 +116,6 @@ async def test_iwant_retrieves_missing_messages():
         # Simulate gsub0 sending IWANT to gsub1
         await gsub1.handle_iwant(iwant_msg, host0.get_id())
 
-        # Wait for async operations
-        await trio.sleep(0.5)
-
         # Verify that gsub1's message cache was queried
         gsub1.mcache.get.assert_called_once()
 
@@ -133,13 +140,14 @@ async def test_ihave_rate_limiting():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
 
         # Both subscribe to the same topic
         topic = "test_ihave_rate_limiting"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_ready(pubsubs, topic)
 
         # Create multiple message IDs
         msg_ids = [f"peer_{i}".encode() + f"seqno_{i}".encode() for i in range(100)]
@@ -178,13 +186,19 @@ async def test_no_infinite_gossip_loops():
         await connect(host0, host1)
         await connect(host1, host2)
         await connect(host0, host2)
-        await trio.sleep(0.5)
+        for i, j in ((0, 1), (1, 2), (0, 2)):
+            await pubsubs[i].wait_for_peer(pubsubs[j].my_id)
+            await pubsubs[j].wait_for_peer(pubsubs[i].my_id)
 
         # All subscribe to the same topic
         topic = "test_gossip_loops"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        for i, j in ((0, 1), (1, 2), (0, 2)):
+            await pubsubs[i].wait_for_subscription(pubsubs[j].my_id, topic)
+            await pubsubs[j].wait_for_subscription(pubsubs[i].my_id, topic)
+            await pubsubs[i].wait_for_mesh(pubsubs[j].my_id, topic)
+            await pubsubs[j].wait_for_mesh(pubsubs[i].my_id, topic)
 
         # Create a message ID that would be in the seen cache
         seqno = b"seqno123"
@@ -228,13 +242,23 @@ async def test_dropping_gossip_triggers_iwant():
         # This means host0 and host2 are not directly connected
         await connect(host0, host1)
         await connect(host1, host2)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
 
         # All subscribe to the same topic
         topic = "test_dropping_gossip"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_mesh(pubsubs[1].my_id, topic)
 
         # Create a message ID that gsub0 doesn't have
         seqno = b"seqno123"

--- a/tests/core/pubsub/test_gossipsub_v1_1_invalid_behavior.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_invalid_behavior.py
@@ -10,13 +10,39 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.pubsub.pb import rpc_pb2
 from libp2p.pubsub.score import ScoreParams, TopicScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+
+
+async def _wait_line_mesh_ready(pubsubs, topic: str) -> None:
+    """Wait for peer/subscription/mesh readiness on a 0-1-2 line topology."""
+    await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+    await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+    await pubsubs[1].wait_for_peer(pubsubs[2].my_id)
+    await pubsubs[2].wait_for_peer(pubsubs[1].my_id)
+
+    await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+    await pubsubs[1].wait_for_subscription(pubsubs[2].my_id, topic)
+    await pubsubs[2].wait_for_subscription(pubsubs[1].my_id, topic)
+
+    await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+    await pubsubs[1].wait_for_mesh(pubsubs[2].my_id, topic)
+    await pubsubs[2].wait_for_mesh(pubsubs[1].my_id, topic)
+
+
+async def _wait_pair_mesh_ready(pubsubs, topic: str) -> None:
+    await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+    await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+    await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+    await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
 
 
 @pytest.mark.trio
@@ -40,7 +66,6 @@ async def test_invalid_signatures_rejected():
         # Connect hosts in a line: 0 - 1 - 2
         await connect(hosts[0], hosts[1])
         await connect(hosts[1], hosts[2])
-        await trio.sleep(0.5)
 
         # All peers subscribe to the topic
         topic = "test_invalid_signatures"
@@ -49,7 +74,7 @@ async def test_invalid_signatures_rejected():
         for i in range(len(pubsubs)):
             await pubsubs[i].subscribe(topic)
 
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_line_mesh_ready(pubsubs, topic)
 
         # Get the peer ID of host 0
         peer_id = hosts[0].get_id()
@@ -72,9 +97,6 @@ async def test_invalid_signatures_rejected():
         # Simulate an invalid signature by directly applying a penalty
         # This is what would happen when an invalid signature is detected
         gsubs[1].scorer.on_invalid_message(peer_id, topic)
-
-        # Allow time for processing
-        await trio.sleep(0.1)
 
         # Check that the score decreased
         final_score = gsubs[1].scorer.score(peer_id, [topic])
@@ -103,7 +125,6 @@ async def test_malformed_payloads_rejected():
         # Connect hosts in a line: 0 - 1 - 2
         await connect(hosts[0], hosts[1])
         await connect(hosts[1], hosts[2])
-        await trio.sleep(0.5)
 
         # All peers subscribe to the topic
         topic = "test_malformed_payloads"
@@ -112,7 +133,7 @@ async def test_malformed_payloads_rejected():
         for i in range(len(pubsubs)):
             await pubsubs[i].subscribe(topic)
 
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_line_mesh_ready(pubsubs, topic)
 
         # Get the peer ID of host 0
         peer_id = hosts[0].get_id()
@@ -135,9 +156,6 @@ async def test_malformed_payloads_rejected():
         # Directly simulate an invalid message penalty
         # This is what would happen when a malformed message is detected
         gsubs[1].scorer.on_invalid_message(peer_id, topic)
-
-        # Allow time for processing
-        await trio.sleep(0.1)
 
         # Check that the score of peer 0 decreased
         final_score = gsubs[1].scorer.score(peer_id, [topic])
@@ -163,14 +181,13 @@ async def test_excessive_ihave_iwant_spam_penalized():
 
         # Connect the hosts
         await connect(hosts[0], hosts[1])
-        await trio.sleep(0.5)
 
         # Both peers subscribe to the topic
         topic = "test_ihave_iwant_spam"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
 
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Get the peer ID of host 1
         peer_id = hosts[1].get_id()
@@ -210,9 +227,6 @@ async def test_excessive_ihave_iwant_spam_penalized():
         # This is what would happen if peer1 sent excessive IHAVE messages
         gsubs[0].scorer.penalize_behavior(peer_id, 1.0)
 
-        # Allow time for processing
-        await trio.sleep(1.0)
-
         # No need to check if handle_ihave was called since we directly simulated
         # the penalty
 
@@ -244,14 +258,13 @@ async def test_repeated_invalid_messages_lead_to_graylist():
 
         # Connect the hosts
         await connect(hosts[0], hosts[1])
-        await trio.sleep(0.5)
 
         # Both peers subscribe to the topic
         topic = "test_graylist"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
 
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Get the peer ID of host 1
         peer_id = hosts[1].get_id()
@@ -273,9 +286,6 @@ async def test_repeated_invalid_messages_lead_to_graylist():
         # Apply enough penalties to cross the graylist threshold
         for i in range(10):  # More invalid messages to ensure we cross the threshold
             gsubs[0].scorer.on_invalid_message(peer_id, topic)
-
-        # Allow time for score updates
-        await trio.sleep(0.1)
 
         # Configure the mock for final state (graylisted)
         score = -20.0  # A very negative score

--- a/tests/core/pubsub/test_gossipsub_v1_1_network_scenarios.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_network_scenarios.py
@@ -8,6 +8,22 @@ import trio
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for
+
+
+async def _wait_connected_pair(pubsubs, i: int, j: int) -> None:
+    await pubsubs[i].wait_for_peer(pubsubs[j].my_id)
+    await pubsubs[j].wait_for_peer(pubsubs[i].my_id)
+
+
+async def _wait_subscription_pair(pubsubs, i: int, j: int, topic: str) -> None:
+    await pubsubs[i].wait_for_subscription(pubsubs[j].my_id, topic)
+    await pubsubs[j].wait_for_subscription(pubsubs[i].my_id, topic)
+
+
+async def _wait_mesh_pair(pubsubs, i: int, j: int, topic: str) -> None:
+    await pubsubs[i].wait_for_mesh(pubsubs[j].my_id, topic)
+    await pubsubs[j].wait_for_mesh(pubsubs[i].my_id, topic)
 
 
 @pytest.mark.trio
@@ -24,8 +40,10 @@ async def test_large_scale_fanout():
 
         # Connect in a star topology with peer 0 at the center
         # This allows testing fanout without requiring a full mesh
+        edges: list[tuple[int, int]] = []
         for i in range(1, len(hosts)):
             await connect(hosts[0], hosts[i])
+            edges.append((0, i))
 
         # Add some additional connections to create a more realistic network
         # Connect every 2nd peer to create some redundancy
@@ -33,8 +51,10 @@ async def test_large_scale_fanout():
             for j in range(i + 2, len(hosts), 2):
                 if j < len(hosts):
                     await connect(hosts[i], hosts[j])
+                    edges.append((i, j))
 
-        await trio.sleep(1.0)  # Allow time for connections to establish
+        for i, j in edges:
+            await _wait_connected_pair(pubsubs, i, j)
 
         # All peers subscribe to the same topic
         topic = "test_large_scale"
@@ -42,10 +62,8 @@ async def test_large_scale_fanout():
 
         async with trio.open_nursery() as nursery:
             # Subscribe all peers to the topic and collect messages
-            subscriptions = []
             for i, pubsub in enumerate(pubsubs):
                 subscription = await pubsub.subscribe(topic)
-                subscriptions.append(subscription)
 
                 async def collect_messages(peer_index, sub):
                     try:
@@ -56,7 +74,16 @@ async def test_large_scale_fanout():
 
                 nursery.start_soon(collect_messages, i, subscription)
 
-            await trio.sleep(2.0)  # Allow time for mesh formation
+            for i, j in edges:
+                await _wait_subscription_pair(pubsubs, i, j, topic)
+
+            await wait_for(
+                lambda: all(
+                    topic in gsub.mesh and len(gsub.mesh[topic]) > 0 for gsub in gsubs
+                ),
+                timeout=10.0,
+                fail_msg="Large-scale mesh did not form",
+            )
 
             # Verify mesh formation
             for gsub in gsubs:
@@ -68,17 +95,28 @@ async def test_large_scale_fanout():
             middle_peer_index = num_peers // 2
             await pubsubs[middle_peer_index].publish(topic, message_data)
 
-            # Allow time for message propagation in the network
-            await trio.sleep(3.0)
+            # Wait until at least 90% of peers receive the message
+            min_received = int(num_peers * 0.9)
+            await wait_for(
+                lambda: sum(
+                    1
+                    for msgs in received_messages
+                    if any(msg.data == message_data for msg in msgs)
+                )
+                >= min_received,
+                timeout=10.0,
+                fail_msg=(
+                    f"Fewer than {min_received}/{num_peers} peers received "
+                    "large-scale fanout message"
+                ),
+            )
 
-            # Verify message propagation
-            # We expect at least 90% of peers to receive the message
             peers_received = sum(
                 1
                 for msgs in received_messages
                 if any(msg.data == message_data for msg in msgs)
             )
-            assert peers_received >= int(num_peers * 0.9)
+            assert peers_received >= min_received
 
             # Cancel all background tasks before exiting
             nursery.cancel_scope.cancel()
@@ -97,11 +135,14 @@ async def test_simulated_partition():
         hosts = [ps.host for ps in pubsubs]
 
         # Connect all peers in a full mesh
+        edges = []
         for i in range(len(hosts)):
             for j in range(i + 1, len(hosts)):
                 await connect(hosts[i], hosts[j])
+                edges.append((i, j))
 
-        await trio.sleep(1.0)  # Allow time for connections to establish
+        for i, j in edges:
+            await _wait_connected_pair(pubsubs, i, j)
 
         # Create two separate topics to simulate partitions
         topic_group1 = "group1_topic"
@@ -169,7 +210,14 @@ async def test_simulated_partition():
 
                 nursery.start_soon(collect_common2, i, common_sub2)
 
-            await trio.sleep(1.0)  # Allow time for mesh formation
+            # Group-topic mesh between peers that share the topic
+            await _wait_subscription_pair(pubsubs, 0, 1, topic_group1)
+            await _wait_mesh_pair(pubsubs, 0, 1, topic_group1)
+            await _wait_subscription_pair(pubsubs, 2, 3, topic_group2)
+            await _wait_mesh_pair(pubsubs, 2, 3, topic_group2)
+            for i, j in edges:
+                await _wait_subscription_pair(pubsubs, i, j, common_topic)
+                await _wait_mesh_pair(pubsubs, i, j, common_topic)
 
             # Publish messages to the partitioned topics
             message_group1 = b"message for group 1"
@@ -178,7 +226,24 @@ async def test_simulated_partition():
             message_group2 = b"message for group 2"
             await pubsubs[2].publish(topic_group2, message_group2)
 
-            await trio.sleep(2.0)  # Allow time for message propagation
+            await wait_for(
+                lambda: all(
+                    any(
+                        msg.data == message_group1
+                        for msg in received_messages[topic_group1][i]
+                    )
+                    for i in range(2)
+                )
+                and all(
+                    any(
+                        msg.data == message_group2
+                        for msg in received_messages[topic_group2][i]
+                    )
+                    for i in range(2, 4)
+                ),
+                timeout=10.0,
+                fail_msg="Partitioned group messages did not arrive",
+            )
 
             # Verify that messages stayed within their respective groups
             # Group 1 (peers 0-1) should have received message_group1
@@ -203,7 +268,17 @@ async def test_simulated_partition():
             message_common = b"message for everyone"
             await pubsubs[1].publish(common_topic, message_common)
 
-            await trio.sleep(2.0)  # Allow time for message propagation
+            await wait_for(
+                lambda: all(
+                    any(
+                        msg.data == message_common
+                        for msg in received_messages[common_topic][i]
+                    )
+                    for i in range(len(pubsubs))
+                ),
+                timeout=10.0,
+                fail_msg="Common-topic message did not reach all peers",
+            )
 
             # Verify that all peers received the common message
             for i in range(len(pubsubs)):
@@ -227,17 +302,20 @@ async def test_mesh_stability():
         gsubs = [cast(GossipSub, ps.router) for ps in pubsubs]
 
         # Connect peers in a ring topology initially
-        for i in range(len(hosts)):
-            await connect(hosts[i], hosts[(i + 1) % len(hosts)])
-
-        await trio.sleep(1.0)  # Allow time for connections to establish
+        ring_edges = [(i, (i + 1) % len(hosts)) for i in range(len(hosts))]
+        for i, j in ring_edges:
+            await connect(hosts[i], hosts[j])
+        for i, j in ring_edges:
+            await _wait_connected_pair(pubsubs, i, j)
 
         # All peers subscribe to the same topic
         topic = "test_stability"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
 
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        for i, j in ring_edges:
+            await _wait_subscription_pair(pubsubs, i, j, topic)
+            await _wait_mesh_pair(pubsubs, i, j, topic)
 
         # Verify initial mesh state
         for gsub in gsubs:
@@ -246,14 +324,21 @@ async def test_mesh_stability():
 
         # Add some new connections to change the topology
         await connect(hosts[0], hosts[2])
-
-        await trio.sleep(1.0)  # Allow time for new connections
+        await _wait_connected_pair(pubsubs, 0, 2)
+        await _wait_subscription_pair(pubsubs, 0, 2, topic)
 
         # Trigger mesh heartbeat
         for gsub in gsubs:
             gsub.mesh_heartbeat()
 
-        await trio.sleep(1.0)  # Allow time for mesh changes to take effect
+        # Wait until mesh remains non-empty after topology change
+        await wait_for(
+            lambda: all(
+                topic in gsub.mesh and len(gsub.mesh[topic]) > 0 for gsub in gsubs
+            ),
+            timeout=10.0,
+            fail_msg="Mesh not maintained after topology change",
+        )
 
         # Verify that mesh is still maintained
         for i, gsub in enumerate(gsubs):
@@ -279,13 +364,29 @@ async def test_mesh_stability():
 
                 nursery.start_soon(collect_messages, i, subscription)
 
-            await trio.sleep(0.5)  # Allow time for subscriptions to be processed
+            # Already subscribed; ensure collectors are attached and mesh ready
+            await wait_for(
+                lambda: all(
+                    topic in gsub.mesh and len(gsub.mesh[topic]) > 0 for gsub in gsubs
+                ),
+                timeout=10.0,
+                fail_msg="Mesh not ready before stability publish",
+            )
 
             # Publish a message
             await pubsubs[0].publish(topic, message_data)
 
-            # Allow time for message propagation
-            await trio.sleep(2.0)
+            # Wait until at least 75% of peers receive the message
+            await wait_for(
+                lambda: sum(
+                    1
+                    for msgs in received_messages
+                    if any(msg.data == message_data for msg in msgs)
+                )
+                >= 3,
+                timeout=10.0,
+                fail_msg="Fewer than 3 peers received message after topology change",
+            )
 
             # Verify message propagation
             peers_received = sum(

--- a/tests/core/pubsub/test_gossipsub_v1_1_network_scenarios.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_network_scenarios.py
@@ -118,7 +118,10 @@ async def test_large_scale_fanout():
             )
             assert peers_received >= min_received
 
-            # Cancel all background tasks before exiting
+            # Unsubscribe before cancel so late deliveries cannot schedule
+            # push_msg on a closing Swarm nursery under CI load.
+            for ps in pubsubs:
+                await ps.unsubscribe(topic)
             nursery.cancel_scope.cancel()
 
 
@@ -287,7 +290,10 @@ async def test_simulated_partition():
                     for msg in received_messages[common_topic][i]
                 )
 
-            # Cancel all background tasks before exiting
+            for ps in pubsubs:
+                await ps.unsubscribe(topic_group1)
+                await ps.unsubscribe(topic_group2)
+                await ps.unsubscribe(common_topic)
             nursery.cancel_scope.cancel()
 
 
@@ -398,5 +404,6 @@ async def test_mesh_stability():
                 peers_received >= 3
             )  # At least 75% of peers should receive the message
 
-            # Cancel all background tasks before exiting
+            for ps in pubsubs:
+                await ps.unsubscribe(topic)
             nursery.cancel_scope.cancel()

--- a/tests/core/pubsub/test_gossipsub_v1_1_opportunistic_grafting.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_opportunistic_grafting.py
@@ -9,12 +9,12 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.pubsub.score import ScoreParams, TopicScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
+from tests.utils.pubsub.wait import wait_for
 
 
 @pytest.mark.trio
@@ -39,13 +39,21 @@ async def test_mesh_improvement_with_high_scoring_peers():
         await connect(host0, host1)
         await connect(host0, host2)
         # Deliberately don't connect host1 and host2 directly
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host1.get_id())
+        await pubsubs[1].wait_for_peer(host0.get_id())
+        await pubsubs[0].wait_for_peer(host2.get_id())
+        await pubsubs[2].wait_for_peer(host0.get_id())
 
         # All subscribe to the same topic
         topic = "test_mesh_improvement"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+        await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_subscription(host2.get_id(), topic)
+        await pubsubs[2].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host2.get_id(), topic)
 
         # Verify initial mesh state
         assert isinstance(gsub0, GossipSub)
@@ -59,7 +67,6 @@ async def test_mesh_improvement_with_high_scoring_peers():
         assert gsub0.scorer is not None
         for _ in range(10):  # Simulate multiple good message deliveries
             gsub0.scorer.on_mesh_delivery(peer2_id, topic)
-        await trio.sleep(0.1)
 
         # Verify peer2 has a higher score than peer1
         peer1_score = gsub0.scorer.score(peer1_id, [topic])
@@ -104,13 +111,21 @@ async def test_mesh_improvement_with_score_based_selection():
         # Connect host0 to all other hosts
         await connect(host0, host1)
         await connect(host0, host2)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host1.get_id())
+        await pubsubs[1].wait_for_peer(host0.get_id())
+        await pubsubs[0].wait_for_peer(host2.get_id())
+        await pubsubs[2].wait_for_peer(host0.get_id())
 
         # All subscribe to the same topic
         topic = "test_mesh_improvement"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+        await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_subscription(host2.get_id(), topic)
+        await pubsubs[2].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host2.get_id(), topic)
 
         # Verify initial mesh state
         assert isinstance(gsub0, GossipSub)
@@ -128,7 +143,6 @@ async def test_mesh_improvement_with_score_based_selection():
 
         for _ in range(10):
             gsub0.scorer.on_mesh_delivery(peer2_id, topic)
-        await trio.sleep(0.1)
 
         # Verify scores
         peer1_score = gsub0.scorer.score(peer1_id, [topic])
@@ -152,8 +166,11 @@ async def test_mesh_improvement_with_score_based_selection():
             for topic_id in topics:
                 await gsub0.emit_prune(topic_id, peer_id, False, False)
 
-        # Allow time for mesh changes to take effect
-        await trio.sleep(1.0)
+        # mesh_heartbeat updates local membership synchronously; wait for it
+        await wait_for(
+            lambda: len(gsub0.mesh.get(topic, set())) > 0,
+            fail_msg="mesh should remain non-empty after heartbeat",
+        )
 
         # Check the updated mesh
         final_mesh = set(gsub0.mesh[topic])
@@ -185,13 +202,21 @@ async def test_mesh_maintenance_with_scoring():
         # Connect all hosts
         await connect(host0, host1)
         await connect(host0, host2)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host1.get_id())
+        await pubsubs[1].wait_for_peer(host0.get_id())
+        await pubsubs[0].wait_for_peer(host2.get_id())
+        await pubsubs[2].wait_for_peer(host0.get_id())
 
         # All subscribe to the same topic
         topic = "test_mesh_maintenance"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+        await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_subscription(host2.get_id(), topic)
+        await pubsubs[2].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host2.get_id(), topic)
 
         # Verify initial mesh state
         assert isinstance(gsub0, GossipSub)
@@ -204,7 +229,6 @@ async def test_mesh_maintenance_with_scoring():
         assert gsub0.scorer is not None
         for _ in range(3):  # Not enough to exceed threshold
             gsub0.scorer.on_mesh_delivery(peer2_id, topic)
-        await trio.sleep(0.1)
 
         # Verify peer2's score is positive but below threshold
         peer2_score = gsub0.scorer.score(peer2_id, [topic])
@@ -239,13 +263,26 @@ async def test_mesh_with_degraded_peers():
         await connect(host0, host1)
         await connect(host0, host2)
         await connect(host0, host3)
-        await trio.sleep(0.5)
+        for other in (host1, host2, host3):
+            await pubsubs[0].wait_for_peer(other.get_id())
+        await pubsubs[1].wait_for_peer(host0.get_id())
+        await pubsubs[2].wait_for_peer(host0.get_id())
+        await pubsubs[3].wait_for_peer(host0.get_id())
 
         # All subscribe to the same topic
         topic = "test_degraded_mesh"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        for other in (host1, host2, host3):
+            await pubsubs[0].wait_for_subscription(other.get_id(), topic)
+        await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[2].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[3].wait_for_subscription(host0.get_id(), topic)
+        # degree may not include every peer; wait until mesh is non-empty
+        await wait_for(
+            lambda: len(gsub0.mesh.get(topic, set())) > 0,
+            fail_msg="host0 mesh should form after subscribe",
+        )
 
         # Verify initial mesh state
         assert isinstance(gsub0, GossipSub)
@@ -266,7 +303,6 @@ async def test_mesh_with_degraded_peers():
         # Make peer3 high-scoring (assuming it might not be in the initial mesh)
         for _ in range(10):
             gsub0.scorer.on_mesh_delivery(peer3_id, topic)
-        await trio.sleep(0.1)
 
         # Verify peer3 has a high score
         assert gsub0.scorer.score(peer3_id, [topic]) > 0
@@ -287,8 +323,10 @@ async def test_mesh_with_degraded_peers():
             for topic_id in topics:
                 await gsub0.emit_prune(topic_id, peer_id, False, False)
 
-        # Allow time for mesh changes to take effect
-        await trio.sleep(1.0)
+        await wait_for(
+            lambda: topic in gsub0.mesh,
+            fail_msg="mesh topic should remain after heartbeat",
+        )
 
         # Create a mock scorer if needed
         if not hasattr(gsub0, "scorer") or gsub0.scorer is None:
@@ -329,13 +367,21 @@ async def test_mesh_heartbeat_backoff():
         # Connect all hosts
         await connect(host0, host1)
         await connect(host0, host2)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(host1.get_id())
+        await pubsubs[1].wait_for_peer(host0.get_id())
+        await pubsubs[0].wait_for_peer(host2.get_id())
+        await pubsubs[2].wait_for_peer(host0.get_id())
 
         # All subscribe to the same topic
         topic = "test_mesh_backoff"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+        await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_subscription(host2.get_id(), topic)
+        await pubsubs[2].wait_for_subscription(host0.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+        await pubsubs[0].wait_for_mesh(host2.get_id(), topic)
 
         # Verify initial mesh state
         assert isinstance(gsub0, GossipSub)
@@ -348,7 +394,6 @@ async def test_mesh_heartbeat_backoff():
         assert gsub0.scorer is not None
         for _ in range(10):
             gsub0.scorer.on_mesh_delivery(peer2_id, topic)
-        await trio.sleep(0.1)
 
         # Verify peer2 has a high score
         assert gsub0.scorer.score(peer2_id, [topic]) > 0

--- a/tests/core/pubsub/test_gossipsub_v1_1_peer_scoring.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_peer_scoring.py
@@ -284,12 +284,16 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_publish_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+            await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+            await pubsubs[1].wait_for_mesh(host0.get_id(), topic)
 
             # Ensure scorer exists
             assert isinstance(gsub0, GossipSub)
@@ -351,12 +355,14 @@ class TestGossipSubScoringIntegration:
             for i in range(len(hosts)):
                 for j in range(i + 1, len(hosts)):
                     await connect(hosts[i], hosts[j])
-            await trio.sleep(0.2)
+                    await pubsubs[i].wait_for_peer(hosts[j].get_id())
+                    await pubsubs[j].wait_for_peer(hosts[i].get_id())
 
             topic = "test_gossip_gate"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(hosts[1].get_id(), topic)
+            await pubsubs[0].wait_for_subscription(hosts[2].get_id(), topic)
 
             # Test gossip filtering
             gsub0 = cast(GossipSub, gsubs[0])
@@ -404,12 +410,14 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_graylist_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -441,12 +449,14 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_px_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -494,12 +504,14 @@ class TestGossipSubScoringIntegration:
             for i in range(len(hosts)):
                 for j in range(i + 1, len(hosts)):
                     await connect(hosts[i], hosts[j])
-            await trio.sleep(0.2)
+                    await pubsubs[i].wait_for_peer(hosts[j].get_id())
+                    await pubsubs[j].wait_for_peer(hosts[i].get_id())
 
             topic = "test_opportunistic_grafting"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(0.2)
+            for i in range(1, len(hosts)):
+                await pubsubs[0].wait_for_subscription(hosts[i].get_id(), topic)
 
             # Manually set up mesh with some peers having higher scores
             gsub0 = gsubs[0]
@@ -574,12 +586,16 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_mesh_hooks"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+            await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+            await pubsubs[1].wait_for_mesh(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -620,12 +636,14 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_delivery_hooks"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -658,12 +676,14 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_invalid_hook"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -693,12 +713,14 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_behavior_penalty"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
             topics = [topic]
@@ -728,7 +750,8 @@ class TestGossipSubScoringIntegration:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             peer_id = host1.get_id()
 
@@ -739,7 +762,8 @@ class TestGossipSubScoringIntegration:
             topic = "test_protocol_detection"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             # After subscription, peer should be in peer_protocol mapping
             # The exact protocol depends on the factory implementation

--- a/tests/core/pubsub/test_gossipsub_v1_1_peer_scoring_behavior.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_peer_scoring_behavior.py
@@ -16,6 +16,15 @@ from libp2p.tools.utils import connect
 from tests.utils.factories import PubsubFactory
 
 
+async def _wait_pair_mesh_ready(pubsubs, topic: str) -> None:
+    await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+    await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+    await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+    await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+    await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+
+
 @pytest.mark.trio
 async def test_score_decreases_for_invalid_messages():
     """Test that peer score decreases when sending invalid messages."""
@@ -31,13 +40,12 @@ async def test_score_decreases_for_invalid_messages():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
 
         # Both subscribe to the same topic
         topic = "test_invalid_messages"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Get initial score
         assert isinstance(gsub0, GossipSub)
@@ -71,13 +79,12 @@ async def test_score_decreases_for_duplicate_messages():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
 
         # Both subscribe to the same topic
         topic = "test_duplicate_messages"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Get initial score
         assert isinstance(gsub0, GossipSub)
@@ -109,13 +116,12 @@ async def test_honest_peers_maintain_stable_scores():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
 
         # Both subscribe to the same topic
         topic = "test_honest_peers"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Get initial score
         assert isinstance(gsub0, GossipSub)
@@ -155,13 +161,12 @@ async def test_low_scoring_peers_get_pruned():
 
         # Connect hosts
         await connect(host0, host1)
-        await trio.sleep(0.5)
 
         # Both subscribe to the same topic
         topic = "test_pruning"
         await pubsubs[0].subscribe(topic)
         await pubsubs[1].subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await _wait_pair_mesh_ready(pubsubs, topic)
 
         # Verify that hosts are in each other's mesh
         assert isinstance(gsub0, GossipSub)
@@ -201,13 +206,23 @@ async def test_score_based_message_propagation():
         # Connect hosts
         await connect(host0, host1)
         await connect(host0, host2)
-        await trio.sleep(0.5)
+        await pubsubs[0].wait_for_peer(pubsubs[1].my_id)
+        await pubsubs[1].wait_for_peer(pubsubs[0].my_id)
+        await pubsubs[0].wait_for_peer(pubsubs[2].my_id)
+        await pubsubs[2].wait_for_peer(pubsubs[0].my_id)
 
         # All subscribe to the same topic
         topic = "test_score_propagation"
         for pubsub in pubsubs:
             await pubsub.subscribe(topic)
-        await trio.sleep(1.0)  # Allow time for mesh formation
+        await pubsubs[0].wait_for_subscription(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_subscription(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_subscription(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[1].my_id, topic)
+        await pubsubs[1].wait_for_mesh(pubsubs[0].my_id, topic)
+        await pubsubs[0].wait_for_mesh(pubsubs[2].my_id, topic)
+        await pubsubs[2].wait_for_mesh(pubsubs[0].my_id, topic)
 
         # Give host1 a good score
         assert isinstance(gsub0, GossipSub)

--- a/tests/core/pubsub/test_gossipsub_v1_1_score_gates.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_score_gates.py
@@ -9,13 +9,13 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import GossipSub
 from libp2p.pubsub.pb import rpc_pb2
 from libp2p.pubsub.score import PeerScorer, ScoreParams, TopicScoreParams
 from libp2p.tools.utils import connect
 from tests.utils.factories import IDFactory, PubsubFactory
+from tests.utils.pubsub.wait import wait_for
 
 
 class TestScoreGates:
@@ -37,12 +37,16 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_publish_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+            await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+            await pubsubs[1].wait_for_mesh(host0.get_id(), topic)
 
             # Mock send_rpc to capture sent messages
             mock_send_rpc = MagicMock()
@@ -127,7 +131,8 @@ class TestScoreGates:
             for i in range(len(hosts)):
                 for j in range(i + 1, len(hosts)):
                     await connect(hosts[i], hosts[j])
-            await trio.sleep(0.2)
+                    await pubsubs[i].wait_for_peer(hosts[j].get_id())
+                    await pubsubs[j].wait_for_peer(hosts[i].get_id())
 
             topic = "test_gossip_gate"
             for pubsub in pubsubs:
@@ -199,12 +204,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_graylist_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -239,12 +246,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_px_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -300,12 +309,16 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_graft_gate"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
+            await pubsubs[0].wait_for_mesh(host1.get_id(), topic)
+            await pubsubs[1].wait_for_mesh(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -350,13 +363,15 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topics = ["topic1", "topic2"]
             for topic in topics:
                 await pubsubs[0].subscribe(topic)
                 await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+                await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+                await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
 
@@ -437,12 +452,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_behavior_penalty_gates"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
             topics = [topic]
@@ -483,12 +500,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_edge_cases"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
             topics = [topic]
@@ -531,12 +550,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_zero_weights"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
             topics = [topic]
@@ -577,12 +598,20 @@ class TestScoreGates:
             for i in range(len(hosts)):
                 for j in range(i + 1, len(hosts)):
                     await connect(hosts[i], hosts[j])
-            await trio.sleep(0.2)
+                    await pubsubs[i].wait_for_peer(hosts[j].get_id())
+                    await pubsubs[j].wait_for_peer(hosts[i].get_id())
 
             topic = "test_mesh_integration"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(hosts[1].get_id(), topic)
+            await pubsubs[0].wait_for_subscription(hosts[2].get_id(), topic)
+            # degree=2 with 3 peers: mesh need not contain every peer. Wait until
+            # mesh has formed with at least one neighbour.
+            await wait_for(
+                lambda: len(gsubs[0].mesh.get(topic, set())) >= 1,
+                fail_msg="mesh should form before mesh_heartbeat checks",
+            )
 
             # Test that graylisted peers are excluded from mesh management
             gsub0 = gsubs[0]
@@ -632,12 +661,14 @@ class TestScoreGates:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id())
+            await pubsubs[1].wait_for_peer(host0.get_id())
 
             topic = "test_decay_gates"
             await pubsubs[0].subscribe(topic)
             await pubsubs[1].subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic)
 
             peer_id = host1.get_id()
             topics = [topic]

--- a/tests/core/pubsub/test_gossipsub_v1_1_signed_peer_records.py
+++ b/tests/core/pubsub/test_gossipsub_v1_1_signed_peer_records.py
@@ -9,7 +9,6 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import trio
 
 from libp2p.peer.peerinfo import PeerInfo
 from libp2p.pubsub.gossipsub import GossipSub
@@ -107,12 +106,24 @@ class TestGossipSubSignedPeerRecords:
             await connect(host0, host1)
             await connect(host1, host2)
             await connect(host0, host2)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host2.get_id(), timeout=10)
+            await pubsubs[2].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[0].wait_for_peer(host2.get_id(), timeout=10)
+            await pubsubs[2].wait_for_peer(host0.get_id(), timeout=10)
 
             topic = "test_emit_prune_signed_records"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_subscription(host1.get_id(), topic, timeout=10)
+            await pubsubs[0].wait_for_subscription(host2.get_id(), topic, timeout=10)
+            await pubsubs[1].wait_for_subscription(host0.get_id(), topic, timeout=10)
+            await pubsubs[1].wait_for_subscription(host2.get_id(), topic, timeout=10)
+            await pubsubs[2].wait_for_subscription(host0.get_id(), topic, timeout=10)
+            await pubsubs[2].wait_for_subscription(host1.get_id(), topic, timeout=10)
+            await pubsubs[0].wait_for_mesh(host1.get_id(), topic, timeout=10)
+            await pubsubs[1].wait_for_mesh(host0.get_id(), topic, timeout=10)
 
             # Mock the peerstore to return a signed record for host2
             assert gsub0.pubsub is not None
@@ -161,7 +172,8 @@ class TestGossipSubSignedPeerRecords:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
 
             # Create mock signed peer record
             mock_envelope = MagicMock()
@@ -378,7 +390,8 @@ class TestGossipSubSignedPeerRecords:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
 
             # Create PX peer info for already connected peer
             px_peer = rpc_pb2.PeerInfo()
@@ -406,7 +419,8 @@ class TestGossipSubSignedPeerRecords:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
 
             # Mock maybe_consume_signed_record to return False (invalid record)
             with patch(
@@ -439,7 +453,8 @@ class TestGossipSubSignedPeerRecords:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
 
             # Mock env_to_send_in_RPC
             with patch("libp2p.pubsub.gossipsub.env_to_send_in_RPC") as mock_env:
@@ -477,7 +492,8 @@ class TestGossipSubSignedPeerRecords:
 
             # Connect hosts
             await connect(host0, host1)
-            await trio.sleep(0.2)
+            await pubsubs[0].wait_for_peer(host1.get_id(), timeout=10)
+            await pubsubs[1].wait_for_peer(host0.get_id(), timeout=10)
 
             # Mock env_to_send_in_RPC
             with patch("libp2p.pubsub.gossipsub.env_to_send_in_RPC") as mock_env:

--- a/tests/core/pubsub/test_gossipsub_v2_0.py
+++ b/tests/core/pubsub/test_gossipsub_v2_0.py
@@ -14,7 +14,6 @@ import time
 from unittest.mock import Mock
 
 import pytest
-import trio
 
 from libp2p.pubsub.gossipsub import PROTOCOL_ID_V20, GossipSub
 from libp2p.pubsub.pb import rpc_pb2
@@ -599,15 +598,29 @@ class TestGossipsubV20Integration:
             # Connect hosts
             from libp2p.tools.utils import connect
 
+            peer0_id = hosts[0].get_id()
+            peer1_id = hosts[1].get_id()
+            peer2_id = hosts[2].get_id()
+
             await connect(hosts[0], hosts[1])
             await connect(hosts[1], hosts[2])
-            await trio.sleep(0.5)
+            await pubsubs[0].wait_for_peer(peer1_id, timeout=10)
+            await pubsubs[1].wait_for_peer(peer0_id, timeout=10)
+            await pubsubs[1].wait_for_peer(peer2_id, timeout=10)
+            await pubsubs[2].wait_for_peer(peer1_id, timeout=10)
 
             # Subscribe to topic
             topic = "gossipsub_v20_test"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(1.0)
+            await pubsubs[0].wait_for_subscription(peer1_id, topic, timeout=10)
+            await pubsubs[1].wait_for_subscription(peer0_id, topic, timeout=10)
+            await pubsubs[1].wait_for_subscription(peer2_id, topic, timeout=10)
+            await pubsubs[2].wait_for_subscription(peer1_id, topic, timeout=10)
+            await pubsubs[0].wait_for_mesh(peer1_id, topic, timeout=10)
+            await pubsubs[1].wait_for_mesh(peer0_id, topic, timeout=10)
+            await pubsubs[1].wait_for_mesh(peer2_id, topic, timeout=10)
+            await pubsubs[2].wait_for_mesh(peer1_id, topic, timeout=10)
 
             # Verify mesh formation with v2.0 features
             for gsub in gsubs:
@@ -620,7 +633,6 @@ class TestGossipsubV20Integration:
             # Test message publishing with v2.0 security checks
             test_message = b"gossipsub v2.0 test message"
             await pubsubs[0].publish(topic, test_message)
-            await trio.sleep(1.0)
 
     @pytest.mark.trio
     async def test_v20_with_mixed_protocol_versions(self):
@@ -635,6 +647,7 @@ class TestGossipsubV20Integration:
         ) as pubsubs:
             hosts = [ps.host for ps in pubsubs]
             gsubs = [ps.router for ps in pubsubs]
+            peer_ids = [host.get_id() for host in hosts]
 
             # Connect all hosts
             from libp2p.tools.utils import connect
@@ -642,13 +655,25 @@ class TestGossipsubV20Integration:
             for i in range(len(hosts)):
                 for j in range(i + 1, len(hosts)):
                     await connect(hosts[i], hosts[j])
-            await trio.sleep(0.5)
+            for i in range(len(pubsubs)):
+                for j in range(len(pubsubs)):
+                    if i != j:
+                        await pubsubs[i].wait_for_peer(peer_ids[j], timeout=10)
 
             # All subscribe to same topic
             topic = "mixed_version_test"
             for pubsub in pubsubs:
                 await pubsub.subscribe(topic)
-            await trio.sleep(1.0)
+            for i in range(len(pubsubs)):
+                for j in range(len(pubsubs)):
+                    if i != j:
+                        await pubsubs[i].wait_for_subscription(
+                            peer_ids[j], topic, timeout=10
+                        )
+            for i in range(len(pubsubs)):
+                for j in range(len(pubsubs)):
+                    if i != j:
+                        await pubsubs[i].wait_for_mesh(peer_ids[j], topic, timeout=10)
 
             # Verify mesh formation works across versions
             for gsub in gsubs:
@@ -658,4 +683,3 @@ class TestGossipsubV20Integration:
             # Test message propagation across versions
             test_message = b"cross-version message"
             await pubsubs[0].publish(topic, test_message)
-            await trio.sleep(1.0)

--- a/tests/core/pubsub/test_pubsub_write_msg_exceptions.py
+++ b/tests/core/pubsub/test_pubsub_write_msg_exceptions.py
@@ -113,12 +113,15 @@ async def test_write_msg_stream_reset():
                         await pubsub_a.subscribe("test")
                         await pubsub_b.subscribe("test")
 
-                        # Allow some time for subscriptions to propagate
-                        await trio.sleep(1.0)
+                        peer_b_id = host_b.get_id()
+                        peer_a_id = host_a.get_id()
+                        await pubsub_a.wait_for_peer(peer_b_id)
+                        await pubsub_b.wait_for_peer(peer_a_id)
+                        await pubsub_a.wait_for_subscription(peer_b_id, "test")
+                        await pubsub_b.wait_for_subscription(peer_a_id, "test")
 
                         # Get the stream
-                        peer_a_id = host_b.get_id()
-                        stream = pubsub_a.peers[peer_a_id]
+                        stream = pubsub_a.peers[peer_b_id]
 
                         await stream.reset()
 

--- a/tests/core/pubsub/test_rpc_queue.py
+++ b/tests/core/pubsub/test_rpc_queue.py
@@ -569,7 +569,14 @@ async def test_publish_reaches_peer_through_split():
         sub1 = await pubsubs[1].subscribe(topic)
 
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(2)
+        peer0 = pubsubs[0].host.get_id()
+        peer1 = pubsubs[1].host.get_id()
+        await pubsubs[0].wait_for_peer(peer1)
+        await pubsubs[1].wait_for_peer(peer0)
+        await pubsubs[0].wait_for_subscription(peer1, topic)
+        await pubsubs[1].wait_for_subscription(peer0, topic)
+        await pubsubs[0].wait_for_mesh(peer1, topic)
+        await pubsubs[1].wait_for_mesh(peer0, topic)
 
         payload = b"A" * 100
         await pubsubs[0].publish(topic, payload)
@@ -592,7 +599,14 @@ async def test_split_rpc_actually_splits_in_send_rpc():
         await pubsubs[1].subscribe(topic)
 
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(2)
+        peer0 = pubsubs[0].host.get_id()
+        peer1 = pubsubs[1].host.get_id()
+        await pubsubs[0].wait_for_peer(peer1)
+        await pubsubs[1].wait_for_peer(peer0)
+        await pubsubs[0].wait_for_subscription(peer1, topic)
+        await pubsubs[1].wait_for_subscription(peer0, topic)
+        await pubsubs[0].wait_for_mesh(peer1, topic)
+        await pubsubs[1].wait_for_mesh(peer0, topic)
 
         # Shrink queues on node 0.
         _shrink_queues(pubsubs[0], 200)
@@ -653,7 +667,14 @@ async def test_sender_record_reaches_peer():
         sub1 = await pubsubs[1].subscribe(topic)
 
         await connect(pubsubs[0].host, pubsubs[1].host)
-        await trio.sleep(2)
+        peer0 = pubsubs[0].host.get_id()
+        peer1 = pubsubs[1].host.get_id()
+        await pubsubs[0].wait_for_peer(peer1)
+        await pubsubs[1].wait_for_peer(peer0)
+        await pubsubs[0].wait_for_subscription(peer1, topic)
+        await pubsubs[1].wait_for_subscription(peer0, topic)
+        await pubsubs[0].wait_for_mesh(peer1, topic)
+        await pubsubs[1].wait_for_mesh(peer0, topic)
 
         import libp2p.pubsub.pubsub as pubsub_mod
 


### PR DESCRIPTION
## Summary
- De-flake pubsub tests across Phase 1 and Phase 2 of #1493 by replacing fixed `trio.sleep` connect/subscribe/mesh/delivery waits with `wait_for_peer` / `wait_for_subscription` / `wait_for_mesh` / `wait_for` / `wait_for_pubsub_payload(s)`.
- Keep intentional time-based sleeps: backoff/TTL expiry, injected identify delays, negative-assert race windows, rate-limit pacing, stream-reset settle, and score-decay pacing.
- Tests only; no production GossipSub changes. Newsfragment: `1493.internal`.

Fixes #1493

## Converted (readiness sleeps removed)
Phase 1: score_gates, peer_scoring, floodsub, signed_peer_records, core_functionality, v14 message_id/core/scoring, rpc_queue, ihave_iwant, peer_scoring_behavior, invalid_behavior, v12_integration, v2_0, write_msg_exceptions.

Phase 2: flood_publishing, network_scenarios, gossipsub (dense/sparse/graft), px_and_backoff (rejoin only), opportunistic_grafting, adaptive_gossip, rate_limiting/extensions setup + processing predicates, identify_aware multi-hop payload wait.

## Intentionally retained sleeps (examples)
| Area | Reason |
|------|--------|
| `PRUNE_BACKOFF * 2` / TTL fanout | Duration is the contract under test |
| Injected identify delay | Stub behavior, not readiness |
| Rate-limit `sleep(0.1)` pacing | Behavior under test |
| Negative GRAFT settle / “event not set” | Proving absence needs a window |
| Post-`stream.reset` settle | No clear peer-gone predicate without redesign |
| Score decay / scorer heartbeat pacing | Time-based scoring behavior |

## Test plan
- [x] `make lint` / `make typecheck`
- [x] Touched pubsub files via pytest (289+ passed; re-ran score_gates after mesh-degree wait fix)
- [x] Confirm CI green (esp. Windows `core` if flaky historically)


Made with [Cursor](https://cursor.com)