### PR TITLE
fix: quiet host.run/close on expected connection teardown

### DIFF
--- a/interop/perf/perf_test.py
+++ b/interop/perf/perf_test.py
@@ -30,11 +30,6 @@ import multiaddr
 import redis
 import trio
 
-try:
-    ExceptionGroup  # noqa: B018
-except NameError:
-    from exceptiongroup import ExceptionGroup  # type: ignore[no-redef]
-
 from libp2p import create_mplex_muxer_option, create_yamux_muxer_option, new_host
 from libp2p.crypto.ed25519 import create_new_key_pair
 from libp2p.crypto.x25519 import create_new_key_pair as create_new_x25519_key_pair
@@ -179,22 +174,6 @@ def _percentile(sorted_values: list[float], p: float) -> float:
     return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
 
 
-# Phrases when mplex/TLS read loops exit after peer disconnect (tcp+tls+mplex).
-_SHUTDOWN_ERROR_PHRASES = (
-    "connection closed",
-    "connection is closed",
-    "cannot read: tls connection is closed",
-    "tls connection is closed",
-    "broken pipe",
-    "connection reset",
-    "stream reset",
-    "stream eof",
-    "end of file",
-    "eof",
-    "closed resource",
-    "broken resource",
-)
-
 # Extra settle time so dialer can exit before listener during interop teardown.
 _LISTENER_POST_PERF_GRACE_TLS_MPLEX_SECS = 3.0
 _LISTENER_POST_PERF_GRACE_SECS = 0.5
@@ -210,45 +189,11 @@ _LISTENER_WS_MPLEX_TEARDOWN_IDLE_SECS = 30.0
 _PERF_LOOPBACK_DENY_LIST = ("127.0.0.0/8", "::1/128")
 
 
-def _is_connection_closed_error(exc: BaseException | None) -> bool:
-    """True if this is an expected connection-closed error during muxer/TLS shutdown."""
-    if exc is None:
-        return False
-
-    msg = str(exc).lower()
-    if any(phrase in msg for phrase in _SHUTDOWN_ERROR_PHRASES):
-        return True
-
-    if isinstance(exc, ExceptionGroup):
-        if not exc.exceptions:
-            return False
-        return all(_is_connection_closed_error(e) for e in exc.exceptions)
-
-    if exc.__cause__ is not None and _is_connection_closed_error(exc.__cause__):
-        return True
-    if (
-        exc.__context__ is not None
-        and exc.__context__ is not exc.__cause__
-        and _is_connection_closed_error(exc.__context__)
-    ):
-        return True
-
-    return False
-
-
 def _log_perf_phase(role: str, phase: str, **details: Any) -> None:
     extra = " ".join(f"{k}={v}" for k, v in details.items())
     msg = f"[PERF_PHASE] {role} {phase}" + (f" {extra}" if extra else "")
     print(msg, file=sys.stderr)
     logger.info(msg)
-
-
-def _log_ignored_shutdown_error(role: str, exc: BaseException) -> None:
-    print(
-        f"{role} completed (connection closed during cleanup)",
-        file=sys.stderr,
-    )
-    logger.info("Ignored shutdown error: %s", exc)
 
 
 def _compute_stats(samples: list[float], is_latency: bool = False) -> dict[str, Any]:
@@ -404,29 +349,6 @@ class PerfTest:
         if self.transport in ("ws", "wss") and self.muxer == "mplex":
             return _LISTENER_WS_MPLEX_TEARDOWN_IDLE_SECS
         return _LISTENER_EMPTY_PEER_POLLS_REQUIRED * _LISTENER_PEER_POLL_INTERVAL_SECS
-
-    def _should_ignore_shutdown_error(self, exc: BaseException) -> bool:
-        """Swallow connection-closed errors only during post-benchmark cleanup."""
-        if not _is_connection_closed_error(exc):
-            _log_perf_phase(
-                self._role_label(),
-                "shutdown_error_not_ignored",
-                reason="not_connection_closed",
-                exc=type(exc).__name__,
-            )
-            return False
-        if self.is_dialer:
-            ignore = self._benchmarks_complete
-        else:
-            ignore = self._listener_served_peer
-        _log_perf_phase(
-            self._role_label(),
-            "shutdown_ignore" if ignore else "shutdown_error_not_ignored",
-            benchmarks_complete=self._benchmarks_complete,
-            listener_served_peer=self._listener_served_peer,
-            exc=type(exc).__name__,
-        )
-        return ignore
 
     def _role_label(self) -> str:
         return "dialer" if self.is_dialer else "listener"
@@ -832,83 +754,70 @@ class PerfTest:
         self._install_listener_perf_lifecycle_handler()
         print(f"Perf service started (protocol {PROTOCOL_NAME})", file=sys.stderr)
 
