### PR TITLE
fix: improve mplex warning logs and QUIC/Mplex type annotations

### DIFF
--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -205,7 +205,7 @@ class Mplex(IMuxedConn):
 
     async def send_message(
         self, flag: HeaderTags, data: bytes | None, stream_id: StreamID
-    ) -> int:
+    ) -> None:
         """
         Send a message over the connection.
 
@@ -221,8 +221,7 @@ class Mplex(IMuxedConn):
 
         _bytes = header + encode_varint_prefixed(data)
 
-        # type ignored TODO figure out return for this and write_to_stream
-        return await self.write_to_stream(_bytes)  # type: ignore
+        await self.write_to_stream(_bytes)
 
     async def write_to_stream(self, _bytes: bytes) -> None:
         """
@@ -313,7 +312,7 @@ class Mplex(IMuxedConn):
             await self._handle_reset(stream_id)
         else:
             # Receives messages with an unknown flag
-            # TODO: logging
+            logger.warning("Received message with unknown flag: %d", flag)
             async with self.streams_lock:
                 if stream_id in self.streams:
                     stream = self.streams[stream_id]
@@ -337,13 +336,19 @@ class Mplex(IMuxedConn):
             if stream_id not in self.streams:
                 # We receive a message of the stream `stream_id` which is not accepted
                 #   before. It is abnormal. Possibly disconnect?
-                # TODO: Warn and emit logs about this.
+                logger.warning(
+                    "Received message for non-existent stream: %s", stream_id
+                )
                 return
             stream = self.streams[stream_id]
             send_channel = self.streams_msg_channels[stream_id]
         async with stream.close_lock:
             if stream.event_remote_closed.is_set():
-                # TODO: Warn "Received data from remote after stream was closed by them. (len = %d)"  # noqa: E501
+                logger.warning(
+                    "Received data from remote after stream was closed by them. "
+                    "(len = %d)",
+                    len(message),
+                )
                 return
         try:
             send_channel.send_nowait(message)

