### PR TITLE
fix(quic): send-side write backpressure for honest throughput

### DIFF
--- a/libp2p/transport/quic/aioquic_compat.py
+++ b/libp2p/transport/quic/aioquic_compat.py
@@ -20,16 +20,51 @@ Currently applied:
     The wrapper defers the FIN-only frame when ``max_size`` is negative, which
     is exactly the condition under which ``start_frame`` would reject it, so
     the FIN stays pending and is emitted in the next packet.
+
+``stream_send_buffer_size`` exposes the un-ACKed send buffer of a stream
+    aioquic's ``QuicConnection.send_stream_data`` only appends to an unbounded
+    per-stream buffer and returns; nothing in its public API reports how much
+    of that buffer is still waiting to be sent or acknowledged. libp2p needs
+    that number to apply send-side backpressure in ``QUICStream.write()``
+    (otherwise a writer can enqueue gigabytes in memory and "finish" long
+    before the peer receives anything). The helper reads the sender's private
+    ``_buffer_start`` / ``_buffer_stop`` offsets, which are the only place this
+    information exists.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aioquic.quic.connection import QuicConnection
 
 logger = logging.getLogger(__name__)
 
 _APPLIED_ATTR = "_libp2p_keep_pending_fin"
+
+
+def stream_send_buffer_size(quic: QuicConnection, stream_id: int) -> int:
+    """
+    Return the number of bytes written to ``stream_id`` that the peer has not
+    acknowledged yet (queued for transmission or in flight).
+
+    Returns 0 when the stream is unknown to aioquic, which also covers the
+    normal case of a stream that has been fully delivered and discarded.
+    """
+    streams = getattr(quic, "_streams", None)
+    if not isinstance(streams, dict):
+        return 0
+    stream = streams.get(stream_id)
+    if stream is None:
+        return 0
+    sender = getattr(stream, "sender", None)
+    start = getattr(sender, "_buffer_start", None)
+    stop = getattr(sender, "_buffer_stop", None)
+    if not isinstance(start, int) or not isinstance(stop, int):
+        return 0
+    return max(0, stop - start)
 
 
 def apply() -> None:

--- a/libp2p/transport/quic/config.py
+++ b/libp2p/transport/quic/config.py
@@ -167,6 +167,27 @@ class QUICTransportConfig(ConnectionConfig):
     STREAM_RECEIVE_BUFFER_HIGH_WATERMARK: int = 512 * 1024  # 512KB
     """High watermark for stream receive buffer."""
 
+    # Send-side backpressure
+    STREAM_SEND_BUFFER_HIGH_WATERMARK: int = 1024 * 1024  # 1MB
+    """Un-ACKed bytes per stream above which ``QUICStream.write()`` blocks.
+
+    aioquic buffers written data without limit; this bounds how far a writer
+    may run ahead of the peer. It should not be smaller than the peer's
+    per-stream flow-control window (``STREAM_FLOW_CONTROL_WINDOW`` for a
+    py-libp2p peer), otherwise the local buffer, not QUIC flow control,
+    becomes the throughput limit.
+    """
+
+    STREAM_SEND_BUFFER_LOW_WATERMARK: int = 256 * 1024  # 256KB
+    """Un-ACKed bytes per stream below which blocked writers are resumed."""
+
+    STREAM_WRITE_CHUNK_SIZE: int = 64 * 1024  # 64KB
+    """Maximum bytes handed to aioquic per ``write()`` step.
+
+    Large writes are split into chunks of this size so the send watermark is
+    checked between chunks and a single big write cannot overshoot it.
+    """
+
     # Stream lifecycle configuration
     ENABLE_STREAM_RESET_ON_ERROR: bool = True
     """Whether to automatically reset streams on errors."""
@@ -274,6 +295,22 @@ class QUICTransportConfig(ConnectionConfig):
             raise ValueError(
                 "STREAM_RECEIVE_BUFFER_LOW_WATERMARK must be < HIGH_WATERMARK"
             )