-        listener_ready = False
-        try:
-            async with self.host.run(listen_addrs=listen_addrs):
-                all_addrs = self.host.get_addrs()
-                if not all_addrs:
-                    raise RuntimeError("No listen addresses available")
-                actual_addr = self._get_publishable_address(all_addrs)
-                print(f"Publishing address: {actual_addr}", file=sys.stderr)
-                if self.local_addr_file:
-                    Path(self.local_addr_file).write_text(actual_addr, encoding="utf-8")
-                else:
-                    redis_key = f"{self.test_key}_listener_multiaddr"
-                    assert self.redis_client is not None
-                    self.redis_client.set(redis_key, actual_addr)
-                print("Listener ready, waiting for dialer...", file=sys.stderr)
-                _log_perf_phase(
-                    "listener",
-                    "ready",
-                    test_timeout_seconds=self.test_timeout_seconds,
-                    muxer=self.muxer,
-                    security=self.security,
-                    transport=self.transport,
-                )
-                listener_ready = True
+        async with self.host.run(listen_addrs=listen_addrs):
+            all_addrs = self.host.get_addrs()
+            if not all_addrs:
+                raise RuntimeError("No listen addresses available")
+            actual_addr = self._get_publishable_address(all_addrs)
+            print(f"Publishing address: {actual_addr}", file=sys.stderr)
+            if self.local_addr_file:
+                Path(self.local_addr_file).write_text(actual_addr, encoding="utf-8")
+            else:
+                redis_key = f"{self.test_key}_listener_multiaddr"
+                assert self.redis_client is not None
+                self.redis_client.set(redis_key, actual_addr)
+            print("Listener ready, waiting for dialer...", file=sys.stderr)
+            _log_perf_phase(
+                "listener",
+                "ready",
+                test_timeout_seconds=self.test_timeout_seconds,
+                muxer=self.muxer,
+                security=self.security,
+                transport=self.transport,
+            )
 
-                connect_deadline = time.monotonic() + self.test_timeout_seconds
-                saw_peer = False
-                empty_peer_polls = 0
-                last_peer_seen_at = time.monotonic()
-                teardown_idle_secs = self._listener_teardown_idle_secs()
-                while True:
-                    if not saw_peer:
-                        if self._listener_peer_present():
-                            saw_peer = True
-                            empty_peer_polls = 0
-                            last_peer_seen_at = time.monotonic()
-                        elif time.monotonic() >= connect_deadline:
-                            raise RuntimeError(
-                                f"Timeout: dialer never connected within "
-                                f"{self.test_timeout_seconds}s"
-                            )
-                    elif self.host.get_live_peers():
+            connect_deadline = time.monotonic() + self.test_timeout_seconds
+            saw_peer = False
+            empty_peer_polls = 0
+            last_peer_seen_at = time.monotonic()
+            teardown_idle_secs = self._listener_teardown_idle_secs()
+            while True:
+                if not saw_peer:
+                    if self._listener_peer_present():
+                        saw_peer = True
                         empty_peer_polls = 0
                         last_peer_seen_at = time.monotonic()
-                    else:
-                        empty_peer_polls += 1
-                        peer_idle_secs = time.monotonic() - last_peer_seen_at
-                        if (
-                            empty_peer_polls >= _LISTENER_EMPTY_PEER_POLLS_REQUIRED
-                            and peer_idle_secs >= teardown_idle_secs
-                        ):
-                            print(
-                                "Listener: peer disconnected, shutting down",
-                                file=sys.stderr,
-                            )
-                            _log_perf_phase(
-                                "listener",
-                                "teardown_start",
-                                peer_idle_secs=f"{peer_idle_secs:.1f}",
-                            )
-                            await trio.sleep(self._listener_shutdown_grace_secs())
-                            break
+                    elif time.monotonic() >= connect_deadline:
+                        raise RuntimeError(
+                            f"Timeout: dialer never connected within "
+                            f"{self.test_timeout_seconds}s"
+                        )
+                elif self.host.get_live_peers():
+                    empty_peer_polls = 0
+                    last_peer_seen_at = time.monotonic()
+                else:
+                    empty_peer_polls += 1
+                    peer_idle_secs = time.monotonic() - last_peer_seen_at
+                    if (
+                        empty_peer_polls >= _LISTENER_EMPTY_PEER_POLLS_REQUIRED
+                        and peer_idle_secs >= teardown_idle_secs
+                    ):
+                        print(
+                            "Listener: peer disconnected, shutting down",
+                            file=sys.stderr,
+                        )
+                        _log_perf_phase(
+                            "listener",
+                            "teardown_start",
+                            peer_idle_secs=f"{peer_idle_secs:.1f}",
+                        )
+                        await trio.sleep(self._listener_shutdown_grace_secs())
+                        break
 
-                    await trio.sleep(_LISTENER_PEER_POLL_INTERVAL_SECS)
+                await trio.sleep(_LISTENER_PEER_POLL_INTERVAL_SECS)
 
-                await self._stop_perf_service()
-                self._close_redis()
-        except ExceptionGroup as eg:
-            if listener_ready and self._should_ignore_shutdown_error(eg):
-                _log_ignored_shutdown_error("Listener", eg)
-                return
-            raise
-        except BaseException as e:
-            if listener_ready and self._should_ignore_shutdown_error(e):
-                _log_ignored_shutdown_error("Listener", e)
-                return
-            raise
+            await self._stop_perf_service()
+            self._close_redis()
 
     async def _wait_for_listener_addr(self) -> str:
         timeout = min(self.test_timeout_seconds, MAX_TEST_TIMEOUT)
@@ -991,127 +900,108 @@ class PerfTest:
 
         # Must run host inside host.run() so swarm/nursery are active
         # (required for connect and QUIC)
-        try:
-            async with self.host.run(listen_addrs=dialer_listen_addrs or []):
-                # Brief delay so listener is fully listening before we dial
-                await trio.sleep(1.0)
+        async with self.host.run(listen_addrs=dialer_listen_addrs or []):
+            # Brief delay so listener is fully listening before we dial
+            await trio.sleep(1.0)
 
