### PR TITLE
fix(host): make BasicHost.close() stop services and tear down tests

### DIFF
--- a/libp2p/host/basic_host.py
+++ b/libp2p/host/basic_host.py
@@ -360,6 +360,7 @@ class BasicHost(IHost):
         self._identified_peers: dict[ID, str] = {}
         self._identify_tasks: set[trio.CancelScope] = set()
         self._network.register_notifee(_IdentifyNotifee(self))
+        self._closed = False
 
         # Metrics
         self.metric_recv_channel = metric_recv_channel
@@ -578,18 +579,44 @@ class BasicHost(IHost):
                         yield
                     finally:
                         nursery.cancel_scope.cancel()
-                        if self.mDNS is not None:
-                            self.mDNS.stop()
-                    if self.upnp and self.upnp.get_external_ip():
-                        upnp_manager = self.upnp
-                        logger.debug("Removing UPnP port mappings")
-                        for addr in self.get_transport_addrs():
-                            if port := addr.value_for_protocol("tcp"):
-                                await upnp_manager.remove_port_mapping(int(port), "TCP")
-                    if self.bootstrap is not None:
-                        self.bootstrap.stop()
+                await self._shutdown_background_services()
 
         return _run()
+
+    async def _shutdown_background_services(self) -> None:
+        """
+        Best-effort stop of mDNS, UPnP, and bootstrap.
+
+        Safe to call multiple times: service references are cleared after stop
+        so a second call is a no-op (avoids double ``zeroconf.close()``).
+        """
+        if self.mDNS is not None:
+            try:
+                logger.debug("Stopping mDNS Discovery")
+                self.mDNS.stop()
+            except Exception as e:
+                logger.warning(f"Error stopping mDNS during shutdown: {e}")
+            self.mDNS = None
+
+        upnp_manager = self.upnp
+        if upnp_manager is not None:
+            self.upnp = None
+            try:
+                if upnp_manager.get_external_ip():
+                    logger.debug("Removing UPnP port mappings")
+                    for addr in self.get_transport_addrs():
+                        if port := addr.value_for_protocol("tcp"):
+                            await upnp_manager.remove_port_mapping(int(port), "TCP")
+            except Exception as e:
+                logger.warning(f"Error removing UPnP mappings during shutdown: {e}")
+
+        if self.bootstrap is not None:
+            try:
+                logger.debug("Stopping Bootstrap Discovery")
+                self.bootstrap.stop()
+            except Exception as e:
+                logger.warning(f"Error stopping bootstrap during shutdown: {e}")
+            self.bootstrap = None
 
     def set_stream_handler(
         self, protocol_id: TProtocol, stream_handler: StreamHandlerFn
@@ -1107,6 +1134,18 @@ class BasicHost(IHost):
         await self._network.close_peer(peer_id)
 
     async def close(self) -> None:
+        """
+        Close the host and its underlying network service.
+
+        Cleanup order is intentional: stop background services, cancel
+        inflight identify tasks, then close the network. Idempotent.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        await self._shutdown_background_services()
+
         for cs in self._identify_tasks:
             cs.cancel()
         self._identify_tasks.clear()

--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -2154,8 +2154,11 @@ class Swarm(Service, INetworkService):
         Active connections are closed explicitly (best-effort) BEFORE the
         manager is stopped, so resource scopes are released and sockets are
         torn down deterministically instead of relying on task cancellation
-        (Bug 9).
+        (Bug 9). Idempotent: a second call is a no-op.
         """
+        if self._closing:
+            logger.debug("swarm close() called again; already closing/closed")
+            return
         self._closing = True
 
         # Close all connections manually first.

--- a/newsfragments/92.bugfix.rst
+++ b/newsfragments/92.bugfix.rst
@@ -1,0 +1,3 @@
+``BasicHost.close()`` now stops background services (mDNS, UPnP, bootstrap) and
+cancels identify tasks before closing the network. Test ``HostFactory`` tears
+hosts down via ``close()``, eliminating pending-task warnings (issue #92).

--- a/tests/core/host/test_basic_host.py
+++ b/tests/core/host/test_basic_host.py
@@ -91,13 +91,67 @@ async def test_swarm_stream_handler_no_protocol_selected(monkeypatch):
     monkeypatch.setattr(host.multiselect, "negotiate", fake_negotiate)
 
     # Now run the handler and expect StreamFailure
-    with pytest.raises(
-        StreamFailure, match="Failed to negotiate protocol: no protocol selected"
-    ):
-        await host._swarm_stream_handler(net_stream)
+    try:
+        with pytest.raises(
+            StreamFailure, match="Failed to negotiate protocol: no protocol selected"
+        ):
+            await host._swarm_stream_handler(net_stream)
+    finally:
+        await host.close()
 
     # Ensure reset was called since negotiation failed
     net_stream.reset.assert_awaited()
+
+
+@pytest.mark.trio
+async def test_host_close_is_idempotent():
+    key_pair = create_new_key_pair()
+    swarm = new_swarm(key_pair)
+    swarm.close = AsyncMock(wraps=swarm.close)
+    host = BasicHost(swarm)
+
+    await host.close()
+    await host.close()
+
+    assert host._closed is True
+    swarm.close.assert_awaited_once()
+
+
+@pytest.mark.trio
+async def test_host_close_stops_background_services():
+    key_pair = create_new_key_pair()
+    swarm = new_swarm(key_pair)
+    swarm.close = AsyncMock()
+    host = BasicHost(swarm)
+
+    mdns = MagicMock()
+    bootstrap = MagicMock()
+    upnp = MagicMock()
+    upnp.get_external_ip.return_value = "1.2.3.4"
+    upnp.remove_port_mapping = AsyncMock()
+
+    host.mDNS = mdns
+    host.bootstrap = bootstrap
+    host.upnp = upnp
+
+    mock_listener = MagicMock()
+    mock_listener.get_addrs.return_value = [Multiaddr("/ip4/127.0.0.1/tcp/8000")]
+    swarm.listeners = {"tcp": mock_listener}
+
+    await host.close()
+
+    mdns.stop.assert_called_once()
+    bootstrap.stop.assert_called_once()
+    upnp.remove_port_mapping.assert_awaited_once_with(8000, "TCP")
+    assert host.mDNS is None
+    assert host.bootstrap is None
+    assert host.upnp is None
+
+    # Second close must not re-invoke service teardown.
+    await host.close()
+    mdns.stop.assert_called_once()
+    bootstrap.stop.assert_called_once()
+    upnp.remove_port_mapping.assert_awaited_once()
 
 
 def test_get_addrs_and_transport_addrs():

--- a/tests/core/network/test_swarm.py
+++ b/tests/core/network/test_swarm.py
@@ -155,6 +155,18 @@ async def test_swarm_close_peer(security_protocol):
 
 
 @pytest.mark.trio
+async def test_swarm_close_is_idempotent(security_protocol):
+    async with SwarmFactory.create_and_listen(
+        security_protocol=security_protocol
+    ) as swarm:
+        await swarm.close()
+        assert swarm._closing is True
+        # Second close must be a no-op (HostFactory + SwarmFactory double-close path).
+        await swarm.close()
+        assert swarm._closing is True
+
+
+@pytest.mark.trio
 async def test_swarm_remove_conn(swarm_pair):
     swarm_0, swarm_1 = swarm_pair
     # Get the first connection from the list

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -562,7 +562,11 @@ class HostFactory(factory.Factory):
             connection_config=connection_config,
         ) as swarms:
             hosts = tuple(BasicHost(swarm) for swarm in swarms)
-            yield hosts
+            try:
+                yield hosts
+            finally:
+                for host in hosts:
+                    await host.close()
 
 
 class DummyRouter(IPeerRouting):


### PR DESCRIPTION
## Summary
- Make `BasicHost.close()` idempotent and stop mDNS / UPnP / bootstrap via a shared `_shutdown_background_services()` path also used by `run()` teardown.
- Make `Swarm.close()` idempotent so HostFactory + SwarmFactory double-close is safe.
- Have `HostFactory.create_batch_and_listen` call `host.close()` on teardown; add focused tests and a newsfragment for #92.

This supersedes stale [#1208](https://github.com/libp2p/py-libp2p/pull/1208) (do not revive its `_identify_scopes` design; main already cancels identify via `_identify_tasks`).

Fixes #92

## Test plan
- [x] `pytest tests/core/host/test_basic_host.py` (includes new idempotent / service-stop close tests)
- [x] `pytest tests/core/network/test_swarm.py::test_swarm_close_is_idempotent`
- [x] pre-commit hooks (ruff, mypy, pyrefly) on commit
- [x] CI green on this PR


Made with [Cursor](https://cursor.com)