+
+        # Validate send backpressure watermarks
+        if self.STREAM_SEND_BUFFER_LOW_WATERMARK <= 0:
+            raise ValueError("STREAM_SEND_BUFFER_LOW_WATERMARK must be positive")
+
+        if (
+            self.STREAM_SEND_BUFFER_LOW_WATERMARK
+            >= self.STREAM_SEND_BUFFER_HIGH_WATERMARK
+        ):
+            raise ValueError(
+                "STREAM_SEND_BUFFER_LOW_WATERMARK must be < "
+                "STREAM_SEND_BUFFER_HIGH_WATERMARK"
+            )
+
+        if self.STREAM_WRITE_CHUNK_SIZE <= 0:
+            raise ValueError("STREAM_WRITE_CHUNK_SIZE must be positive")
 
         # Validate memory limits
         if self.STREAM_MEMORY_LIMIT_PER_STREAM <= 0:

--- a/libp2p/transport/quic/connection.py
+++ b/libp2p/transport/quic/connection.py
@@ -1635,6 +1635,26 @@ class QUICConnection(IRawConnection, IMuxedConn):
         except Exception as e:
             logger.error(f"Transmission error: {e}")
             await self._handle_connection_error(e)
+            return
+
+        # Every receive path (client receiver, listener routing, event loop)
+        # ends here after aioquic has consumed incoming ACKs, so this is the
+        # single place to wake writers blocked on send backpressure.
+        self._refresh_send_backpressure()
+
+    # Send-side backpressure support
+
+    def stream_send_buffer_size(self, stream_id: int) -> int:
+        """Bytes written to ``stream_id`` that the peer has not acknowledged yet."""
+        return aioquic_compat.stream_send_buffer_size(self._quic, stream_id)
+
+    def _refresh_send_backpressure(self) -> None:
+        """Release streams whose un-ACKed send buffer dropped below the watermark."""
+        for stream in list(self._streams.values()):
+            # Writers re-arm backpressure themselves after each write step;
+            # here we only need to look at streams that are currently blocked.
+            if not stream._backpressure_event.is_set():
+                stream._update_send_backpressure()
 
     # Additional methods for stream data processing
     async def _process_quic_event(self, event: events.QuicEvent) -> None:

--- a/libp2p/transport/quic/stream.py
+++ b/libp2p/transport/quic/stream.py
@@ -172,6 +172,13 @@ class QUICStream(IMuxedStream):
         self.MAX_RECEIVE_BUFFER_SIZE = (
             connection._transport._config.MAX_STREAM_RECEIVE_BUFFER
         )
+        self.SEND_BUFFER_HIGH_WATERMARK = (
+            connection._transport._config.STREAM_SEND_BUFFER_HIGH_WATERMARK
+        )
+        self.SEND_BUFFER_LOW_WATERMARK = (
+            connection._transport._config.STREAM_SEND_BUFFER_LOW_WATERMARK
+        )
+        self.WRITE_CHUNK_SIZE = connection._transport._config.STREAM_WRITE_CHUNK_SIZE
 
         if self._resource_scope:
             self._reserve_memory(self.FLOW_CONTROL_WINDOW_SIZE)
@@ -303,15 +310,25 @@ class QUICStream(IMuxedStream):
 
     async def write(self, data: bytes) -> None:
         """
-        Write data to the stream with QUIC flow control.
+        Write data to the stream with send-side backpressure.
+
+        aioquic buffers written data without limit and only paces the actual
+        transmission by congestion control and the peer's flow-control window.
+        To keep a fast writer honest (and bounded in memory), the data is handed
+        to aioquic in ``WRITE_CHUNK_SIZE`` pieces and, whenever the stream's
+        un-ACKed send buffer reaches ``SEND_BUFFER_HIGH_WATERMARK``, this call
+        blocks until acknowledgements bring it back down to
+        ``SEND_BUFFER_LOW_WATERMARK``. Returning therefore means the peer has
+        acknowledged all but at most ``SEND_BUFFER_HIGH_WATERMARK`` bytes.
 
         Args:
             data: Data to write
 
         Raises:
             QUICStreamClosedError: Stream is closed for writing
+            QUICStreamResetError: Stream was reset while waiting to write
+            QUICStreamTimeoutError: No send capacity within ``WRITE_TIMEOUT``
             QUICStreamBackpressureError: Flow control window exhausted
-            QUICStreamResetError: Stream was reset
 
         """
         if not data:
