### PR TITLE
Revert #1464: undo fast-uri bump merged with failing CI

### DIFF
--- a/examples/request_response/synapse_sidecar/package-lock.json
+++ b/examples/request_response/synapse_sidecar/package-lock.json
@@ -320,9 +320,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
-      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Reverts #1464 (`9cb3da43`), which was squash-merged while lint CI was failing.
- Restores `fast-uri` to 3.1.5 in `examples/request_response/synapse_sidecar/package-lock.json`.

## Why
The bump should not have landed with failing checks. Re-open / re-merge only after CI is green.

## Test plan
- [ ] Diff is only the lockfile restore
- [ ] No other Dependabot commits reverted (#1489 stays)


Made with [Cursor](https://cursor.com)