-                maddr = multiaddr.Multiaddr(self.listener_addr)
-                info = info_from_p2p_addr(maddr)
-                listener_peer_id = info.peer_id
-                await self.host.connect(info)
-                print("Connected to listener", file=sys.stderr)
-                _log_perf_phase(
-                    "dialer",
-                    "connected",
-                    test_timeout_seconds=self.test_timeout_seconds,
-                    muxer=self.muxer,
-                    security=self.security,
-                    transport=self.transport,
+            maddr = multiaddr.Multiaddr(self.listener_addr)
+            info = info_from_p2p_addr(maddr)
+            listener_peer_id = info.peer_id
+            await self.host.connect(info)
+            print("Connected to listener", file=sys.stderr)
+            _log_perf_phase(
+                "dialer",
+                "connected",
+                test_timeout_seconds=self.test_timeout_seconds,
+                muxer=self.muxer,
+                security=self.security,
+                transport=self.transport,
+            )
+
+            upload_samples: list[float] = []
+            _log_perf_phase("dialer", "upload_start", iterations=self.upload_iterations)
+            for i in range(self.upload_iterations):
+                elapsed = await self._one_measurement(self.upload_bytes, 0)
+                gbps = (self.upload_bytes * 8.0) / elapsed / 1e9 if elapsed > 0 else 0.0
+                upload_samples.append(gbps)
+                print(
+                    f"Upload {i + 1}/{self.upload_iterations}: {gbps:.2f} Gbps",
+                    file=sys.stderr,
                 )
 
-                upload_samples: list[float] = []
-                _log_perf_phase(
-                    "dialer", "upload_start", iterations=self.upload_iterations
+            download_samples: list[float] = []
+            _log_perf_phase(
+                "dialer", "download_start", iterations=self.download_iterations
+            )
+            for i in range(self.download_iterations):
+                elapsed = await self._one_measurement(0, self.download_bytes)
+                gbps = (
+                    (self.download_bytes * 8.0) / elapsed / 1e9 if elapsed > 0 else 0.0
                 )
-                for i in range(self.upload_iterations):
-                    elapsed = await self._one_measurement(self.upload_bytes, 0)
-                    gbps = (
-                        (self.upload_bytes * 8.0) / elapsed / 1e9
-                        if elapsed > 0
-                        else 0.0
-                    )
-                    upload_samples.append(gbps)
-                    print(
-                        f"Upload {i + 1}/{self.upload_iterations}: {gbps:.2f} Gbps",
-                        file=sys.stderr,
-                    )
-
-                download_samples: list[float] = []
-                _log_perf_phase(
-                    "dialer", "download_start", iterations=self.download_iterations
-                )
-                for i in range(self.download_iterations):
-                    elapsed = await self._one_measurement(0, self.download_bytes)
-                    gbps = (
-                        (self.download_bytes * 8.0) / elapsed / 1e9
-                        if elapsed > 0
-                        else 0.0
-                    )
-                    download_samples.append(gbps)
-                    print(
-                        f"Download {i + 1}/{self.download_iterations}: {gbps:.2f} Gbps",
-                        file=sys.stderr,
-                    )
-
-                latency_samples: list[float] = []
-                for i in range(self.latency_iterations):
-                    elapsed = await self._one_measurement(1, 1)
-                    latency_samples.append(elapsed * 1000.0)
-                print("Latency iterations done", file=sys.stderr)
-                _log_perf_phase(
-                    "dialer", "latency_done", iterations=self.latency_iterations
+                download_samples.append(gbps)
+                print(
+                    f"Download {i + 1}/{self.download_iterations}: {gbps:.2f} Gbps",
+                    file=sys.stderr,
                 )
 
-                u = _compute_stats(upload_samples, is_latency=False)
-                d = _compute_stats(download_samples, is_latency=False)
-                lat = _compute_stats(latency_samples, is_latency=True)
+            latency_samples: list[float] = []
+            for i in range(self.latency_iterations):
+                elapsed = await self._one_measurement(1, 1)
+                latency_samples.append(elapsed * 1000.0)
+            print("Latency iterations done", file=sys.stderr)
+            _log_perf_phase(
+                "dialer", "latency_done", iterations=self.latency_iterations
+            )
 
-                # YAML to stdout only (per write-a-perf-test-app.md)
-                print("upload:")
-                print(f"  iterations: {self.upload_iterations}")
-                print(f"  min: {u['min']:.2f}")
-                print(f"  q1: {u['q1']:.2f}")
-                print(f"  median: {u['median']:.2f}")
-                print(f"  q3: {u['q3']:.2f}")
-                print(f"  max: {u['max']:.2f}")
-                print(f"  outliers: {u['outliers']}")
-                print(f"  samples: {u['samples']}")
-                print("  unit: Gbps")
-                print("download:")
-                print(f"  iterations: {self.download_iterations}")
-                print(f"  min: {d['min']:.2f}")
-                print(f"  q1: {d['q1']:.2f}")
-                print(f"  median: {d['median']:.2f}")
-                print(f"  q3: {d['q3']:.2f}")
-                print(f"  max: {d['max']:.2f}")
-                print(f"  outliers: {d['outliers']}")
-                print(f"  samples: {d['samples']}")
-                print("  unit: Gbps")
-                print("latency:")
-                print(f"  iterations: {self.latency_iterations}")
-                print(f"  min: {lat['min']:.3f}")
-                print(f"  q1: {lat['q1']:.3f}")
-                print(f"  median: {lat['median']:.3f}")
-                print(f"  q3: {lat['q3']:.3f}")
-                print(f"  max: {lat['max']:.3f}")
-                print(f"  outliers: {lat['outliers']}")
-                print(f"  samples: {lat['samples']}")
-                print("  unit: ms")
+            u = _compute_stats(upload_samples, is_latency=False)
+            d = _compute_stats(download_samples, is_latency=False)
+            lat = _compute_stats(latency_samples, is_latency=True)
 
-                self._benchmarks_complete = True
-                _log_perf_phase("dialer", "benchmarks_complete")
+            # YAML to stdout only (per write-a-perf-test-app.md)
+            print("upload:")
+            print(f"  iterations: {self.upload_iterations}")
+            print(f"  min: {u['min']:.2f}")
+            print(f"  q1: {u['q1']:.2f}")
+            print(f"  median: {u['median']:.2f}")
+            print(f"  q3: {u['q3']:.2f}")
+            print(f"  max: {u['max']:.2f}")
+            print(f"  outliers: {u['outliers']}")
+            print(f"  samples: {u['samples']}")
+            print("  unit: Gbps")
+            print("download:")
+            print(f"  iterations: {self.download_iterations}")
+            print(f"  min: {d['min']:.2f}")
+            print(f"  q1: {d['q1']:.2f}")
+            print(f"  median: {d['median']:.2f}")
+            print(f"  q3: {d['q3']:.2f}")
+            print(f"  max: {d['max']:.2f}")
+            print(f"  outliers: {d['outliers']}")
+            print(f"  samples: {d['samples']}")
+            print("  unit: Gbps")
+            print("latency:")
+            print(f"  iterations: {self.latency_iterations}")
+            print(f"  min: {lat['min']:.3f}")
+            print(f"  q1: {lat['q1']:.3f}")
+            print(f"  median: {lat['median']:.3f}")
+            print(f"  q3: {lat['q3']:.3f}")
+            print(f"  max: {lat['max']:.3f}")
+            print(f"  outliers: {lat['outliers']}")
+            print(f"  samples: {lat['samples']}")
+            print("  unit: ms")
 
-                # Graceful close: disconnect listener so it sees a clean
-                # close, then stop services
-                _log_perf_phase("dialer", "teardown_start")
-                try:
-                    await self.host.disconnect(listener_peer_id)
-                except Exception as e:
-                    logger.debug("Disconnect: %s", e)
-                await trio.sleep(self._dialer_disconnect_grace_secs())
-                await self._stop_perf_service()
-                self._close_redis()
-        except ExceptionGroup as eg:
-            if self._should_ignore_shutdown_error(eg):
-                _log_ignored_shutdown_error("Dialer", eg)
-                return
-            raise
-        except BaseException as e:
-            if self._should_ignore_shutdown_error(e):
-                _log_ignored_shutdown_error("Dialer", e)
-                return
-            raise
+            self._benchmarks_complete = True
+            _log_perf_phase("dialer", "benchmarks_complete")
+
+            # Graceful close: disconnect listener so it sees a clean
+            # close, then stop services
+            _log_perf_phase("dialer", "teardown_start")
+            try:
+                await self.host.disconnect(listener_peer_id)
+            except Exception as e:
+                logger.debug("Disconnect: %s", e)
+            await trio.sleep(self._dialer_disconnect_grace_secs())
+            await self._stop_perf_service()
+            self._close_redis()
 
     async def run(self) -> None:
         try:
@@ -1119,19 +1009,7 @@ class PerfTest:
                 await self.run_dialer()
             else:
                 await self.run_listener()
-        except ExceptionGroup as eg:
-            if self._should_ignore_shutdown_error(eg):
-                _log_ignored_shutdown_error("Perf", eg)
-                return
-            print(f"Error: {eg}", file=sys.stderr)
-            import traceback
-
-            traceback.print_exc(file=sys.stderr)
-            sys.exit(1)
-        except BaseException as e:
-            if self._should_ignore_shutdown_error(e):
-                _log_ignored_shutdown_error("Perf", e)
-                return
+        except Exception as e:
             print(f"Error: {e}", file=sys.stderr)
             import traceback
 

--- a/interop/transport/ping_test.py
+++ b/interop/transport/ping_test.py
@@ -28,12 +28,6 @@ import multiaddr
 import redis
 import trio
 
-# ExceptionGroup is built-in in Python 3.11+, import for older versions
-try:
-    ExceptionGroup  # noqa: B018
-except NameError:
-    from exceptiongroup import ExceptionGroup  # type: ignore[no-redef]
-
 from libp2p import create_mplex_muxer_option, create_yamux_muxer_option, new_host
 from libp2p.crypto.ed25519 import create_new_key_pair
 from libp2p.crypto.x25519 import create_new_key_pair as create_new_x25519_key_pair
@@ -654,44 +648,6 @@ class PingTest:
             except (AttributeError, Exception):
                 return "unknown"
 
-    def _is_connection_closed_error(self, exc: BaseException) -> bool:
-        """
-        Check if an exception is an expected 'Connection closed' error.
-
-        These errors occur during graceful shutdown when the muxer is still
-        trying to read from a connection that has been closed by the other side.
-        """
-        if exc is None:
-            return False
-
-        # Check direct exception message (shutdown races with many implementations)
-        exc_str = str(exc).lower()
-        if any(
-            phrase in exc_str
-            for phrase in (
-                "connection closed",
-                "stream reset",
-                "connection reset",
-                "broken pipe",
-                "stream eof",
-                "end of file",
-            )
-        ):
-            return True
-
-        # Check cause chain
-        if hasattr(exc, "__cause__") and exc.__cause__:
-            if self._is_connection_closed_error(exc.__cause__):
-                return True
-
-        # Check nested ExceptionGroups
-        if isinstance(exc, ExceptionGroup):
-            return all(
-                self._is_connection_closed_error(inner) for inner in exc.exceptions
-            )
-
-        return False
-
     def _listener_post_ping_grace_secs(self) -> float:
         if not self.test_plans:
             return 0.2
@@ -901,12 +857,10 @@ class PingTest:
         self.host.set_stream_handler(PING_PROTOCOL_ID, self.handle_ping)
         self.log_protocols()
 
-        listener_success = False
-        try:
-            async with self.host.run(listen_addrs=listen_addrs):
-                all_addrs = self.host.get_addrs()
-                if not all_addrs:
-                    raise RuntimeError("No listen addresses available")
+        async with self.host.run(listen_addrs=listen_addrs):
+            all_addrs = self.host.get_addrs()
+            if not all_addrs:
+                raise RuntimeError("No listen addresses available")
 
                 actual_addr = self._get_publishable_address(all_addrs)
                 print(
@@ -948,7 +902,6 @@ class PingTest:
                             "Ping received and responded, listener exiting",
                             file=sys.stderr,
                         )
-                        listener_success = True
                         # Small muxer drain delay; in test-plans wait longer so the
                         # dialer container can exit before we do (see module note).
                         grace = self._listener_post_ping_grace_secs()
@@ -963,40 +916,6 @@ class PingTest:
                         file=sys.stderr,
                     )
                     sys.exit(1)
-
-        except ExceptionGroup as eg:
-            # Handle expected "Connection closed" errors during shutdown
-            if listener_success:
-                # Check if all errors are connection closed errors
-                all_conn_closed = True
-                for exc in eg.exceptions:
-                    if isinstance(exc, ExceptionGroup):
-                        for inner in exc.exceptions:
-                            if not self._is_connection_closed_error(inner):
-                                all_conn_closed = False
-                                break
-                    elif not self._is_connection_closed_error(exc):
-                        all_conn_closed = False
-                        break
-
-                if all_conn_closed:
-                    print(
-                        "Listener completed (connection closed during cleanup)",
-                        file=sys.stderr,
-                    )
-                    return
-            # Re-raise if we didn't succeed or if there are real errors
-            raise
-
-        except Exception as e:
-            # Check if it's a connection closed error after success
-            if listener_success and self._is_connection_closed_error(e):
-                print(
-                    "Listener completed (connection closed during cleanup)",
-                    file=sys.stderr,
-                )
-                return
-            raise
 
     async def _connect_redis_with_retry(
         self, max_retries: int = 10, retry_delay: float = 1.0
@@ -1419,43 +1338,12 @@ class PingTest:
                 # Small delay to allow muxer to drain
                 await trio.sleep(0.1)
 
-        except ExceptionGroup as eg:
-            # Handle expected "Connection closed" errors during shutdown
-            # These occur when the muxer is still reading while we close
-            non_connection_errors = []
-            for exc in eg.exceptions:
-                if isinstance(exc, ExceptionGroup):
-                    for inner in exc.exceptions:
-                        if not self._is_connection_closed_error(inner):
-                            non_connection_errors.append(inner)
-                elif not self._is_connection_closed_error(exc):
-                    non_connection_errors.append(exc)
-
-            if non_connection_errors:
-                print(f"Dialer error: {eg}", file=sys.stderr)
-                import traceback
-
-                traceback.print_exc(file=sys.stderr)
-                sys.exit(1)
-            else:
-                print(
-                    "Dialer completed (connection closed during cleanup)",
-                    file=sys.stderr,
-                )
-
         except Exception as e:
-            # Check if it's a connection closed error (expected during shutdown)
-            if self._is_connection_closed_error(e):
-                print(
-                    "Dialer completed (connection closed during cleanup)",
-                    file=sys.stderr,
-                )
-            else:
-                print(f"Dialer error: {e}", file=sys.stderr)
-                import traceback
+            print(f"Dialer error: {e}", file=sys.stderr)
+            import traceback
 
-                traceback.print_exc(file=sys.stderr)
-                sys.exit(1)
+            traceback.print_exc(file=sys.stderr)
+            sys.exit(1)
 
     async def run(self) -> None:
         """Main run method."""
@@ -1468,35 +1356,12 @@ class PingTest:
             else:
                 await self.run_listener()
 
-        except ExceptionGroup as eg:
-            # Check if all exceptions are "connection closed" (expected during cleanup)
-            all_conn_closed = True
-            for exc in eg.exceptions:
-                if isinstance(exc, ExceptionGroup):
-                    for inner in exc.exceptions:
-                        if not self._is_connection_closed_error(inner):
-                            all_conn_closed = False
-                            break
-                elif not self._is_connection_closed_error(exc):
-                    all_conn_closed = False
-                    break
-
-            if not all_conn_closed:
-                print(f"Error: {eg}", file=sys.stderr)
-                import traceback
-
-                traceback.print_exc(file=sys.stderr)
-                sys.exit(1)
-            # If all are connection closed, that's expected - exit normally
-
         except Exception as e:
-            # Check if it's a connection closed error (expected during shutdown)
-            if not self._is_connection_closed_error(e):
-                print(f"Error: {e}", file=sys.stderr)
-                import traceback
+            print(f"Error: {e}", file=sys.stderr)
+            import traceback
 
-                traceback.print_exc(file=sys.stderr)
-                sys.exit(1)
+            traceback.print_exc(file=sys.stderr)
+            sys.exit(1)
 
         finally:
             if self.redis_client:

--- a/libp2p/network/connection/swarm_connection.py
+++ b/libp2p/network/connection/swarm_connection.py
@@ -230,14 +230,36 @@ class SwarmConn(INetConn):
             while not self.event_closed.is_set():
                 try:
                     stream = await self.muxed_conn.accept_stream()
-                except MuxedConnUnavailable:
+                except MuxedConnUnavailable as e:
+                    from libp2p.utils.connection_shutdown import (
+                        log_expected_connection_shutdown,
+                    )
+
+                    log_expected_connection_shutdown(
+                        component="SwarmConn.accept_stream",
+                        peer_id=self.muxed_conn.peer_id,
+                        direction="remote",
+                        exc=e,
+                    )
                     await self.close()
                     break
                 except Exception as e:
-                    # Catch QUICConnectionClosedError and other unexpected disconnects
-                    logging.debug(
-                        f"Connection closed for peer {self.muxed_conn.peer_id}: {e}"
+                    from libp2p.utils.connection_shutdown import (
+                        is_expected_connection_shutdown,
+                        log_expected_connection_shutdown,
                     )
+
+                    if is_expected_connection_shutdown(e):
+                        log_expected_connection_shutdown(
+                            component="SwarmConn.accept_stream",
+                            peer_id=self.muxed_conn.peer_id,
+                            direction="remote",
+                            exc=e,
+                        )
+                    else:
+                        logging.debug(
+                            f"Connection closed for peer {self.muxed_conn.peer_id}: {e}"
+                        )
                     await self.close()
                     break
                 # The connection may have been closed while we were waiting

--- a/libp2p/tools/anyio_service/manager.py
+++ b/libp2p/tools/anyio_service/manager.py
@@ -414,24 +414,44 @@ class AnyIOManager(InternalManagerAPI):
                 self._root_tasks.discard(task)
 
         except Exception as err:
-            self.logger.error(
-                "%s: task %s exited with error: %s",
-                self._service,
-                task,
-                err,
-                exc_info=not isinstance(err, DaemonTaskExit),
+            from libp2p.utils.connection_shutdown import (
+                is_expected_connection_shutdown,
+                log_expected_connection_shutdown,
             )
-            # HIGH COMPLEXITY: Trigger cancellation and re-raise
-            # Don't collect here - let the outer task_group handler collect
-            self.logger.debug("%s: calling cancel() due to exception", self._service)
-            self.cancel()
-            self.logger.debug(
-                "%s: cancel() called, is_cancelled=%s",
-                self._service,
-                self.is_cancelled,
-            )
-            # Re-raise so AnyIO's task group can cancel all other tasks immediately
-            raise
+
+            # Peer hangup / clean muxer teardown must not cancel the whole Swarm
+            # or surface as ExceptionGroup to host.run / host.close callers.
+            if is_expected_connection_shutdown(err):
+                log_expected_connection_shutdown(
+                    component=str(self._service),
+                    direction="task_exit",
+                    exc=err,
+                )
+                if task.parent is None:
+                    self._root_tasks.discard(task)
+                if isinstance(task, FunctionTask) and task.count_in_stats:
+                    self._finished_task_count += 1
+            else:
+                self.logger.error(
+                    "%s: task %s exited with error: %s",
+                    self._service,
+                    task,
+                    err,
+                    exc_info=not isinstance(err, DaemonTaskExit),
+                )
+                # HIGH COMPLEXITY: Trigger cancellation and re-raise
+                # Don't collect here - let the outer task_group handler collect
+                self.logger.debug(
+                    "%s: calling cancel() due to exception", self._service
+                )
+                self.cancel()
+                self.logger.debug(
+                    "%s: cancel() called, is_cancelled=%s",
+                    self._service,
+                    self.is_cancelled,
+                )
+                # Re-raise so AnyIO's task group can cancel all other tasks immediately
+                raise
 
         else:
             # Task completed successfully

--- a/libp2p/tools/anyio_service/trio_manager.py
+++ b/libp2p/tools/anyio_service/trio_manager.py
@@ -357,16 +357,32 @@ class TrioManager(InternalManagerAPI):
                         )
 
         except Exception as err:
-            self.logger.error(
-                "%s: task %s exited with error: %s",
-                self._service,
-                task,
-                err,
-                exc_info=not isinstance(err, DaemonTaskExit),
+            from libp2p.utils.connection_shutdown import (
+                is_expected_connection_shutdown,
+                log_expected_connection_shutdown,
             )
-            # HIGH COMPLEXITY: Collect error and trigger cancellation
-            self._errors.append(cast(EXC_INFO, sys.exc_info()))
-            self.cancel()
+
+            if is_expected_connection_shutdown(err):
+                log_expected_connection_shutdown(
+                    component=str(self._service),
+                    direction="task_exit",
+                    exc=err,
+                )
+                if task.parent is None:
+                    self._root_tasks.discard(task)
+                if isinstance(task, FunctionTask) and task.count_in_stats:
+                    self._finished_task_count += 1
+            else:
+                self.logger.error(
+                    "%s: task %s exited with error: %s",
+                    self._service,
+                    task,
+                    err,
+                    exc_info=not isinstance(err, DaemonTaskExit),
+                )
+                # HIGH COMPLEXITY: Collect error and trigger cancellation
+                self._errors.append(cast(EXC_INFO, sys.exc_info()))
+                self.cancel()
 
         else:
             # Task completed successfully

--- a/libp2p/utils/connection_shutdown.py
+++ b/libp2p/utils/connection_shutdown.py
@@ -1,0 +1,115 @@
+"""
+Detect expected connection / muxer shutdown errors.
+
+Remote peer hangup or local teardown should not surface as fatal service
+errors (ExceptionGroup from the Swarm manager). Active stream I/O still
+raises these types to callers; only background tasks / host.run close
+paths should absorb them via this predicate.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Final
+
+from libp2p.io.exceptions import ConnectionClosedError
+from libp2p.network.connection.exceptions import RawConnError
+from libp2p.stream_muxer.exceptions import (
+    MuxedConnUnavailable,
+    MuxedStreamClosed,
+    MuxedStreamEOF,
+    MuxedStreamReset,
+)
+
+logger = logging.getLogger("libp2p.connection_shutdown")
+
+if sys.version_info >= (3, 11):
+    from builtins import ExceptionGroup
+else:
+    from exceptiongroup import ExceptionGroup
+
+# Extra phrases used by TLS/stream stacks during peer hangup.
+_EXPECTED_PHRASES: Final[tuple[str, ...]] = (
+    "connection closed",
+    "connection is closed",
+    "tls connection is closed",
+    "stream reset",
+    "connection reset",
+    "broken pipe",
+    "stream eof",
+    "end of file",
+    "stream is closed",
+    "stream buffer closed",
+    "closed resource",
+    "broken resource",
+    "failed to read the header correctly",
+    "failed to read the message body correctly",
+    "failed to write message to the underlying connection",
+)
+
+_EXPECTED_TYPES: Final[tuple[type[BaseException], ...]] = (
+    MuxedConnUnavailable,
+    MuxedStreamEOF,
+    MuxedStreamClosed,
+    MuxedStreamReset,
+    ConnectionClosedError,
+)
+
+
+def is_expected_connection_shutdown(exc: BaseException | None) -> bool:
+    """
+    Return True if *exc* represents a normal peer/local connection teardown.
+
+    Recurses into ExceptionGroup / __cause__ / __context__. Unexpected
+    members of a group make the whole group unexpected.
+    """
+    if exc is None:
+        return False
+
+    if isinstance(exc, ExceptionGroup):
+        nested = exc.exceptions
+        if not nested:
+            return False
+        return all(is_expected_connection_shutdown(inner) for inner in nested)
+
+    if any(isinstance(exc, expected) for expected in _EXPECTED_TYPES):
+        return True
+
+    # Empty RawConnError is used as a normal EOF signal in yamux/mplex paths.
+    if isinstance(exc, RawConnError):
+        msg = str(exc).strip().lower()
+        return (not msg) or any(p in msg for p in _EXPECTED_PHRASES)
+
+    msg = str(exc).lower()
+    if any(p in msg for p in _EXPECTED_PHRASES):
+        return True
+
+    if exc.__cause__ is not None and is_expected_connection_shutdown(exc.__cause__):
+        return True
+    if (
+        exc.__context__ is not None
+        and exc.__context__ is not exc.__cause__
+        and is_expected_connection_shutdown(exc.__context__)
+    ):
+        return True
+
+    return False
+
+
+def log_expected_connection_shutdown(
+    *,
+    component: str,
+    peer_id: object | None = None,
+    direction: str = "unknown",
+    exc: BaseException | None = None,
+) -> None:
+    """DEBUG one line describing an absorbed connection shutdown."""
+    logger.debug(
+        "%s: expected connection shutdown (direction=%s peer=%s): %s: %s",
+        component,
+        direction,
+        peer_id,
+        type(exc).__name__ if exc is not None else "none",
+        exc,
+    )

--- a/newsfragments/1516.bugfix.rst
+++ b/newsfragments/1516.bugfix.rst
@@ -1,0 +1,1 @@
+Quietly exit `host.run` / `host.close` when muxer background tasks see expected peer hangup, so apps no longer need ExceptionGroup teardown swallows.

--- a/tests/core/utils/test_connection_shutdown.py
+++ b/tests/core/utils/test_connection_shutdown.py
@@ -1,0 +1,79 @@
+"""Unit tests for expected connection-shutdown detection."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    ExceptionGroup  # noqa: B018
+except NameError:
+    from exceptiongroup import ExceptionGroup  # type: ignore[no-redef]
+
+from libp2p.network.connection.exceptions import RawConnError
+from libp2p.stream_muxer.exceptions import MuxedConnUnavailable
+from libp2p.utils.connection_shutdown import (
+    is_expected_connection_shutdown,
+    log_expected_connection_shutdown,
+)
+
+
+def test_expected_muxed_conn_unavailable() -> None:
+    assert is_expected_connection_shutdown(MuxedConnUnavailable("Connection closed"))
+
+
+def test_expected_phrases() -> None:
+    assert is_expected_connection_shutdown(RuntimeError("connection closed"))
+    assert is_expected_connection_shutdown(RuntimeError("TLS connection is closed"))
+    assert is_expected_connection_shutdown(RuntimeError("broken pipe"))
+
+
+def test_empty_raw_conn_error_is_expected() -> None:
+    assert is_expected_connection_shutdown(RawConnError())
+
+
+def test_unrelated_error_not_expected() -> None:
+    assert not is_expected_connection_shutdown(RuntimeError("negotiation failed"))
+    assert not is_expected_connection_shutdown(None)
+
+
+def test_exception_group_all_expected() -> None:
+    eg = ExceptionGroup(
+        "shutdown",
+        [RuntimeError("connection closed"), RuntimeError("stream eof")],
+    )
+    assert is_expected_connection_shutdown(eg)
+
+
+def test_exception_group_mixed_not_expected() -> None:
+    mixed = ExceptionGroup(
+        "shutdown",
+        [RuntimeError("connection closed"), RuntimeError("other failure")],
+    )
+    assert not is_expected_connection_shutdown(mixed)
+
+
+def test_cause_chain() -> None:
+    cause = RuntimeError("connection reset")
+    wrapper = RuntimeError("wrapper")
+    wrapper.__cause__ = cause
+    assert is_expected_connection_shutdown(wrapper)
+
+
+def test_log_expected_emits_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[str] = []
+
+    def _capture(msg: str, *args: object, **_kwargs: object) -> None:
+        recorded.append(msg % args if args else msg)
+
+    monkeypatch.setattr(
+        "libp2p.utils.connection_shutdown.logger.debug",
+        _capture,
+    )
+    log_expected_connection_shutdown(
+        component="test",
+        peer_id="peer",
+        direction="remote",
+        exc=MuxedConnUnavailable("Connection closed"),
+    )
+    assert recorded
+    assert "expected connection shutdown" in recorded[0]

--- a/tests/interop/perf/test_perf_test_helpers.py
+++ b/tests/interop/perf/test_perf_test_helpers.py
@@ -11,11 +11,6 @@ import multiaddr
 
 pytest.importorskip("redis")
 
-try:
-    ExceptionGroup  # noqa: B018
-except NameError:
-    from exceptiongroup import ExceptionGroup  # type: ignore[no-redef]
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PERF_TEST_PATH = _REPO_ROOT / "interop" / "perf" / "perf_test.py"
 
@@ -31,90 +26,9 @@ def _load_perf_test_module():
 
 perf_test = _load_perf_test_module()
 
-_is_connection_closed_error = perf_test._is_connection_closed_error
 _env_int = perf_test._env_int
 _env_float = perf_test._env_float
 PerfTest = perf_test.PerfTest
-
-
-def _perf_test_env(
-    monkeypatch: pytest.MonkeyPatch, *, is_dialer: bool, tmp_path: Path
-) -> PerfTest:
-    monkeypatch.setenv("TRANSPORT", "tcp")
-    monkeypatch.setenv("MUXER", "mplex")
-    monkeypatch.setenv("SECURE_CHANNEL", "tls")
-    monkeypatch.setenv("IS_DIALER", "true" if is_dialer else "false")
-    monkeypatch.setenv("TEST_KEY", "test-key")
-    monkeypatch.setenv("PERF_LOCAL_ADDR_FILE", str(tmp_path / "perf-local-addr"))
-    monkeypatch.delenv("REDIS_ADDR", raising=False)
-    return PerfTest()
-
-
-def test_is_connection_closed_error_matching_phrases() -> None:
-    assert _is_connection_closed_error(RuntimeError("connection closed"))
-    assert _is_connection_closed_error(RuntimeError("TLS connection is closed"))
-    assert _is_connection_closed_error(RuntimeError("broken pipe"))
-
-
-def test_is_connection_closed_error_unrelated() -> None:
-    assert not _is_connection_closed_error(RuntimeError("negotiation failed"))
-    assert not _is_connection_closed_error(None)
-
-
-def test_is_connection_closed_error_exception_group() -> None:
-    eg = ExceptionGroup(
-        "shutdown",
-        [RuntimeError("connection closed"), RuntimeError("stream eof")],
-    )
-    assert _is_connection_closed_error(eg)
-
-    mixed = ExceptionGroup(
-        "shutdown",
-        [RuntimeError("connection closed"), RuntimeError("other failure")],
-    )
-    assert not _is_connection_closed_error(mixed)
-
-
-def test_is_connection_closed_error_cause_chain() -> None:
-    cause = RuntimeError("connection reset")
-    wrapper = RuntimeError("wrapper")
-    wrapper.__cause__ = cause
-    assert _is_connection_closed_error(wrapper)
-
-
-def test_should_ignore_shutdown_error_dialer(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    test = _perf_test_env(monkeypatch, is_dialer=True, tmp_path=tmp_path)
-    exc = RuntimeError("connection closed")
-
-    test._benchmarks_complete = False
-    assert not test._should_ignore_shutdown_error(exc)
-
-    test._benchmarks_complete = True
-    assert test._should_ignore_shutdown_error(exc)
-
-
-def test_should_ignore_shutdown_error_listener(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    test = _perf_test_env(monkeypatch, is_dialer=False, tmp_path=tmp_path)
-    exc = RuntimeError("connection closed")
-
-    test._listener_served_peer = False
-    assert not test._should_ignore_shutdown_error(exc)
-
-    test._listener_served_peer = True
-    assert test._should_ignore_shutdown_error(exc)
-
-
-def test_should_ignore_shutdown_error_non_connection(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    test = _perf_test_env(monkeypatch, is_dialer=True, tmp_path=tmp_path)
-    test._benchmarks_complete = True
-    assert not test._should_ignore_shutdown_error(RuntimeError("timeout"))
 
 
 def test_env_int_defaults_and_minimum(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Fixes #1516.

After a successful dial/ping, exiting `async with host.run(...):` (or `await host.close()`) could still raise an `ExceptionGroup` when yamux/mplex background tasks exited because the peer had already closed. Interop harnesses worked around this with post-success ExceptionGroup swallows (#1162); apps should not need that.

This change:

- Adds `libp2p.utils.connection_shutdown.is_expected_connection_shutdown()` (known muxer/connection types + phrases; recurses into ExceptionGroup / cause / context).
- Absorbs expected task-exit errors in the anyio and trio service managers (DEBUG log; do not cancel Swarm / do not surface as ExceptionGroup).
- Logs expected remote close in `SwarmConn` accept loop.
- Removes ExceptionGroup teardown swallows from `interop/transport/ping_test.py` and `interop/perf/perf_test.py`.
- Keeps ExceptionGroup as the manager aggregation path for **unexpected** failures (#973).
- Keeps active stream I/O raising (`accept_stream` / read / write mid-session).

## Test plan

- [x] `pytest tests/core/utils/test_connection_shutdown.py tests/interop/perf/test_perf_test_helpers.py`
- [x] Pre-commit: ruff, mypy, pyrefly
- [x] CI green on this PR
- [x] Local unified-testing transport matrix after rebuild: full `--test-select "python-v0.x"` → **330/337**; remaining fails are known peer/browser issues (dotnet TLS, zig dialer, firefox WT), not teardown ExceptionGroups
- [x] Spot-check: `examples/interop/local_ping_test.py` (tcp+mplex / tcp+yamux) exits cleanly after peer hangup without harness swallows


Made with [Cursor](https://cursor.com)