@@ -327,17 +344,38 @@ class QUICStream(IMuxedStream):
                 )
 
         try:
-            # Handle flow control backpressure
-            await self._backpressure_event.wait()
+            view = memoryview(data)
+            total = len(view)
+            offset = 0
+            while offset < total:
+                # Block while the peer has not acknowledged enough of what we
+                # already handed to aioquic.
+                await self._wait_for_send_capacity()
 
-            # Send data through QUIC connection
-            self._connection._quic.send_stream_data(self._stream_id, data)
-            self._connection._signal_activity()
-            await self._connection._transmit()
+                end = min(offset + self.WRITE_CHUNK_SIZE, total)
+                if offset == 0 and end == total:
+                    chunk = data  # fits in one chunk: avoid a copy
+                else:
+                    chunk = bytes(view[offset:end])
+                offset = end
+
+                # Send data through QUIC connection
+                self._connection._quic.send_stream_data(self._stream_id, chunk)
+                self._connection._signal_activity()
+                await self._connection._transmit()
+                self._update_send_backpressure()
 
             self._timeline.record_first_data()
-            logger.debug(f"Wrote {len(data)} bytes to stream {self.stream_id}")
+            logger.debug(f"Wrote {total} bytes to stream {self.stream_id}")
 
+        except (
+            QUICStreamClosedError,
+            QUICStreamResetError,
+            QUICStreamTimeoutError,
+        ):
+            # Raised by _wait_for_send_capacity(): the stream state already
+            # reflects what happened, do not additionally reset the stream.
+            raise
         except ValueError as e:
             if "unknown peer-initiated stream" in str(e):
                 raise QUICStreamClosedError(
@@ -688,15 +726,92 @@ class QUICStream(IMuxedStream):
 
         """
         if available_window > 0:
-            self._backpressure_event.set()
+            # Re-evaluate against the actual send buffer: writers resume only
+            # if we are also below the send watermark.
+            self._update_send_backpressure()
             logger.debug(
-                f"Stream {self.stream_id} flow control".__add__(
-                    f"window updated: {available_window}"
-                )
+                f"Stream {self.stream_id} flow control "
+                f"window updated: {available_window}"
             )
         else:
-            self._backpressure_event = trio.Event()  # Reset to blocking state
+            self._block_writers()
             logger.debug(f"Stream {self.stream_id} flow control window exhausted")
+
+    # Send-side backpressure
+
+    def send_buffer_size(self) -> int:
+        """Bytes handed to aioquic for this stream that the peer has not ACKed."""
+        return self._connection.stream_send_buffer_size(self._stream_id)
+
+    def _block_writers(self) -> None:
+        """Make subsequent write() calls wait until capacity is available."""
+        if self._backpressure_event.is_set():
+            # Only ever replace a *set* event: nobody can be waiting on it, so
+            # waiters on the previous (unset) event are never orphaned.
+            self._backpressure_event = trio.Event()
+
+    def _update_send_backpressure(self) -> None:
+        """
+        Re-evaluate send backpressure from the un-ACKed send buffer.
+
+        Called after each write step and by the connection after datagrams are
+        processed (ACKs are handled inside aioquic's ``receive_datagram`` and
+        do not surface as events). Cheap enough to run frequently: it reads
+        two integers.
+        """
+        if self._write_closed or self._state in (
+            StreamState.CLOSED,
+            StreamState.RESET,
+        ):
+            # Nothing more will be written; never leave a writer stuck.
+            self._backpressure_event.set()
+            return
+
+        buffered = self.send_buffer_size()
+        if buffered >= self.SEND_BUFFER_HIGH_WATERMARK:
+            if self._backpressure_event.is_set():
+                logger.debug(
+                    f"Stream {self.stream_id} send buffer {buffered} bytes >= "
+                    f"{self.SEND_BUFFER_HIGH_WATERMARK}: applying backpressure"
+                )
+            self._block_writers()
+        elif buffered <= self.SEND_BUFFER_LOW_WATERMARK:
+            if not self._backpressure_event.is_set():
+                logger.debug(
+                    f"Stream {self.stream_id} send buffer {buffered} bytes <= "
+                    f"{self.SEND_BUFFER_LOW_WATERMARK}: releasing backpressure"
+                )
+                self._backpressure_event.set()
+
+    async def _wait_for_send_capacity(self) -> None:
+        """
+        Wait until the send buffer is below the low watermark.
+
+        Raises:
+            QUICStreamResetError: The stream was reset while waiting
+            QUICStreamClosedError: The write side was closed while waiting
+            QUICStreamTimeoutError: No capacity within ``WRITE_TIMEOUT``
+
+        """
+        if not self._backpressure_event.is_set():
+            with trio.move_on_after(self.WRITE_TIMEOUT) as scope:
+                await self._backpressure_event.wait()
+            if scope.cancelled_caught:
+                raise QUICStreamTimeoutError(
+                    f"Stream {self.stream_id} write timed out after "
+                    f"{self.WRITE_TIMEOUT}s waiting for the peer to acknowledge "
+                    f"{self.send_buffer_size()} buffered bytes"
+                )
+
+        # The wait may have ended because the stream went away, not because
+        # capacity was freed.
+        if self._state == StreamState.RESET:
+            raise QUICStreamResetError(
+                f"Stream {self.stream_id} was reset",
+                error_code=self._reset_error_code,
+            )
+        if self._write_closed or self._state == StreamState.CLOSED:
+            raise QUICStreamClosedError(f"Stream {self.stream_id} write side is closed")
 
     def _extract_data_from_buffer(self, n: int) -> bytes:
         """Extract data from receive buffer with specified limit."""

--- a/newsfragments/1520.bugfix.rst
+++ b/newsfragments/1520.bugfix.rst
@@ -1,0 +1,1 @@
+QUIC stream writes now apply send-side backpressure so writers wait when the transport send buffer is full, making upload throughput measurements honest.

--- a/tests/core/transport/quic/test_send_backpressure.py
+++ b/tests/core/transport/quic/test_send_backpressure.py
@@ -1,0 +1,297 @@
+"""
+Send-side backpressure for QUICStream.write().
+
+aioquic's ``send_stream_data`` appends to an unbounded buffer and returns, so a
+writer could "finish" gigabytes in memory long before the peer received them.
+These tests exercise the watermark logic that makes write() wait for ACKs, using
+a real aioquic ``QuicStream`` sender behind a mocked ``QuicConnection`` so the
+buffer accounting is the real thing.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from aioquic.quic.packet_builder import QuicDeliveryState
+from aioquic.quic.stream import QuicStream as AioquicStream
+from multiaddr.multiaddr import Multiaddr
+import trio
+from trio.testing import MockClock, wait_all_tasks_blocked
+
+from libp2p.crypto.ed25519 import create_new_key_pair
+from libp2p.peer.id import ID
+from libp2p.transport.quic import aioquic_compat
+from libp2p.transport.quic.config import QUICTransportConfig
+from libp2p.transport.quic.connection import QUICConnection
+from libp2p.transport.quic.exceptions import (
+    QUICStreamResetError,
+    QUICStreamTimeoutError,
+)
+from libp2p.transport.quic.stream import QUICStream, StreamDirection
+
+HIGH = 4096
+LOW = 1024
+CHUNK = 1024
+
+
+def _make_connection(config: QUICTransportConfig) -> QUICConnection:
+    """QUICConnection over a mocked aioquic core with real per-stream senders."""
+    streams: dict[int, AioquicStream] = {}
+
+    def send_stream_data(stream_id: int, data: bytes, end_stream: bool = False) -> None:
+        stream = streams.get(stream_id)
+        if stream is None:
+            stream = streams[stream_id] = AioquicStream(stream_id=stream_id)
+        stream.sender.write(data, end_stream=end_stream)
+
+    mock_quic = Mock()
+    mock_quic._streams = streams
+    mock_quic.next_event.return_value = None
+    mock_quic.datagrams_to_send.return_value = []
+    mock_quic.get_timer.return_value = None
+    mock_quic.send_stream_data = Mock(side_effect=send_stream_data)
+    mock_quic.reset_stream = Mock()
+
+    mock_transport = Mock()
+    mock_transport._config = config
+
+    private_key = create_new_key_pair().private_key
+    peer_id = ID.from_pubkey(private_key.get_public_key())
+
+    return QUICConnection(
+        quic_connection=mock_quic,
+        remote_addr=("127.0.0.1", 4001),
+        remote_peer_id=None,
+        local_peer_id=peer_id,
+        is_initiator=True,
+        maddr=Multiaddr("/ip4/127.0.0.1/udp/4001/quic"),
+        transport=mock_transport,
+        resource_scope=None,
+        security_manager=Mock(),
+    )
+
+
+def _ack(connection: QUICConnection, stream_id: int, start: int, stop: int) -> None:
+    """Simulate the peer acknowledging [start, stop) and run the ACK hook."""
+    sender = connection._quic._streams[stream_id].sender  # type: ignore[attr-defined]
+    sender.on_data_delivery(QuicDeliveryState.ACKED, start, stop, False)
+    connection._refresh_send_backpressure()
+
+
+@pytest.fixture
+def config() -> QUICTransportConfig:
+    return QUICTransportConfig(
+        STREAM_SEND_BUFFER_HIGH_WATERMARK=HIGH,
+        STREAM_SEND_BUFFER_LOW_WATERMARK=LOW,
+        STREAM_WRITE_CHUNK_SIZE=CHUNK,
+    )
+
+
+@pytest.fixture
+def connection(config: QUICTransportConfig) -> QUICConnection:
+    return _make_connection(config)
+
+
+@pytest.fixture
+def stream(connection: QUICConnection) -> QUICStream:
+    stream = QUICStream(
+        connection=connection,
+        stream_id=0,
+        direction=StreamDirection.OUTBOUND,
+        remote_addr=("127.0.0.1", 4001),
+    )
+    connection._streams[0] = stream
+    return stream
+
+
+# --- aioquic introspection helper -------------------------------------------
+
+
+def test_stream_send_buffer_size_tracks_unacked_bytes() -> None:
+    quic = Mock()
+    quic._streams = {4: AioquicStream(stream_id=4)}
+    sender = quic._streams[4].sender
+
+    assert aioquic_compat.stream_send_buffer_size(quic, 4) == 0
+    sender.write(b"x" * 1000)
+    assert aioquic_compat.stream_send_buffer_size(quic, 4) == 1000
+
+    # ACK the first 400 bytes: only the tail is still outstanding.
+    sender.on_data_delivery(QuicDeliveryState.ACKED, 0, 400, False)
+    assert aioquic_compat.stream_send_buffer_size(quic, 4) == 600
+
+    # A loss does not shrink the buffer (data is rescheduled, not discarded).
+    sender.on_data_delivery(QuicDeliveryState.LOST, 400, 700, False)
+    assert aioquic_compat.stream_send_buffer_size(quic, 4) == 600
+
+    sender.on_data_delivery(QuicDeliveryState.ACKED, 400, 1000, False)
+    assert aioquic_compat.stream_send_buffer_size(quic, 4) == 0
+
+
+def test_stream_send_buffer_size_is_zero_for_unknown_or_opaque_streams() -> None:
+    quic = Mock()
+    quic._streams = {}
+    assert aioquic_compat.stream_send_buffer_size(quic, 8) == 0
+
+    # A fully-mocked QuicConnection (no real ``_streams`` dict) must not blow up.
+    assert aioquic_compat.stream_send_buffer_size(Mock(), 8) == 0
+
+
+# --- config -----------------------------------------------------------------
+
+
+def test_defaults_are_consistent() -> None:
+    cfg = QUICTransportConfig()
+    assert 0 < cfg.STREAM_SEND_BUFFER_LOW_WATERMARK
+    assert cfg.STREAM_SEND_BUFFER_LOW_WATERMARK < cfg.STREAM_SEND_BUFFER_HIGH_WATERMARK
+    # Do not make the local buffer tighter than the peer's flow-control window,
+    # otherwise our backpressure (not QUIC flow control) caps throughput.
+    assert cfg.STREAM_SEND_BUFFER_HIGH_WATERMARK >= cfg.STREAM_FLOW_CONTROL_WINDOW
+    assert cfg.STREAM_WRITE_CHUNK_SIZE > 0
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "chunk"),
+    [
+        (0, HIGH, CHUNK),  # low must be positive
+        (HIGH, HIGH, CHUNK),  # low must be strictly below high
+        (HIGH + 1, HIGH, CHUNK),  # low above high
+        (LOW, HIGH, 0),  # chunk must be positive
+    ],
+)
+def test_invalid_send_watermarks_are_rejected(low: int, high: int, chunk: int) -> None:
+    with pytest.raises(ValueError):
+        QUICTransportConfig(
+            STREAM_SEND_BUFFER_LOW_WATERMARK=low,
+            STREAM_SEND_BUFFER_HIGH_WATERMARK=high,
+            STREAM_WRITE_CHUNK_SIZE=chunk,
+        )
+
+
+# --- write() behaviour --------------------------------------------------------
+
+
+@pytest.mark.trio
+async def test_small_write_does_not_block(stream: QUICStream) -> None:
+    await stream.write(b"a" * (HIGH - 1))
+    assert stream.send_buffer_size() == HIGH - 1
+    assert stream._backpressure_event.is_set()
+
+
+@pytest.mark.trio
+async def test_write_blocks_at_high_watermark_and_resumes_on_ack(
+    connection: QUICConnection, stream: QUICStream
+) -> None:
+    payload = b"b" * (2 * HIGH)
+    done = False
+
+    async def writer() -> None:
+        nonlocal done
+        await stream.write(payload)
+        done = True
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(writer)
+        await wait_all_tasks_blocked()
+
+        # Exactly HIGH bytes were handed to aioquic, then the writer parked.
+        assert not done
+        assert stream.send_buffer_size() == HIGH
+        assert not stream._backpressure_event.is_set()
+
+        # ACKing down to (but not below) LOW+1 is not enough to resume.
+        _ack(connection, 0, 0, HIGH - LOW - 1)
+        await wait_all_tasks_blocked()
+        assert not done
+        assert stream.send_buffer_size() == LOW + 1
+        assert not stream._backpressure_event.is_set()
+
+        # Reaching LOW releases the writer, which fills up to HIGH again.
+        _ack(connection, 0, HIGH - LOW - 1, HIGH - LOW)
+        await wait_all_tasks_blocked()
+        assert not done
+        assert stream.send_buffer_size() == HIGH
+        assert not stream._backpressure_event.is_set()
+
+        # ACK everything sent so far: the remainder fits below HIGH and completes.
+        sent = connection._quic._streams[0].sender._buffer_stop  # type: ignore[attr-defined]
+        _ack(connection, 0, HIGH - LOW, sent)
+        await wait_all_tasks_blocked()
+        assert done
+
+    total = connection._quic._streams[0].sender._buffer_stop  # type: ignore[attr-defined]
+    assert total == len(payload)
+    # Everything was delivered in CHUNK-sized steps.
+    calls = connection._quic.send_stream_data.call_args_list  # type: ignore[attr-defined]
+    assert all(len(c.args[1]) <= CHUNK for c in calls)
+    assert sum(len(c.args[1]) for c in calls) == len(payload)
+
+
+@pytest.mark.trio
+async def test_write_times_out_when_peer_never_acks(
+    config: QUICTransportConfig, autojump_clock: MockClock
+) -> None:
+    config.STREAM_WRITE_TIMEOUT = 5.0
+    connection = _make_connection(config)
+    stream = QUICStream(
+        connection=connection,
+        stream_id=0,
+        direction=StreamDirection.OUTBOUND,
+        remote_addr=("127.0.0.1", 4001),
+    )
+    connection._streams[0] = stream
+
+    with pytest.raises(QUICStreamTimeoutError):
+        await stream.write(b"c" * (HIGH + 1))
+
+    # A timeout is not a protocol error: the stream must not be reset.
+    assert not stream.is_reset()
+    connection._quic.reset_stream.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.trio
+async def test_reset_while_blocked_raises_reset_error(
+    connection: QUICConnection, stream: QUICStream
+) -> None:
+    caught: BaseException | None = None
+
+    async def writer() -> None:
+        nonlocal caught
+        try:
+            await stream.write(b"d" * (HIGH + 1))
+        except QUICStreamResetError as exc:
+            caught = exc
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(writer)
+        await wait_all_tasks_blocked()
+        assert not stream._backpressure_event.is_set()
+        await stream.handle_reset(error_code=7)
+
+    assert isinstance(caught, QUICStreamResetError)
+    assert caught.error_code == 7
+
+
+@pytest.mark.trio
+async def test_refresh_only_releases_when_buffer_drained(
+    connection: QUICConnection, stream: QUICStream
+) -> None:
+    """The connection-side hook must not release a still-full stream."""
+    await stream.write(b"e" * HIGH)
+    assert not stream._backpressure_event.is_set()
+
+    connection._refresh_send_backpressure()
+    assert not stream._backpressure_event.is_set()
+
+    _ack(connection, 0, 0, HIGH)
+    assert stream._backpressure_event.is_set()
+
+
+@pytest.mark.trio
+async def test_closed_stream_never_keeps_writers_blocked(stream: QUICStream) -> None:
+    await stream.write(b"f" * HIGH)
+    assert not stream._backpressure_event.is_set()
+
+    # Once our write side is closed there is nothing left to wait for.
+    await stream.close_write()
+    stream._update_send_backpressure()
+    assert stream._backpressure_event.is_set()


