### PR TITLE
feat: add DHT Peer-ID chat example (issue #880)

### DIFF
--- a/docs/examples.dht_chat.rst
+++ b/docs/examples.dht_chat.rst
@@ -164,22 +164,34 @@ Interactive commands:
 Automated network-size mode
 ---------------------------
 
-For scaling checks, spin up ``N`` loopback peers in one process. Peer 0 is the
-intro node; peers ``1..N-1`` join it; peer 1 looks up peer ``N-1`` by Peer ID
-and sends a chat message::
+For scaling checks, spin up ``N`` loopback peers in one process, join them in a
+**tree** (peer ``i`` dials parent ``(i-1)//2``), warm routing tables, then run
+random directed ``src -> dst`` pairs. Each pair must:
+
+1. Resolve the destination with ``KadDHT.find_peer`` (Peer ID only)
+2. Deliver a ``/dht-chat/1.0.0`` message
+
+Completeness means **all pairs succeed**. Latencies are reported in
+milliseconds (so sub-10ms chat no longer looks like ``0.00s``).
+
+::
 
     $ python -m examples.dht_chat.dht_chat --network-size 10
-    === DHT network-size experiment: N=10 ===
-    Joined 9 peers to intro in 0.25s (intro connected=9)
-    Routing table sizes: intro=9 source(peer1)=1 target(peer9)=1 min=1 max=9 median=1
-    Peer 1 looked up peer 9 via DHT in 0.29s (1 attempt(s), 1 addr(s))
-    Chat delivery OK in 0.00s
-    TOTAL N=10: join=0.25s lookup=0.29s msg=0.00s wall=0.56s
+    === DHT network-size experiment: N=10 pairs=10 seed=880 ===
+    Join phase done in 0.76s: ok=9 fail=0 joined=10/10
+    Overlay warm-up done in 0.96s
+    Running 10 lookup+chat pairs ...
+    === Pair results ===
+    pairs: ok=10/10 fail=0 success_rate=100.0% ...
+    lookup_ms: p50=... p95=...
+    msg_ms: p50=... p95=...
+    COMPLETE: all lookup+chat pairs succeeded
 
-On the same machine, ``N=100`` completed successfully as well (join ~1s,
-lookup ~0.3s, chat OK). Joiners typically keep a small routing table (often
-just the intro) while the intro accumulates everyone; ``find_peer`` still
-succeeds because peer 1 queries the intro, which knows the target.
+Useful flags:
+
+- ``-n`` / ``--network-size N`` — number of peers
+- ``-k`` / ``--pair-count K`` — number of random directed pairs (default ``min(N, 40)``)
+- ``--seed`` — RNG seed for pair selection
 
 Notes
 -----
@@ -188,6 +200,8 @@ Notes
 - On a small local cluster, DHT query traffic may already dial other joiners
   before you type ``connect``. Use ``lookup`` to always exercise
   ``find_peer`` explicitly.
+- In-process ``N=1000+`` is limited by local handshake/FD load; prefer the
+  pair battery at moderate ``N`` for correctness, not a single lucky path.
 - This example does not cover NAT traversal or public IPFS bootstrap lists;
   see :doc:`examples.nat`, :doc:`examples.circuit_relay`, and
   :doc:`examples.kademlia` for related topics.

--- a/docs/examples.dht_chat.rst
+++ b/docs/examples.dht_chat.rst
@@ -1,0 +1,172 @@
+DHT Peer-ID Chat Demo
+=====================
+
+This example demonstrates **decentralized messaging with DHT bootstrap**
+(issue `#880 <https://github.com/libp2p/py-libp2p/issues/880>`_): after a
+one-time introduction into a KadDHT overlay, peers look each other up by
+**Peer ID** and open a direct chat stream — without pasting full multiaddrs
+for every messaging dial.
+
+What this demonstrates
+----------------------
+
+- Messaging dApps often hardcode bootstrap / rendezvous servers just to find
+  chat peers.
+- With KadDHT, peers that already share an overlay can resolve
+  ``PeerInfo`` via ``KadDHT.find_peer(peer_id)`` and then dial.
+- The DHT is a **routing layer**, not magic: an empty routing table cannot
+  resolve Peer IDs. You still need a one-time intro (``--bootstrap``
+  multiaddr in this demo). After that, subsequent dials use Peer IDs only.
+
+How discovery works
+-------------------
+
+1. **Intro (once):** Peer A starts with no ``--bootstrap``. Peers B and C
+   dial A's multiaddr once to join the overlay and seed their routing tables.
+2. **Lookup:** B runs ``lookup <C_peer_id>`` / ``connect <C_peer_id>``. The
+   node calls ``KadDHT.find_peer`` and receives C's listen addresses from the
+   DHT (typically via A, which knows both joiners).
+3. **Chat:** B opens a ``/dht-chat/1.0.0`` stream to C and sends a message.
+
+This is different from :doc:`examples.chat`, where every dial requires the
+full destination multiaddr.
+
+Quick start
+-----------
+
+Install and run from a checkout (or use the ``dht-chat-demo`` console script
+after installing the package)::
+
+    $ python -m examples.dht_chat.dht_chat --port 18001
+
+Copy the printed ``--bootstrap`` multiaddr (loopback is fine on one machine)::
+
+    $ python -m examples.dht_chat.dht_chat --port 18002 \
+        --bootstrap /ip4/127.0.0.1/tcp/18001/p2p/<PEER_A_ID>
+
+    $ python -m examples.dht_chat.dht_chat --port 18003 \
+        --bootstrap /ip4/127.0.0.1/tcp/18001/p2p/<PEER_A_ID>
+
+Then on peer B (Peer ID of C only — no multiaddr)::
+
+    > lookup <PEER_C_ID>
+    > msg <PEER_C_ID> hello
+
+Walkthrough (live demo transcript)
+----------------------------------
+
+The following logs were captured from a real three-process run on one host.
+Noisy internal DHT stream warnings were omitted for readability.
+
+Phase 1 — start intro peer A
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Peer A starts with an empty DHT. Other peers will use its multiaddr once to
+join the overlay.
+
+.. code-block:: console
+
+    $ python -m examples.dht_chat.dht_chat --port 18001
+    INFO Started as intro peer (empty DHT until others --bootstrap here)
+
+    === DHT Chat node ready ===
+    Peer ID: 12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+    Listening on:
+      /ip4/127.0.0.1/tcp/18001/p2p/12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+      ...
+
+    Other peers can join the overlay with:
+      dht-chat-demo --bootstrap /ip4/127.0.0.1/tcp/18001/p2p/12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+
+Phase 2 — B and C join via ``--bootstrap``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+B and C dial A once. After this, they share a DHT overlay with A (and will
+learn about each other through routing-table maintenance and FIND_NODE).
+
+.. code-block:: console
+
+    $ python -m examples.dht_chat.dht_chat --port 18002 \
+        --bootstrap /ip4/127.0.0.1/tcp/18001/p2p/12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+    INFO Connecting to intro peer 12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+    INFO Joined DHT overlay via intro peer 12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+
+    === DHT Chat node ready ===
+    Peer ID: 12D3KooWLLjeAnSrVfC2CH1SYT1GMGPWvF5eJ2LVmpCAYsswsmN5
+    ...
+
+.. code-block:: console
+
+    $ python -m examples.dht_chat.dht_chat --port 18003 \
+        --bootstrap /ip4/127.0.0.1/tcp/18001/p2p/12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+    INFO Connecting to intro peer 12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+    INFO Joined DHT overlay via intro peer 12D3KooWPdi4NB7hkNaGVHKs1VhMvc6dXphLa1kpGPUzuoCn25Y8
+
+    === DHT Chat node ready ===
+    Peer ID: 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok
+    ...
+
+Phase 3 — B resolves C by Peer ID only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+B does **not** paste C's multiaddr. ``lookup`` calls ``KadDHT.find_peer`` and
+prints the addresses returned by the DHT.
+
+.. code-block:: console
+
+    > lookup 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok
+    INFO Looking up 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok via KadDHT.find_peer ...
+    INFO DHT found 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok with 6 addr(s)
+    lookup ok: 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok
+      /ip4/127.0.0.1/tcp/18003/p2p/12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok
+      ...
+
+Phase 4 — send a chat message
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``msg`` dials if needed and opens ``/dht-chat/1.0.0``. C prints the inbound
+message.
+
+.. code-block:: console
+
+    # on B
+    > msg 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok hello-from-B-via-DHT
+    INFO Sent to 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok: hello-from-B-via-DHT
+
+.. code-block:: console
+
+    # on C
+    [12D3KooWLLjeAnSrVfC2CH1SYT1GMGPWvF5eJ2LVmpCAYsswsmN5] hello-from-B-via-DHT
+
+Command reference
+-----------------
+
+.. code-block:: console
+
+    $ python -m examples.dht_chat.dht_chat --help
+
+CLI flags:
+
+- ``-p`` / ``--port`` — TCP listen port (``0`` = ephemeral)
+- ``-b`` / ``--bootstrap`` — intro peer multiaddr
+
+Interactive commands:
+
+- ``id`` — print local Peer ID
+- ``addrs`` — print listen multiaddrs
+- ``peers`` — connected peers and routing-table size
+- ``lookup <peer_id>`` — ``KadDHT.find_peer`` only (no dial)
+- ``connect <peer_id>`` — lookup (if needed) then dial
+- ``msg <peer_id> <text>`` — send a chat line
+- ``help`` / ``quit``
+
+Notes
+-----
+
+- All demo peers run KadDHT in **SERVER** mode so they answer FIND_NODE.
+- On a small local cluster, DHT query traffic may already dial other joiners
+  before you type ``connect``. Use ``lookup`` to always exercise
+  ``find_peer`` explicitly.
+- This example does not cover NAT traversal or public IPFS bootstrap lists;
+  see :doc:`examples.nat`, :doc:`examples.circuit_relay`, and
+  :doc:`examples.kademlia` for related topics.

--- a/docs/examples.dht_chat.rst
+++ b/docs/examples.dht_chat.rst
@@ -149,6 +149,7 @@ CLI flags:
 
 - ``-p`` / ``--port`` — TCP listen port (``0`` = ephemeral)
 - ``-b`` / ``--bootstrap`` — intro peer multiaddr
+- ``-n`` / ``--network-size N`` — automated in-process experiment with ``N`` peers
 
 Interactive commands:
 
@@ -159,6 +160,26 @@ Interactive commands:
 - ``connect <peer_id>`` — lookup (if needed) then dial
 - ``msg <peer_id> <text>`` — send a chat line
 - ``help`` / ``quit``
+
+Automated network-size mode
+---------------------------
+
+For scaling checks, spin up ``N`` loopback peers in one process. Peer 0 is the
+intro node; peers ``1..N-1`` join it; peer 1 looks up peer ``N-1`` by Peer ID
+and sends a chat message::
+
+    $ python -m examples.dht_chat.dht_chat --network-size 10
+    === DHT network-size experiment: N=10 ===
+    Joined 9 peers to intro in 0.25s (intro connected=9)
+    Routing table sizes: intro=9 source(peer1)=1 target(peer9)=1 min=1 max=9 median=1
+    Peer 1 looked up peer 9 via DHT in 0.29s (1 attempt(s), 1 addr(s))
+    Chat delivery OK in 0.00s
+    TOTAL N=10: join=0.25s lookup=0.29s msg=0.00s wall=0.56s
+
+On the same machine, ``N=100`` completed successfully as well (join ~1s,
+lookup ~0.3s, chat OK). Joiners typically keep a small routing table (often
+just the intro) while the intro accumulates everyone; ``find_peer`` still
+succeeds because peer 1 queries the intro, which knows the target.
 
 Notes
 -----

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,6 +8,7 @@ Examples
    examples.identify
    examples.identify_push
    examples.chat
+   examples.dht_chat
    examples.echo
    examples.echo_quic
    examples.ping

--- a/examples/dht_chat/__init__.py
+++ b/examples/dht_chat/__init__.py
@@ -1,0 +1,1 @@
+"""DHT Peer-ID chat example for decentralized messaging demos."""

--- a/examples/dht_chat/dht_chat.py
+++ b/examples/dht_chat/dht_chat.py
@@ -21,6 +21,8 @@ from contextlib import (
     AsyncExitStack,
 )
 import logging
+import random
+import statistics
 import sys
 import time
 
@@ -323,134 +325,312 @@ async def run(port: int, bootstrap: str | None) -> None:
             await command_loop(host, dht, nursery)
 
 
-async def run_network_size(network_size: int) -> None:
+async def run_network_size(
+    network_size: int,
+    pair_count: int | None = None,
+    seed: int = 880,
+) -> None:
     """
-    Spin up ``network_size`` in-process DHT chat peers and exercise Peer-ID lookup.
+    Spin up ``network_size`` in-process DHT chat peers and run a multi-pair exam.
 
-    Topology: peer 0 is the intro node; peers 1..N-1 dial peer 0 once. Then peer 1
-    resolves peer N-1 via ``KadDHT.find_peer`` (no multiaddr) and sends a chat
-    message.
+    Completeness: after a tree-shaped join, run ``pair_count`` random directed
+    pairs ``(src -> dst)``. Each pair must ``KadDHT.find_peer(dst)`` (Peer ID
+    only) and deliver a chat message. Reports success rate and latencies in ms.
     """
     if network_size < 2:
         raise ValueError("--network-size must be >= 2")
 
-    print(f"=== DHT network-size experiment: N={network_size} ===")
+    max_pairs = network_size * (network_size - 1)
+    if pair_count is None:
+        # Enough random coverage to be meaningful without O(N^2) cost.
+        pair_count = min(max_pairs, max(network_size, 10), 40)
+    if pair_count < 1:
+        raise ValueError("--pair-count must be >= 1")
+    if pair_count > max_pairs:
+        pair_count = max_pairs
+
+    rng = random.Random(seed)
+    print(
+        f"=== DHT network-size experiment: N={network_size} "
+        f"pairs={pair_count} seed={seed} ===",
+        flush=True,
+    )
     t0 = time.perf_counter()
 
     async with AsyncExitStack() as stack:
         hosts = []
         dhts: list[KadDHT] = []
-        ports: list[int] = []
 
+        t_boot = time.perf_counter()
         for i in range(network_size):
             port = find_free_port()
-            ports.append(port)
             host = new_host()
-            # Loopback-only keeps large-N demos lightweight.
             listen = [Multiaddr(f"/ip4/127.0.0.1/tcp/{port}")]
             await stack.enter_async_context(host.run(listen_addrs=listen))
             hosts.append(host)
+            if (i + 1) % 500 == 0 or i + 1 == network_size:
+                print(
+                    f"Started {i + 1}/{network_size} hosts "
+                    f"({time.perf_counter() - t_boot:.1f}s)",
+                    flush=True,
+                )
 
-        received = trio.Event()
-        got: dict[str, bytes | None] = {"data": None}
-        target_idx = network_size - 1
+        # Per-payload waiters so many peers can receive concurrent chat messages.
+        pending: dict[bytes, trio.Event] = {}
+        pending_lock = trio.Lock()
 
-        async def target_handler(stream: INetStream) -> None:
-            data = await stream.read(MAX_READ_LEN)
-            got["data"] = data
-            received.set()
-            await stream.close()
+        def make_handler(_host_idx: int):
+            async def handler(stream: INetStream) -> None:
+                data = b""
+                try:
+                    data = await stream.read(MAX_READ_LEN)
+                finally:
+                    try:
+                        await stream.close()
+                    except Exception:
+                        pass
+                if not data:
+                    return
+                async with pending_lock:
+                    event = pending.pop(data, None)
+                if event is not None:
+                    event.set()
 
-        hosts[target_idx].set_stream_handler(PROTOCOL_ID, target_handler)
+            return handler
+
+        for i, host in enumerate(hosts):
+            host.set_stream_handler(PROTOCOL_ID, make_handler(i))
 
         for host in hosts:
             dht = KadDHT(host, DHTMode.SERVER)
             await stack.enter_async_context(background_trio_service(dht))
             dhts.append(dht)
-
-        intro = PeerInfo(hosts[0].get_id(), hosts[0].get_addrs())
-        join_limiter = trio.CapacityLimiter(min(32, network_size))
-
-        async def join_peer(i: int) -> None:
-            async with join_limiter:
-                await hosts[i].connect(intro)
-                await dhts[i].add_peer(hosts[0].get_id())
-
-        t_join = time.perf_counter()
-        async with trio.open_nursery() as nursery:
-            for i in range(1, network_size):
-                nursery.start_soon(join_peer, i)
-        join_s = time.perf_counter() - t_join
         print(
-            f"Joined {network_size - 1} peers to intro in {join_s:.2f}s "
-            f"(intro connected={len(hosts[0].get_connected_peers())})"
+            f"DHT services started for {network_size} peers "
+            f"({time.perf_counter() - t0:.1f}s)",
+            flush=True,
         )
 
-        # Seed intro RT with everyone currently connected.
-        for peer_id in hosts[0].get_connected_peers():
-            await dhts[0].add_peer(peer_id)
+        # Tree bootstrap: peer i dials parent (i-1)//2 (avoids star flood on root).
+        join_limit = 8 if network_size >= 200 else min(16, network_size)
+        join_limiter = trio.CapacityLimiter(join_limit)
+        join_stats = {"ok": 0, "fail": 0}
+        joined = {0}
+        join_lock = trio.Lock()
 
-        # Give routing tables a moment to settle under load.
-        settle_deadline = time.perf_counter() + min(30.0, 2.0 + network_size * 0.05)
-        while time.perf_counter() < settle_deadline:
-            for peer_id in hosts[0].get_connected_peers():
-                await dhts[0].add_peer(peer_id)
-            if dhts[0].get_routing_table_size() >= min(network_size - 1, 20):
-                break
-            await trio.sleep(0.2)
+        async def join_peer(i: int) -> None:
+            parent = (i - 1) // 2
+            parent_info = PeerInfo(hosts[parent].get_id(), hosts[parent].get_addrs())
+            async with join_limiter:
+                last_exc: Exception | None = None
+                for attempt in range(8):
+                    try:
+                        await hosts[i].connect(parent_info)
+                        await dhts[i].add_peer(hosts[parent].get_id())
+                        await dhts[parent].add_peer(hosts[i].get_id())
+                        async with join_lock:
+                            join_stats["ok"] += 1
+                            joined.add(i)
+                        return
+                    except Exception as exc:
+                        last_exc = exc
+                        await trio.sleep(0.05 * (attempt + 1))
+                async with join_lock:
+                    join_stats["fail"] += 1
+                logger.warning(
+                    "Join failed for peer %s (parent=%s): %s", i, parent, last_exc
+                )
 
-        rt_sizes = [d.get_routing_table_size() for d in dhts]
+        t_join = time.perf_counter()
+        level = [1, 2] if network_size > 2 else ([1] if network_size > 1 else [])
+        level = [i for i in level if i < network_size]
+        while level:
+            async with trio.open_nursery() as nursery:
+                for i in level:
+                    nursery.start_soon(join_peer, i)
+            next_level: list[int] = []
+            for i in level:
+                for child in (2 * i + 1, 2 * i + 2):
+                    if child < network_size:
+                        next_level.append(child)
+            level = next_level
+        join_s = time.perf_counter() - t_join
+        print(
+            f"Join phase done in {join_s:.2f}s: ok={join_stats['ok']} "
+            f"fail={join_stats['fail']} joined={len(joined)}/{network_size}",
+            flush=True,
+        )
+        if len(joined) < 2:
+            raise RuntimeError("Need at least 2 joined peers for pair testing")
+
+        joined_list = sorted(joined)
+
+        # Seed RT from live connections, and push each peer's PeerInfo up the
+        # tree so ancestors can answer FIND_NODE without everyone dialing root.
+        t_warm = time.perf_counter()
+        for i in joined_list:
+            for peer_id in hosts[i].get_connected_peers():
+                await dhts[i].add_peer(peer_id)
+
+        for i in joined_list:
+            if i == 0:
+                continue
+            info = PeerInfo(hosts[i].get_id(), hosts[i].get_addrs())
+            cur = i
+            while cur > 0:
+                parent = (cur - 1) // 2
+                try:
+                    hosts[parent].get_peerstore().add_addrs(
+                        info.peer_id, info.addrs, 60 * 60
+                    )
+                except Exception:
+                    pass
+                await dhts[parent].add_peer(info.peer_id, skip_server_mode_check=True)
+                cur = parent
+
+        # Bounded FIND_NODE warm toward root (best-effort record exchange).
+        warm_limiter = trio.CapacityLimiter(min(8, network_size))
+
+        async def warm_peer(i: int) -> None:
+            async with warm_limiter:
+                with trio.move_on_after(1.0):
+                    try:
+                        await dhts[i].find_peer(hosts[0].get_id())
+                    except Exception:
+                        pass
+
+        async with trio.open_nursery() as nursery:
+            for i in joined_list:
+                if i != 0:
+                    nursery.start_soon(warm_peer, i)
+        warm_s = time.perf_counter() - t_warm
+        print(f"Overlay warm-up done in {warm_s:.2f}s", flush=True)
+
+        rt_sizes = [dhts[i].get_routing_table_size() for i in joined_list]
         median_rt = sorted(rt_sizes)[len(rt_sizes) // 2]
         print(
             "Routing table sizes: "
-            f"intro={rt_sizes[0]} "
-            f"source(peer1)={rt_sizes[1]} "
-            f"target(peer{target_idx})={rt_sizes[target_idx]} "
-            f"min={min(rt_sizes)} max={max(rt_sizes)} median={median_rt}"
+            f"min={min(rt_sizes)} max={max(rt_sizes)} median={median_rt}",
+            flush=True,
         )
 
-        source_host, source_dht = hosts[1], dhts[1]
-        target_id = hosts[target_idx].get_id()
+        # Build unique random directed pairs among joined peers.
+        all_directed = [(a, b) for a in joined_list for b in joined_list if a != b]
+        rng.shuffle(all_directed)
+        pairs = all_directed[:pair_count]
 
-        t_lookup = time.perf_counter()
-        found: PeerInfo | None = None
-        attempts = 0
-        with trio.fail_after(60):
-            while True:
-                attempts += 1
-                found = await source_dht.find_peer(target_id)
-                if found is not None and found.addrs:
+        lookup_ms: list[float] = []
+        msg_ms: list[float] = []
+        pair_ok = 0
+        pair_fail = 0
+        lookup_budget = min(60.0, 10.0 + network_size * 0.02)
+
+        print(f"Running {len(pairs)} lookup+chat pairs ...", flush=True)
+        t_pairs = time.perf_counter()
+        for idx, (src, dst) in enumerate(pairs, start=1):
+            pair_succeeded = False
+            last_exc: Exception | None = None
+            for attempt in range(3):
+                payload = f"pair-{src}-{dst}-{idx}-{seed}-a{attempt}\n".encode()
+                event = trio.Event()
+                async with pending_lock:
+                    pending[payload] = event
+                try:
+                    t_lookup = time.perf_counter()
+                    found: PeerInfo | None = None
+                    with trio.fail_after(lookup_budget):
+                        while True:
+                            found = await dhts[src].find_peer(hosts[dst].get_id())
+                            if found is not None and found.addrs:
+                                break
+                            await trio.sleep(0.1)
+                    assert found is not None
+                    lookup_ms.append((time.perf_counter() - t_lookup) * 1000.0)
+
+                    t_msg = time.perf_counter()
+                    await hosts[src].connect(found)
+                    await dhts[src].add_peer(found.peer_id)
+                    stream = await hosts[src].new_stream(found.peer_id, [PROTOCOL_ID])
+                    try:
+                        await stream.write(payload)
+                    finally:
+                        await stream.close()
+                    with trio.fail_after(15):
+                        await event.wait()
+                    msg_ms.append((time.perf_counter() - t_msg) * 1000.0)
+                    pair_succeeded = True
+                    pair_ok += 1
                     break
-                await trio.sleep(0.2)
-        lookup_s = time.perf_counter() - t_lookup
-        assert found is not None
-        print(
-            f"Peer 1 looked up peer {target_idx} via DHT in {lookup_s:.2f}s "
-            f"({attempts} attempt(s), {len(found.addrs)} addr(s))"
-        )
+                except Exception as exc:
+                    last_exc = exc
+                    async with pending_lock:
+                        pending.pop(payload, None)
+                    await trio.sleep(0.2 * (attempt + 1))
 
-        t_msg = time.perf_counter()
-        await source_host.connect(found)
-        stream = await source_host.new_stream(target_id, [PROTOCOL_ID])
-        payload = f"hello-from-N{network_size}\n".encode()
-        try:
-            await stream.write(payload)
-        finally:
-            await stream.close()
+            if not pair_succeeded:
+                pair_fail += 1
+                err = (
+                    f"{type(last_exc).__name__}: {last_exc}" if last_exc else "unknown"
+                )
+                print(
+                    f"  FAIL pair {idx}/{len(pairs)} {src}->{dst}: {err}",
+                    flush=True,
+                )
 
-        with trio.fail_after(30):
-            await received.wait()
-        msg_s = time.perf_counter() - t_msg
+            if idx == len(pairs) or idx % max(1, len(pairs) // 5) == 0:
+                print(
+                    f"  progress {idx}/{len(pairs)} ok={pair_ok} fail={pair_fail}",
+                    flush=True,
+                )
 
-        ok = got["data"] == payload
+        pairs_s = time.perf_counter() - t_pairs
         total_s = time.perf_counter() - t0
-        print(f"Chat delivery {'OK' if ok else 'FAIL'} in {msg_s:.2f}s")
+        success_rate = 100.0 * pair_ok / len(pairs)
+
+        def _pct(values: list[float], p: float) -> float:
+            if not values:
+                return float("nan")
+            ordered = sorted(values)
+            rank = int(round((p / 100.0) * (len(ordered) - 1)))
+            return ordered[rank]
+
+        print("=== Pair results ===", flush=True)
         print(
-            f"TOTAL N={network_size}: join={join_s:.2f}s lookup={lookup_s:.2f}s "
-            f"msg={msg_s:.2f}s wall={total_s:.2f}s"
+            f"pairs: ok={pair_ok}/{len(pairs)} fail={pair_fail} "
+            f"success_rate={success_rate:.1f}% in {pairs_s:.2f}s",
+            flush=True,
         )
-        if not ok:
-            raise RuntimeError(f"Unexpected payload: {got['data']!r}")
+        if lookup_ms:
+            print(
+                "lookup_ms: "
+                f"p50={_pct(lookup_ms, 50):.1f} "
+                f"p95={_pct(lookup_ms, 95):.1f} "
+                f"mean={statistics.fmean(lookup_ms):.1f} "
+                f"max={max(lookup_ms):.1f}",
+                flush=True,
+            )
+        if msg_ms:
+            print(
+                "msg_ms: "
+                f"p50={_pct(msg_ms, 50):.1f} "
+                f"p95={_pct(msg_ms, 95):.1f} "
+                f"mean={statistics.fmean(msg_ms):.1f} "
+                f"max={max(msg_ms):.1f}",
+                flush=True,
+            )
+        print(
+            f"TOTAL N={network_size}: join={join_s:.2f}s warm={warm_s:.2f}s "
+            f"pairs={pairs_s:.2f}s wall={total_s:.2f}s "
+            f"join_fail={join_stats['fail']}",
+            flush=True,
+        )
+
+        if pair_fail:
+            raise RuntimeError(
+                f"Pair battery incomplete: {pair_ok}/{len(pairs)} succeeded "
+                f"({success_rate:.1f}%)"
+            )
+        print("COMPLETE: all lookup+chat pairs succeeded", flush=True)
 
 
 def main() -> None:
@@ -460,8 +640,9 @@ def main() -> None:
     Interactive mode: start one intro peer, then join others with
     --bootstrap <multiaddr>. Subsequent dials use KadDHT.find_peer(peer_id).
 
-    Automated mode: --network-size N spins up N in-process peers, joins them
-    through one intro peer, then has peer 1 look up peer N-1 by Peer ID and chat.
+    Automated mode: --network-size N spins up N in-process peers (tree join),
+    warms the DHT, then runs random src->dst lookup+chat pairs and reports
+    success rate plus lookup/msg latency in milliseconds.
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
@@ -485,15 +666,36 @@ def main() -> None:
         default=None,
         help="Run automated N-peer DHT overlay experiment (N >= 2) and exit",
     )
+    parser.add_argument(
+        "-k",
+        "--pair-count",
+        type=int,
+        default=None,
+        help="Random directed lookup+chat pairs to run (default: min(N,40))",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=880,
+        help="RNG seed for pair selection (default: 880)",
+    )
     args = parser.parse_args()
 
     try:
         if args.network_size is not None:
-            trio.run(run_network_size, args.network_size)
+            trio.run(
+                run_network_size,
+                args.network_size,
+                args.pair_count,
+                args.seed,
+            )
         else:
             trio.run(run, args.port, args.bootstrap)
     except KeyboardInterrupt:
         pass
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr, flush=True)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/examples/dht_chat/dht_chat.py
+++ b/examples/dht_chat/dht_chat.py
@@ -1,0 +1,351 @@
+"""
+DHT-based chat example: look up peers by Peer ID, then open a chat stream.
+
+This demo shows how KadDHT can replace hardcoded messaging bootstrap servers
+*after* peers have joined a DHT overlay. A one-time introduction (``--bootstrap``
+multiaddr) is still required — an empty routing table cannot resolve Peer IDs.
+
+Typical 3-terminal flow:
+
+1. Start the intro peer (no ``--bootstrap``). Copy the printed bootstrap multiaddr
+   and its Peer ID.
+2. Start two more peers with ``--bootstrap <intro_multiaddr>``.
+3. On peer B, run ``connect <peer_C_id>`` (Peer ID only — no multiaddr), then
+   ``msg <peer_C_id> hello``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import multiaddr
+import trio
+
+from libp2p import (
+    new_host,
+)
+from libp2p.custom_types import (
+    TProtocol,
+)
+from libp2p.kad_dht.kad_dht import (
+    DHTMode,
+    KadDHT,
+)
+from libp2p.network.stream.net_stream import (
+    INetStream,
+)
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+    info_from_p2p_addr,
+)
+from libp2p.tools.anyio_service import (
+    background_trio_service,
+)
+from libp2p.utils.address_validation import (
+    find_free_port,
+    get_available_interfaces,
+    get_optimal_binding_address,
+)
+
+PROTOCOL_ID = TProtocol("/dht-chat/1.0.0")
+MAX_READ_LEN = 2**16
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger("multiaddr").setLevel(logging.WARNING)
+logging.getLogger("libp2p").setLevel(logging.WARNING)
+
+logger = logging.getLogger("dht-chat")
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    _handler = logging.StreamHandler(sys.stdout)
+    _handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    logger.addHandler(_handler)
+    logger.propagate = False
+
+
+HELP_TEXT = """
+Commands:
+  id                         Print this peer's Peer ID
+  addrs                      Print listen multiaddrs
+  peers                      Print connected peers and DHT routing-table size
+  lookup <peer_id>           Resolve addresses via KadDHT.find_peer (no dial)
+  connect <peer_id>          Look up peer via DHT, then dial
+  msg <peer_id> <text>       Send a chat message (looks up/dials if needed)
+  help                       Show this help
+  quit / exit                Stop the node
+""".strip()
+
+
+async def seed_routing_table(dht: KadDHT) -> None:
+    """Add currently known peerstore peers into the DHT routing table."""
+    host = dht.host
+    local_id = host.get_id()
+    for peer_id in host.get_peerstore().peer_ids():
+        if peer_id == local_id:
+            continue
+        await dht.add_peer(peer_id)
+
+
+async def maintain_routing_table(host, dht: KadDHT) -> None:
+    """
+    Periodically fold connected peers into the DHT routing table.
+
+    The intro peer learns about joiners through host connections; without this
+    loop those peers never enter the RT and FIND_NODE cannot answer lookups.
+    """
+    while True:
+        for peer_id in host.get_connected_peers():
+            await dht.add_peer(peer_id)
+        await seed_routing_table(dht)
+        await trio.sleep(2)
+
+
+async def connect_bootstrap(host, bootstrap: str, dht: KadDHT) -> None:
+    """Dial the intro peer and seed the local routing table."""
+    maddr = multiaddr.Multiaddr(bootstrap)
+    info = info_from_p2p_addr(maddr)
+    logger.info("Connecting to intro peer %s", info.peer_id)
+    await host.connect(info)
+    await dht.add_peer(info.peer_id)
+    await seed_routing_table(dht)
+    logger.info("Joined DHT overlay via intro peer %s", info.peer_id)
+
+
+async def read_incoming_chat(stream: INetStream) -> None:
+    """Print messages from an inbound chat stream until it closes."""
+    remote = stream.muxed_conn.peer_id
+    try:
+        while True:
+            data = await stream.read(MAX_READ_LEN)
+            if not data:
+                break
+            text = data.decode(errors="replace").rstrip("\n")
+            print(f"\n\x1b[32m[{remote}] {text}\x1b[0m")
+            print("> ", end="", flush=True)
+    except Exception as exc:
+        logger.debug("Inbound chat stream closed: %s", exc)
+    finally:
+        try:
+            await stream.close()
+        except Exception:
+            pass
+
+
+async def lookup_peer(dht: KadDHT, peer_id: ID) -> PeerInfo:
+    """Resolve ``peer_id`` through the DHT and return PeerInfo with addresses."""
+    logger.info("Looking up %s via KadDHT.find_peer ...", peer_id)
+    found: PeerInfo | None = None
+    for attempt in range(15):
+        found = await dht.find_peer(peer_id)
+        if found is not None and found.addrs:
+            break
+        await trio.sleep(0.2)
+        logger.debug("find_peer attempt %s returned %s", attempt + 1, found)
+
+    if found is None or not found.addrs:
+        raise RuntimeError(
+            f"DHT lookup failed for {peer_id}. "
+            "Join an overlay first with --bootstrap, and ensure the target "
+            "peer has also joined the same intro peer."
+        )
+
+    logger.info(
+        "DHT found %s with %s addr(s)",
+        found.peer_id,
+        len(found.addrs),
+    )
+    return found
+
+
+async def ensure_connected(host, dht: KadDHT, peer_id: ID) -> PeerInfo:
+    """
+    Resolve ``peer_id`` through the DHT (if needed) and ensure a connection.
+
+    Returns the PeerInfo used for the dial.
+    """
+    if peer_id == host.get_id():
+        raise ValueError("Cannot connect to self")
+
+    if peer_id in host.get_connected_peers():
+        addrs = host.get_peerstore().addrs(peer_id)
+        return PeerInfo(peer_id, list(addrs))
+
+    found = await lookup_peer(dht, peer_id)
+    logger.info("Dialing %s ...", found.peer_id)
+    await host.connect(found)
+    await dht.add_peer(found.peer_id)
+    return found
+
+
+async def send_message(host, dht: KadDHT, peer_id: ID, text: str) -> None:
+    """Open a chat stream to ``peer_id`` and send one line of text."""
+    await ensure_connected(host, dht, peer_id)
+    stream = await host.new_stream(peer_id, [PROTOCOL_ID])
+    try:
+        payload = text if text.endswith("\n") else text + "\n"
+        await stream.write(payload.encode())
+        logger.info("Sent to %s: %s", peer_id, text)
+    finally:
+        await stream.close()
+
+
+async def command_loop(host, dht: KadDHT, nursery: trio.Nursery) -> None:
+    """Read interactive commands from stdin."""
+    async_stdin = trio.wrap_file(sys.stdin)
+    print(HELP_TEXT)
+    print("> ", end="", flush=True)
+
+    while True:
+        line = await async_stdin.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            print("> ", end="", flush=True)
+            continue
+
+        parts = line.split(maxsplit=2)
+        cmd = parts[0].lower()
+
+        try:
+            if cmd in {"quit", "exit"}:
+                logger.info("Shutting down")
+                nursery.cancel_scope.cancel()
+                return
+
+            if cmd == "help":
+                print(HELP_TEXT)
+
+            elif cmd == "id":
+                print(host.get_id())
+
+            elif cmd == "addrs":
+                for addr in host.get_addrs():
+                    print(addr)
+
+            elif cmd == "peers":
+                connected = list(host.get_connected_peers())
+                rt_size = dht.get_routing_table_size()
+                print(f"connected={len(connected)} rt_size={rt_size}")
+                for peer_id in connected:
+                    print(f"  {peer_id}")
+
+            elif cmd == "lookup":
+                if len(parts) < 2:
+                    print("usage: lookup <peer_id>")
+                else:
+                    peer_id = ID.from_string(parts[1])
+                    info = await lookup_peer(dht, peer_id)
+                    print(f"lookup ok: {info.peer_id}")
+                    for addr in info.addrs:
+                        print(f"  {addr}")
+
+            elif cmd == "connect":
+                if len(parts) < 2:
+                    print("usage: connect <peer_id>")
+                else:
+                    peer_id = ID.from_string(parts[1])
+                    info = await ensure_connected(host, dht, peer_id)
+                    print(f"Connected to {info.peer_id}")
+
+            elif cmd == "msg":
+                if len(parts) < 3:
+                    print("usage: msg <peer_id> <text>")
+                else:
+                    peer_id = ID.from_string(parts[1])
+                    await send_message(host, dht, peer_id, parts[2])
+
+            else:
+                print(f"Unknown command: {cmd!r} (type 'help')")
+
+        except Exception as exc:
+            print(f"Error: {exc}")
+
+        print("> ", end="", flush=True)
+
+
+async def run(port: int, bootstrap: str | None) -> None:
+    """Start a DHT chat node and enter the interactive command loop."""
+    if port <= 0:
+        port = find_free_port()
+
+    listen_addrs = get_available_interfaces(port)
+    host = new_host()
+
+    async with host.run(listen_addrs=listen_addrs), trio.open_nursery() as nursery:
+        nursery.start_soon(host.get_peerstore().start_cleanup_task, 60)
+
+        async def stream_handler(stream: INetStream) -> None:
+            nursery.start_soon(read_incoming_chat, stream)
+
+        host.set_stream_handler(PROTOCOL_ID, stream_handler)
+
+        dht = KadDHT(host, DHTMode.SERVER)
+        async with background_trio_service(dht):
+            nursery.start_soon(maintain_routing_table, host, dht)
+
+            if bootstrap:
+                await connect_bootstrap(host, bootstrap, dht)
+            else:
+                logger.info(
+                    "Started as intro peer (empty DHT until others --bootstrap here)"
+                )
+
+            peer_id = host.get_id()
+            all_addrs = host.get_addrs()
+            optimal = get_optimal_binding_address(port)
+            bootstrap_maddr = f"{optimal}/p2p/{peer_id.to_string()}"
+
+            print("\n=== DHT Chat node ready ===")
+            print(f"Peer ID: {peer_id}")
+            print("Listening on:")
+            for addr in all_addrs:
+                print(f"  {addr}")
+            print("\nOther peers can join the overlay with:")
+            print(f"  dht-chat-demo --bootstrap {bootstrap_maddr}")
+            print(
+                "\nAfter joining, use `lookup <peer_id>` / `msg <peer_id> <text>` "
+                "(Peer ID only — DHT resolves addresses).\n"
+            )
+
+            await command_loop(host, dht, nursery)
+
+
+def main() -> None:
+    description = """
+    DHT Peer-ID chat demo (issue #880).
+
+    Start one intro peer, then join others with --bootstrap <multiaddr>.
+    Subsequent dials use KadDHT.find_peer(peer_id) instead of pasting multiaddrs.
+    An empty routing table cannot discover peers — the intro step is required.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "-p",
+        "--port",
+        default=0,
+        type=int,
+        help="TCP listen port (0 = ephemeral)",
+    )
+    parser.add_argument(
+        "-b",
+        "--bootstrap",
+        type=str,
+        default=None,
+        help="Intro peer multiaddr (e.g. /ip4/127.0.0.1/tcp/8000/p2p/<PeerID>)",
+    )
+    args = parser.parse_args()
+
+    try:
+        trio.run(run, args.port, args.bootstrap)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dht_chat/dht_chat.py
+++ b/examples/dht_chat/dht_chat.py
@@ -17,10 +17,17 @@ Typical 3-terminal flow:
 from __future__ import annotations
 
 import argparse
+from contextlib import (
+    AsyncExitStack,
+)
 import logging
 import sys
+import time
 
 import multiaddr
+from multiaddr import (
+    Multiaddr,
+)
 import trio
 
 from libp2p import (
@@ -316,13 +323,145 @@ async def run(port: int, bootstrap: str | None) -> None:
             await command_loop(host, dht, nursery)
 
 
+async def run_network_size(network_size: int) -> None:
+    """
+    Spin up ``network_size`` in-process DHT chat peers and exercise Peer-ID lookup.
+
+    Topology: peer 0 is the intro node; peers 1..N-1 dial peer 0 once. Then peer 1
+    resolves peer N-1 via ``KadDHT.find_peer`` (no multiaddr) and sends a chat
+    message.
+    """
+    if network_size < 2:
+        raise ValueError("--network-size must be >= 2")
+
+    print(f"=== DHT network-size experiment: N={network_size} ===")
+    t0 = time.perf_counter()
+
+    async with AsyncExitStack() as stack:
+        hosts = []
+        dhts: list[KadDHT] = []
+        ports: list[int] = []
+
+        for i in range(network_size):
+            port = find_free_port()
+            ports.append(port)
+            host = new_host()
+            # Loopback-only keeps large-N demos lightweight.
+            listen = [Multiaddr(f"/ip4/127.0.0.1/tcp/{port}")]
+            await stack.enter_async_context(host.run(listen_addrs=listen))
+            hosts.append(host)
+
+        received = trio.Event()
+        got: dict[str, bytes | None] = {"data": None}
+        target_idx = network_size - 1
+
+        async def target_handler(stream: INetStream) -> None:
+            data = await stream.read(MAX_READ_LEN)
+            got["data"] = data
+            received.set()
+            await stream.close()
+
+        hosts[target_idx].set_stream_handler(PROTOCOL_ID, target_handler)
+
+        for host in hosts:
+            dht = KadDHT(host, DHTMode.SERVER)
+            await stack.enter_async_context(background_trio_service(dht))
+            dhts.append(dht)
+
+        intro = PeerInfo(hosts[0].get_id(), hosts[0].get_addrs())
+        join_limiter = trio.CapacityLimiter(min(32, network_size))
+
+        async def join_peer(i: int) -> None:
+            async with join_limiter:
+                await hosts[i].connect(intro)
+                await dhts[i].add_peer(hosts[0].get_id())
+
+        t_join = time.perf_counter()
+        async with trio.open_nursery() as nursery:
+            for i in range(1, network_size):
+                nursery.start_soon(join_peer, i)
+        join_s = time.perf_counter() - t_join
+        print(
+            f"Joined {network_size - 1} peers to intro in {join_s:.2f}s "
+            f"(intro connected={len(hosts[0].get_connected_peers())})"
+        )
+
+        # Seed intro RT with everyone currently connected.
+        for peer_id in hosts[0].get_connected_peers():
+            await dhts[0].add_peer(peer_id)
+
+        # Give routing tables a moment to settle under load.
+        settle_deadline = time.perf_counter() + min(30.0, 2.0 + network_size * 0.05)
+        while time.perf_counter() < settle_deadline:
+            for peer_id in hosts[0].get_connected_peers():
+                await dhts[0].add_peer(peer_id)
+            if dhts[0].get_routing_table_size() >= min(network_size - 1, 20):
+                break
+            await trio.sleep(0.2)
+
+        rt_sizes = [d.get_routing_table_size() for d in dhts]
+        median_rt = sorted(rt_sizes)[len(rt_sizes) // 2]
+        print(
+            "Routing table sizes: "
+            f"intro={rt_sizes[0]} "
+            f"source(peer1)={rt_sizes[1]} "
+            f"target(peer{target_idx})={rt_sizes[target_idx]} "
+            f"min={min(rt_sizes)} max={max(rt_sizes)} median={median_rt}"
+        )
+
+        source_host, source_dht = hosts[1], dhts[1]
+        target_id = hosts[target_idx].get_id()
+
+        t_lookup = time.perf_counter()
+        found: PeerInfo | None = None
+        attempts = 0
+        with trio.fail_after(60):
+            while True:
+                attempts += 1
+                found = await source_dht.find_peer(target_id)
+                if found is not None and found.addrs:
+                    break
+                await trio.sleep(0.2)
+        lookup_s = time.perf_counter() - t_lookup
+        assert found is not None
+        print(
+            f"Peer 1 looked up peer {target_idx} via DHT in {lookup_s:.2f}s "
+            f"({attempts} attempt(s), {len(found.addrs)} addr(s))"
+        )
+
+        t_msg = time.perf_counter()
+        await source_host.connect(found)
+        stream = await source_host.new_stream(target_id, [PROTOCOL_ID])
+        payload = f"hello-from-N{network_size}\n".encode()
+        try:
+            await stream.write(payload)
+        finally:
+            await stream.close()
+
+        with trio.fail_after(30):
+            await received.wait()
+        msg_s = time.perf_counter() - t_msg
+
+        ok = got["data"] == payload
+        total_s = time.perf_counter() - t0
+        print(f"Chat delivery {'OK' if ok else 'FAIL'} in {msg_s:.2f}s")
+        print(
+            f"TOTAL N={network_size}: join={join_s:.2f}s lookup={lookup_s:.2f}s "
+            f"msg={msg_s:.2f}s wall={total_s:.2f}s"
+        )
+        if not ok:
+            raise RuntimeError(f"Unexpected payload: {got['data']!r}")
+
+
 def main() -> None:
     description = """
     DHT Peer-ID chat demo (issue #880).
 
-    Start one intro peer, then join others with --bootstrap <multiaddr>.
-    Subsequent dials use KadDHT.find_peer(peer_id) instead of pasting multiaddrs.
-    An empty routing table cannot discover peers — the intro step is required.
+    Interactive mode: start one intro peer, then join others with
+    --bootstrap <multiaddr>. Subsequent dials use KadDHT.find_peer(peer_id).
+
+    Automated mode: --network-size N spins up N in-process peers, joins them
+    through one intro peer, then has peer 1 look up peer N-1 by Peer ID and chat.
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
@@ -330,7 +469,7 @@ def main() -> None:
         "--port",
         default=0,
         type=int,
-        help="TCP listen port (0 = ephemeral)",
+        help="TCP listen port (0 = ephemeral); ignored with --network-size",
     )
     parser.add_argument(
         "-b",
@@ -339,10 +478,20 @@ def main() -> None:
         default=None,
         help="Intro peer multiaddr (e.g. /ip4/127.0.0.1/tcp/8000/p2p/<PeerID>)",
     )
+    parser.add_argument(
+        "-n",
+        "--network-size",
+        type=int,
+        default=None,
+        help="Run automated N-peer DHT overlay experiment (N >= 2) and exit",
+    )
     args = parser.parse_args()
 
     try:
-        trio.run(run, args.port, args.bootstrap)
+        if args.network_size is not None:
+            trio.run(run_network_size, args.network_size)
+        else:
+            trio.run(run, args.port, args.bootstrap)
     except KeyboardInterrupt:
         pass
 

--- a/newsfragments/880.feature.rst
+++ b/newsfragments/880.feature.rst
@@ -1,0 +1,1 @@
+Added a DHT Peer-ID chat example that looks up peers via KadDHT after a one-time bootstrap intro.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ health-demo = ["rich>=13.0"]
 
 [project.scripts]
 chat-demo = "examples.chat.chat:main"
+dht-chat-demo = "examples.dht_chat.dht_chat:main"
 echo-demo = "examples.echo.echo:main"
 echo-quic-demo = "examples.echo.echo_quic:main"
 ping-demo = "examples.ping.ping:main"

--- a/tests/examples/test_dht_chat.py
+++ b/tests/examples/test_dht_chat.py
@@ -1,0 +1,125 @@
+"""Tests for the DHT Peer-ID chat example (issue #880)."""
+
+from __future__ import annotations
+
+import pytest
+import trio
+
+from libp2p import (
+    new_host,
+)
+from libp2p.custom_types import (
+    TProtocol,
+)
+from libp2p.kad_dht.kad_dht import (
+    DHTMode,
+    KadDHT,
+)
+from libp2p.network.stream.net_stream import (
+    INetStream,
+)
+from libp2p.peer.peerinfo import (
+    PeerInfo,
+)
+from libp2p.tools.anyio_service import (
+    background_trio_service,
+)
+from libp2p.utils.address_validation import (
+    find_free_port,
+    get_available_interfaces,
+)
+
+PROTOCOL_ID = TProtocol("/dht-chat/1.0.0")
+
+
+def test_dht_chat_example_imports() -> None:
+    from examples.dht_chat import dht_chat
+
+    assert hasattr(dht_chat, "main")
+    assert hasattr(dht_chat, "run")
+    assert dht_chat.PROTOCOL_ID == PROTOCOL_ID
+
+
+async def _seed_connected(dht: KadDHT) -> None:
+    host = dht.host
+    for peer_id in host.get_connected_peers():
+        await dht.add_peer(peer_id)
+
+
+@pytest.mark.trio
+async def test_dht_chat_find_peer_then_message() -> None:
+    """
+    Three SERVER DHT peers: B and C join via A, then B looks up C by Peer ID
+    (no multiaddr) and delivers a chat message over /dht-chat/1.0.0.
+    """
+    port_a = find_free_port()
+    port_b = find_free_port()
+    port_c = find_free_port()
+
+    host_a = new_host()
+    host_b = new_host()
+    host_c = new_host()
+
+    received = trio.Event()
+    got: dict[str, bytes | None] = {"data": None}
+
+    async with (
+        host_a.run(listen_addrs=get_available_interfaces(port_a)),
+        host_b.run(listen_addrs=get_available_interfaces(port_b)),
+        host_c.run(listen_addrs=get_available_interfaces(port_c)),
+    ):
+
+        async def handler(stream: INetStream) -> None:
+            data = await stream.read(1024)
+            got["data"] = data
+            received.set()
+            await stream.close()
+
+        host_c.set_stream_handler(PROTOCOL_ID, handler)
+
+        dht_a = KadDHT(host_a, DHTMode.SERVER)
+        dht_b = KadDHT(host_b, DHTMode.SERVER)
+        dht_c = KadDHT(host_c, DHTMode.SERVER)
+
+        async with (
+            background_trio_service(dht_a),
+            background_trio_service(dht_b),
+            background_trio_service(dht_c),
+        ):
+            info_a = PeerInfo(host_a.get_id(), host_a.get_addrs())
+            await host_b.connect(info_a)
+            await host_c.connect(info_a)
+
+            await _seed_connected(dht_a)
+            await _seed_connected(dht_b)
+            await _seed_connected(dht_c)
+
+            # Intro peer must know both joiners for FIND_NODE to answer.
+            await dht_a.add_peer(host_b.get_id())
+            await dht_a.add_peer(host_c.get_id())
+            await dht_b.add_peer(host_a.get_id())
+            await dht_c.add_peer(host_a.get_id())
+
+            found: PeerInfo | None = None
+            with trio.fail_after(10):
+                while True:
+                    found = await dht_b.find_peer(host_c.get_id())
+                    if found is not None and found.addrs:
+                        break
+                    await trio.sleep(0.2)
+
+            assert found is not None
+            assert found.peer_id == host_c.get_id()
+            assert found.addrs
+
+            await host_b.connect(found)
+            stream = await host_b.new_stream(found.peer_id, [PROTOCOL_ID])
+            try:
+                await stream.write(b"hello-from-B\n")
+            finally:
+                await stream.close()
+
+            with trio.fail_after(5):
+                await received.wait()
+
+            assert got["data"] == b"hello-from-B\n"

--- a/tests/examples/test_dht_chat.py
+++ b/tests/examples/test_dht_chat.py
@@ -45,7 +45,7 @@ def test_dht_chat_example_imports() -> None:
 async def test_dht_chat_network_size_small() -> None:
     from examples.dht_chat.dht_chat import run_network_size
 
-    await run_network_size(4)
+    await run_network_size(4, pair_count=6, seed=880)
 
 
 async def _seed_connected(dht: KadDHT) -> None:

--- a/tests/examples/test_dht_chat.py
+++ b/tests/examples/test_dht_chat.py
@@ -37,7 +37,15 @@ def test_dht_chat_example_imports() -> None:
 
     assert hasattr(dht_chat, "main")
     assert hasattr(dht_chat, "run")
+    assert hasattr(dht_chat, "run_network_size")
     assert dht_chat.PROTOCOL_ID == PROTOCOL_ID
+
+
+@pytest.mark.trio
+async def test_dht_chat_network_size_small() -> None:
+    from examples.dht_chat.dht_chat import run_network_size
+
+    await run_network_size(4)
 
 
 async def _seed_connected(dht: KadDHT) -> None:

--- a/tests/examples/test_examples_bind_address.py
+++ b/tests/examples/test_examples_bind_address.py
@@ -44,6 +44,7 @@ class TestExamplesAddressParadigm:
             "bootstrap/bootstrap.py",
             "pubsub/pubsub.py",
             "identify/identify.py",
+            "dht_chat/dht_chat.py",
         ]
 
         paradigm_functions = [


### PR DESCRIPTION
## Summary
- Adds `examples/dht_chat/` — a trio CLI that joins a KadDHT overlay via a one-time `--bootstrap` multiaddr, then resolves peers with `KadDHT.find_peer` and chats on `/dht-chat/1.0.0`.
- Documents a real 3-terminal walkthrough (intro → join → lookup by Peer ID → message) in `docs/examples.dht_chat.rst`.
- Adds smoke + integration tests and `dht-chat-demo` console script.
- Closes #880. Not based on closed #985 (that branch was stale and mixed in unrelated flood-publish work).

## Honest bootstrap note
An empty DHT routing table cannot resolve Peer IDs. `--bootstrap` is a **one-time overlay introduction**, not a permanent messaging server. After join, dials use Peer ID + DHT.

## Demo
Live three-process run (loopback bootstrap):

1. **Peer A** starts as intro (`--port 18001`).
2. **Peers B/C** join with `--bootstrap /ip4/127.0.0.1/tcp/18001/p2p/<A>`.
3. On **B**: `lookup <C_peer_id>` → `KadDHT.find_peer` returns C's listen addrs (no multiaddr pasted).
4. On **B**: `msg <C_peer_id> hello-from-B-via-DHT` → **C** prints the inbound message.

Example lookup/send logs from the captured run:

```text
INFO Looking up 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok via KadDHT.find_peer ...
INFO DHT found 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok with 6 addr(s)
lookup ok: 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok
INFO Sent to 12D3KooWDLGXNskEwn1tFPSSJisnbPh69sTu23VQot57ZEcQFTok: hello-from-B-via-DHT

# on C
[12D3KooWLLjeAnSrVfC2CH1SYT1GMGPWvF5eJ2LVmpCAYsswsmN5] hello-from-B-via-DHT
```

Full annotated walkthrough: `docs/examples.dht_chat.rst`.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `pytest tests/examples/test_dht_chat.py tests/examples/test_examples_bind_address.py`
- [x] `pytest tests/examples/test_examples.py tests/core/kad_dht/` (197 passed)
- [x] `make linux-docs`
- [x] Manual 3-terminal demo (`lookup` + `msg` by Peer ID)


Made with [Cursor](https://cursor.com)