--- a/libp2p/transport/quic/exceptions.py
+++ b/libp2p/transport/quic/exceptions.py
@@ -3,7 +3,8 @@ QUIC Transport exceptions
 """
 
 import logging
-from typing import Any, Literal
+from types import TracebackType
+from typing import Literal
 
 import trio
 
@@ -360,7 +361,7 @@ class QUICErrorContext:
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
-        exc_tb: Any,
+        exc_tb: TracebackType | None,
     ) -> Literal[False]:
         if exc_type is None or exc_val is None:
             return False

--- a/newsfragments/1135.internal.rst
+++ b/newsfragments/1135.internal.rst
@@ -1,0 +1,1 @@
+Improved Mplex edge-case warning logs and corrected QUIC/Mplex type annotations.

--- a/tests/core/stream_muxer/test_mplex_logging.py
+++ b/tests/core/stream_muxer/test_mplex_logging.py
@@ -1,0 +1,137 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+from multiaddr import Multiaddr
+import trio
+
+from libp2p.abc import ConnectionType, ISecureConn
+from libp2p.crypto.keys import PrivateKey, PublicKey
+from libp2p.peer.id import ID
+from libp2p.stream_muxer.mplex.datastructures import StreamID
+from libp2p.stream_muxer.mplex.mplex import Mplex
+
+DUMMY_PEER_ID = ID(b"dummy_peer_id")
+MPLEX_LOGGER_NAME = "libp2p.stream_muxer.mplex.mplex"
+
+
+class DummySecuredConn(ISecureConn):
+    def __init__(self, is_initiator: bool = False):
+        self.is_initiator = is_initiator
+
+    async def write(self, data: bytes) -> None:
+        pass
+
+    async def read(self, n: int | None = -1) -> bytes:
+        return b""
+
+    async def close(self) -> None:
+        pass
+
+    def get_remote_address(self):
+        return None
+
+    def get_local_address(self):
+        return None
+
+    def get_local_peer(self) -> ID:
+        return ID(b"local")
+
+    def get_local_private_key(self) -> PrivateKey:
+        return Mock(spec=PrivateKey)
+
+    def get_remote_peer(self) -> ID:
+        return DUMMY_PEER_ID
+
+    def get_remote_public_key(self) -> PublicKey:
+        return Mock(spec=PublicKey)
+
+    def get_transport_addresses(self) -> list[Multiaddr]:
+        return []
+
+    def get_connection_type(self) -> ConnectionType:
+        return ConnectionType.DIRECT
+
+
+class _LogCollector(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def mplex_log_records():
+    """
+    Capture records from the mplex logger directly.
+
+    pytest ``caplog`` is unreliable here because ``libp2p/utils/logging.py`` may
+    set ``propagate=False`` on the ``libp2p`` hierarchy.
+    """
+    target = logging.getLogger(MPLEX_LOGGER_NAME)
+    handler = _LogCollector()
+    prev_level = target.level
+    prev_disabled = target.disabled
+    target.setLevel(logging.WARNING)
+    target.disabled = False
+    target.addHandler(handler)
+    try:
+        yield handler.records
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prev_level)
+        target.disabled = prev_disabled
+
+
+@pytest.mark.trio
+async def test_handle_incoming_unknown_flag_logs_warning(mplex_log_records):
+    mplex = Mplex(DummySecuredConn(), DUMMY_PEER_ID)
+    unknown_flag = 7
+    channel_id = 42
+
+    async def fake_read_message() -> tuple[int, int, bytes]:
+        return channel_id, unknown_flag, b""
+
+    mplex.read_message = fake_read_message  # type: ignore[method-assign]
+
+    await mplex._handle_incoming_message()
+
+    assert any(
+        f"Received message with unknown flag: {unknown_flag}" in record.getMessage()
+        for record in mplex_log_records
+    )
+
+
+@pytest.mark.trio
+async def test_handle_message_nonexistent_stream_logs_warning(mplex_log_records):
+    mplex = Mplex(DummySecuredConn(), DUMMY_PEER_ID)
+    stream_id = StreamID(channel_id=99, is_initiator=True)
+
+    await mplex._handle_message(stream_id, b"payload")
+
+    assert any(
+        f"Received message for non-existent stream: {stream_id}" in record.getMessage()
+        for record in mplex_log_records
+    )
+
+
+@pytest.mark.trio
+async def test_handle_message_after_remote_close_logs_warning(mplex_log_records):
+    mplex = Mplex(DummySecuredConn(), DUMMY_PEER_ID)
+    stream_id = StreamID(channel_id=1, is_initiator=True)
+    stream = await mplex._initialize_stream(stream_id, "1")
+    stream.event_remote_closed.set()
+    payload = b"late-data"
+
+    await mplex._handle_message(stream_id, payload)
+
+    assert any(
+        "Received data from remote after stream was closed by them. "
+        f"(len = {len(payload)})" in record.getMessage()
+        for record in mplex_log_records
+    )
+    # Message must not be delivered after remote close.
+    with pytest.raises(trio.WouldBlock):
+        stream.incoming_data_channel.receive_nowait()


### PR DESCRIPTION
Fixes #1135
Supersedes #1137

## What was wrong?

Several TODOs related to type safety and logging remained on `main`:

1. `QUICErrorContext.__exit__` typed `exc_tb` as `Any` instead of `TracebackType | None` (the duplicate `| None | None` on `exc_type` was already fixed earlier).
2. `Mplex.send_message` was annotated `-> int` but called `write_to_stream()` which returns `None`, requiring a `# type: ignore`.
3. Three mplex edge cases only had TODO comments for missing `logger.warning()` calls (unknown flag, message for non-existent stream, data after remote close).

## How was it fixed?

- Import `TracebackType` and correct the `__exit__` signature in `libp2p/transport/quic/exceptions.py`.
- Change `send_message` to `-> None`, await `write_to_stream` without returning, and drop the `# type: ignore`.
- Add `logger.warning()` for the three edge cases in `libp2p/stream_muxer/mplex/mplex.py`.
- Add focused tests that capture warnings directly on the mplex logger (same approach as BasicHost log tests, since `caplog` is unreliable when `libp2p` logging sets `propagate=False`).
- Add `newsfragments/1135.internal.rst`.

This replaces stale conflicting PR #1137 (fork was not maintainer-modifiable and had drifted far from `main`).

## Testing

### Commands

```bash
source .venv/bin/activate
make lint
make typecheck
make validate-newsfragments
pytest tests/core/stream_muxer/ -q
```

### Results

```text
# make lint
...
run mypy with all dev dependencies present...............................Passed
run pyrefly typecheck locally............................................Passed
Cross-platform path handling audit (P0/P1)...............................Passed

# make typecheck
run mypy with all dev dependencies present...............................Passed
run pyrefly typecheck locally............................................Passed

# make validate-newsfragments
# draft includes:
- Improved Mplex edge-case warning logs and corrected QUIC/Mplex type annotations. (#1135)

# pytest tests/core/stream_muxer/ -q
======================= 131 passed in 182.71s (0:03:02) ========================
# including 3 new tests in test_mplex_logging.py
```

## Demo / examples

N/A — no user-facing demo or example change.

Made with [Cursor](https://cursor.com)