### PR DESCRIPTION
## Summary
- Watermark aioquic's unbounded per-stream send buffer (`STREAM_SEND_BUFFER_{HIGH,LOW}_WATERMARK`)
- Chunk `QUICStream.write()` and block until peer ACKs bring the buffer under the low watermark
- Refresh blocked writers from the connection `_transmit()` path after ACKs are processed
- Unit tests for buffer accounting, block/resume, timeout, and config validation

Rebased onto `main` after #1522 merged (FIN/half-close).

### Perf check (16 MiB loopback, in-process)
| Mode | Upload | Download |
|------|--------|----------|
| backpressure **off** (old behaviour) | **~2.3 Gbps** | ~0.042 Gbps |
| backpressure **on** (this PR) | **~0.041 Gbps** | ~0.042 Gbps |

Upload and download are now the same order of magnitude. At ~0.04 Gbps, default harness 1 GiB × 10 needs a multi-hour timeout; use measured rates to set `PERF_TEST_TIMEOUT_SECS` / iteration sizes honestly (do not shrink bytes just to greenwash).

Fixes #1520

## Test plan
- [x] `pytest tests/core/transport/quic/test_send_backpressure.py tests/core/transport/quic/test_stream.py`
- [x] In-process A/B perf above
- [x] CI green after rebase

See comment below for full logs and explanation.