### PR TITLE
docs(webrtc): STUN listener vs /sdp harness, and v1/v2 dial guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,24 @@ ______________________________________________________________________
 | **`libp2p-webrtc-browser-to-server`**  |     🌱     |                                                                                       |
 | **`libp2p-webrtc-private-to-private`** |     🌱     |                                                                                       |
 
-WebRTC-Direct (browser/server) uses the spec STUN path by default: inbound dials
-hit a shared UDP port and the listener infers the offer from the first STUN
-packet; outbound dials synthesise an ICE-Lite answer from the multiaddr with no
-default public STUN servers. The listener accepts both the v1 (SDP munging)
-and v2 (libp2p/specs#715, no munging) flows; the dialer speaks v1 by default
-and v2 via `WebRTCTransportConfig(webrtc_direct_dial_version=2)` while
-specs#715 is unmerged. An experimental HTTP `POST /sdp` harness for
-py↔py debugging is opt-in via
-`WebRTCTransportConfig(enable_sdp_http_harness=True)` — it is not
-interoperable with other libp2p implementations.
+WebRTC-Direct (browser/server) uses the spec **STUN path** by default: inbound
+dials hit a shared UDP port and the listener infers the offer from the first
+STUN packet; outbound dials synthesise an ICE-Lite answer from the multiaddr
+with no default public STUN servers. This is the only signalling path that
+interoperates with go-libp2p / js-libp2p / browsers. An experimental HTTP
+`POST /sdp` harness (`WebRTCTransportConfig(enable_sdp_http_harness=True)`) is
+**for py↔py debugging only** and is *not* interoperable — leave it off in
+production.
+
+**Choosing a dial version.** The listener always accepts both v1 and v2; the
+dialer picks with `WebRTCTransportConfig(webrtc_direct_dial_version=1|2)`:
+
+- **v1** (default today) — the migration path (SDP ufrag/pwd munging). Kept the
+  default while [libp2p/specs#715](https://github.com/libp2p/specs/pull/715) is
+  unmerged so existing v1 peers keep working.
+- **v2** (recommended) — the specs#715 flow, no SDP munging. Prefer it for new
+  deployments; **browser dialling needs v2** once `NoSdpMangleUfrag` support is
+  widespread. The default flips to v2 once specs#715 lands.
 
 ______________________________________________________________________
 

--- a/libp2p/transport/webrtc/__init__.py
+++ b/libp2p/transport/webrtc/__init__.py
@@ -5,13 +5,32 @@ Provides two transport variants per the libp2p WebRTC specification:
 
 - **WebRTC Direct** (``/webrtc-direct``): Server-to-browser or server-to-server
   connections where the server publishes its certificate hash in the multiaddr.
-  No relay or signaling server is required. The default path uses inbound STUN
-  on a shared UDP port (offer inferred from the first packet) and outbound
-  dials that synthesise an ICE-Lite answer without public STUN servers. The
-  listener accepts both the v1 (munging) and v2 (libp2p/specs#715) flows; the
-  dialer speaks v1 by default (``webrtc_direct_dial_version=2`` opts in). An
-  experimental HTTP ``POST /sdp`` harness (``WebRTCTransportConfig(
-  enable_sdp_http_harness=True)``) is available for py↔py debugging only.
+  No relay or signaling server is required.
+
+  There are two ways to signal a WebRTC-Direct connection, and they are not
+  interchangeable:
+
+  * **STUN listener (spec path, default).** Inbound dials hit one shared UDP
+    port; the listener infers the SDP offer from the first STUN packet and
+    answers over a muxed ICE agent. Outbound dials synthesise an ICE-Lite
+    answer from the multiaddr with no public STUN servers. This is the only
+    path that interoperates with go-libp2p / js-libp2p / browsers.
+  * **HTTP ``POST /sdp`` harness (dev only).** Opt-in via
+    ``WebRTCTransportConfig(enable_sdp_http_harness=True)``; a minimal HTTP
+    signalling server for **py↔py debugging only** — it is *not* interoperable
+    with other libp2p implementations. Leave it off in production.
+
+  **Dial version — v1 vs v2 (libp2p/specs#715).** The listener always accepts
+  both. The dialer picks with ``WebRTCTransportConfig(webrtc_direct_dial_version=
+  1|2)``:
+
+  * **v1 (default today):** the migration path. Encodes the client password by
+    munging the ICE ufrag/pwd; kept the default while specs#715 is unmerged so
+    py↔py and py↔go keep working against v1 peers.
+  * **v2 (recommended):** the specs#715 flow — no SDP munging
+    (``libp2p+webrtc+v2/<client_pwd>``). Prefer it for new deployments, and it
+    is what **browser dialling requires** once ``NoSdpMangleUfrag`` support is
+    widespread. Switch the default to v2 once specs#715 lands.
 
 - **WebRTC** (``/webrtc``): Private-to-private connections where both peers are
   behind NAT.  Uses Circuit Relay v2 for signaling, then upgrades to a direct

--- a/newsfragments/1511.docs.rst
+++ b/newsfragments/1511.docs.rst
@@ -1,0 +1,1 @@
+Document the two WebRTC-Direct signalling paths (the spec STUN listener vs the dev-only ``POST /sdp`` harness) and add v1-vs-v2 dial guidance — v1 as the migration default and v2 (libp2p/specs#715) as the recommended flow that browser dialling will require — in the ``libp2p.transport.webrtc`` package docstring and the README.


### PR DESCRIPTION
@acul71 Closes #1511. Part of the #1437 track (acul71's docs follow-up).

WebRTC-Direct had no user-facing guidance on two easy-to-confuse choices. This clarifies both, in the `libp2p.transport.webrtc` package docstring and the README:

- **Signalling path:** the spec **STUN listener** (default, the only path that interoperates with go/js/browsers) vs the experimental **`POST /sdp` harness** (`enable_sdp_http_harness`, py↔py debugging only, not interoperable — leave off in production).
- **Dial version:** the listener accepts both; the dialer picks via `webrtc_direct_dial_version`. **v1** is the migration default while [specs#715](https://github.com/libp2p/specs/pull/715) is unmerged; **v2** is recommended (no SDP munging) and is what browser dialling needs once `NoSdpMangleUfrag` is widespread. Default flips to v2 once specs#715 lands.

Docs-only — no code change. Package still imports; ruff clean on the touched module.