### PR TITLE
fix: include nim-libp2p interop tests in pyrefly (#1145)

### DIFF
--- a/newsfragments/1145.misc.rst
+++ b/newsfragments/1145.misc.rst
@@ -1,0 +1,1 @@
+Include the nim-libp2p echo interop tests in pyrefly type checking and fix unbound-variable issues in the test helper.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,7 +335,6 @@ project_excludes = [
     "**/*pb2_grpc.py",
     "**/*.pyi",
     ".venv/**",
-    "./tests/interop/nim_libp2p",
     "./tests/core/transport/webrtc",
     "./libp2p/transport/webrtc/_asyncio_bridge.py",
     "./libp2p/transport/webrtc/_aiortc_helpers.py",

--- a/tests/interop/nim_libp2p/test_echo_interop.py
+++ b/tests/interop/nim_libp2p/test_echo_interop.py
@@ -26,9 +26,14 @@ logger = logging.getLogger(__name__)
 class NimEchoServer:
     """Simple nim echo server manager."""
 
+    binary_path: Path
+    process: None | subprocess.Popen
+    peer_id: str | None
+    listen_addr: str | None
+
     def __init__(self, binary_path: Path):
         self.binary_path = binary_path
-        self.process: None | subprocess.Popen = None
+        self.process = None
         self.peer_id = None
         self.listen_addr = None
 
@@ -36,8 +41,10 @@ class NimEchoServer:
         """Start nim echo server and get connection info."""
         logger.info(f"Starting nim echo server: {self.binary_path}")
 
+        # Work around pyrefly missing-attribute on self.binary_path (@_ base).
+        binary_path = self.binary_path  # type: ignore[missing-attribute]
         self.process = subprocess.Popen(
-            [str(self.binary_path)],
+            [str(binary_path)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
@@ -57,16 +64,16 @@ class NimEchoServer:
                 if not line:
                     continue
 
-            logger.info(f"Server: {line}")
+                logger.info(f"Server: {line}")
 
-            if line.startswith("Peer ID:"):
-                self.peer_id = line.split(":", 1)[1].strip()
+                if line.startswith("Peer ID:"):
+                    self.peer_id = line.split(":", 1)[1].strip()
 
-            elif "/quic-v1/p2p/" in line and self.peer_id:
-                if line.strip().startswith("/"):
-                    self.listen_addr = line.strip()
-                    logger.info(f"Server ready: {self.listen_addr}")
-                    return self.peer_id, self.listen_addr
+                elif "/quic-v1/p2p/" in line and self.peer_id:
+                    if line.strip().startswith("/"):
+                        self.listen_addr = line.strip()
+                        logger.info(f"Server ready: {self.listen_addr}")
+                        return self.peer_id, self.listen_addr
 
         await self.stop()
         raise TimeoutError(f"Server failed to start within {SERVER_START_TIMEOUT}s")
@@ -140,7 +147,7 @@ async def run_echo_test(server_addr: str, messages: list[str]):
 
 
 @pytest.mark.trio
-@pytest.mark.timeout(TEST_TIMEOUT)
+@pytest.mark.timeout(TEST_TIMEOUT)  # type: ignore[attr-defined]
 async def test_basic_echo_interop(nim_server):
     """Test basic echo functionality between py-libp2p and nim-libp2p."""
     server, peer_id, listen_addr = nim_server
@@ -167,12 +174,12 @@ async def test_basic_echo_interop(nim_server):
 
 
 @pytest.mark.trio
-@pytest.mark.timeout(TEST_TIMEOUT)
+@pytest.mark.timeout(TEST_TIMEOUT)  # type: ignore[attr-defined]
 async def test_large_message_echo(nim_server):
     """Test echo with larger messages."""
     server, peer_id, listen_addr = nim_server
 
-    large_messages = [
+    large_messages: list[str] = [
         "x" * 1024,
         "y" * 5000,
     ]


### PR DESCRIPTION
## What was wrong?

Fixes #1145

The `tests/interop/nim_libp2p/` tree was excluded from pyrefly in `pyproject.toml` because `test_echo_interop.py` had static analysis errors (notably an unbound `line` variable used outside `if reader:`). Keeping the exclusion was not sustainable.

This also supersedes the stale conflicting PR #1154 (~600 commits behind main).

## How was it fixed?

- Indented server-output parsing under `if reader:` so `line` is never used unbound.
- Added explicit class attribute annotations on `NimEchoServer` and `large_messages: list[str]`.
- Matched the existing interop pattern for `@pytest.mark.timeout` with `# type: ignore[attr-defined]`.
- Worked around a pyrefly `missing-attribute` limitation on `self.binary_path` via a local binding + `# type: ignore[missing-attribute]`.
- Removed only `"./tests/interop/nim_libp2p"` from `project_excludes` (left webrtc / pb2_grpc excludes intact).

### To-Do

- [x] Clean up commit history
- [x] Add or update documentation related to these changes (N/A — test/tooling only)
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![red panda](https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Ailurus_fulgens_RoterPanda_LesserPanda.jpg/640px-Ailurus_fulgens_RoterPanda_LesserPanda.jpg)


Made with [Cursor](https://cursor.com)