### PR TITLE
fix(mplex): enforce MaxMessageSize and go-mplex flow control

### DIFF
--- a/libp2p/stream_muxer/mplex/constants.py
+++ b/libp2p/stream_muxer/mplex/constants.py
@@ -2,6 +2,20 @@ from enum import (
     Enum,
 )
 
+# go-mplex MaxMessageSize — reject larger frame bodies on read.
+# Ref: https://github.com/libp2p/go-mplex/blob/master/multiplex.go
+MAX_MESSAGE_SIZE = 1 << 20  # 1 MiB
+
+# go-mplex BufferSize / ChunkSize — write frames are chunked at ChunkSize.
+BUFFER_SIZE = 4096
+CHUNK_SIZE = BUFFER_SIZE - 20  # 4076
+
+# go-mplex ReceiveTimeout — reset the stream if the app does not consume data.
+RECEIVE_TIMEOUT_SECS = 5
+
+# go-mplex dataIn channel depth (was historically documented as 8; upstream is 1).
+MPLEX_MESSAGE_CHANNEL_SIZE = 1
+
 
 class HeaderTags(Enum):
     NewStream = 0

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -26,6 +26,7 @@ from libp2p.exceptions import (
 from libp2p.io.exceptions import (
     ConnectionClosedError,
     IncompleteReadError,
+    MessageTooLarge,
 )
 from libp2p.network.connection.exceptions import (
     RawConnError,
@@ -37,10 +38,14 @@ from libp2p.utils import (
     decode_uvarint_from_stream,
     encode_uvarint,
     encode_varint_prefixed,
-    read_varint_prefixed_bytes,
+    read_varint_prefixed_bytes_limited,
 )
 
 from .constants import (
+    BUFFER_SIZE,
+    MAX_MESSAGE_SIZE,
+    MPLEX_MESSAGE_CHANNEL_SIZE,
+    RECEIVE_TIMEOUT_SECS,
     HeaderTags,
 )
 from .datastructures import (
@@ -54,8 +59,13 @@ from .mplex_stream import (
 )
 
 MPLEX_PROTOCOL_ID = TProtocol("/mplex/6.7.0")
-# Ref: https://github.com/libp2p/go-mplex/blob/414db61813d9ad3e6f4a7db5c1b1612de343ace9/multiplex.go#L115  # noqa: E501
-MPLEX_MESSAGE_CHANNEL_SIZE = 8
+
+# Re-export for existing test imports.
+__all__ = (
+    "MPLEX_MESSAGE_CHANNEL_SIZE",
+    "MPLEX_PROTOCOL_ID",
+    "Mplex",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -273,12 +283,15 @@ class Mplex(IMuxedConn):
                 f"{error}"
             )
         try:
-            message = await read_varint_prefixed_bytes(self.secured_conn)
+            message = await read_varint_prefixed_bytes_limited(
+                self.secured_conn, MAX_MESSAGE_SIZE
+            )
         except (
             ParseError,
             RawConnError,
             ConnectionClosedError,
             IncompleteReadError,
+            MessageTooLarge,
         ) as error:
             raise MplexUnavailable(
                 "failed to read the message body correctly from the underlying "
@@ -350,16 +363,29 @@ class Mplex(IMuxedConn):
                     len(message),
                 )
                 return
-        try:
-            send_channel.send_nowait(message)
-        except (trio.BrokenResourceError, trio.ClosedResourceError):
-            raise MplexUnavailable
-        except trio.WouldBlock:
-            # `send_channel` is full, reset this stream.
-            logger.warning(
-                "message channel of stream %s is full: stream is reset", stream_id
-            )
-            await stream.reset()
+        # Deliver body in BUFFER_SIZE slices with blocking backpressure and a
+        # receive timeout, matching go-mplex (channel depth 1 + ReceiveTimeout).
+        if message:
+            chunks = [
+                message[i : i + BUFFER_SIZE]
+                for i in range(0, len(message), BUFFER_SIZE)
+            ]
+        else:
+            chunks = [b""]
+        for chunk in chunks:
+            try:
+                with trio.fail_after(RECEIVE_TIMEOUT_SECS):
+                    await send_channel.send(chunk)
+            except trio.TooSlowError:
+                logger.warning(
+                    "message channel of stream %s timed out waiting for reader: "
+                    "stream is reset",
+                    stream_id,
+                )
+                await stream.reset()
+                return
+            except (trio.BrokenResourceError, trio.ClosedResourceError):
+                raise MplexUnavailable
 
     async def _handle_close(self, stream_id: StreamID) -> None:
         async with self.streams_lock:

--- a/libp2p/stream_muxer/mplex/mplex_stream.py
+++ b/libp2p/stream_muxer/mplex/mplex_stream.py
@@ -18,6 +18,7 @@ from libp2p.stream_muxer.exceptions import (
 from libp2p.stream_muxer.rw_lock import ReadWriteLock
 
 from .constants import (
+    CHUNK_SIZE,
     HeaderTags,
 )
 from .datastructures import (
@@ -52,7 +53,7 @@ class MplexStream(IMuxedStream):
     rw_lock: ReadWriteLock
     close_lock: trio.Lock
 
-    # NOTE: `dataIn` is size of 8 in Go implementation.
+    # NOTE: Incoming channel depth matches go-mplex dataIn (size 1).
     incoming_data_channel: "trio.MemoryReceiveChannel[bytes]"
 
     event_local_closed: trio.Event
@@ -239,13 +240,23 @@ class MplexStream(IMuxedStream):
         """
         Internal write implementation that performs the actual write operation.
 
+        Large payloads are split into go-mplex ChunkSize frames so peers that
+        enforce MaxMessageSize can accept them (#1436).
+
         :param data: bytes to write
         """
         async with self.rw_lock.write_lock():
             if self.event_local_closed.is_set():
                 raise MplexStreamClosed(f"cannot write to closed stream: data={data!r}")
             flag = self._get_header_flag("message")
-            await self.muxed_conn.send_message(flag, data, self.stream_id)
+            if not data:
+                await self.muxed_conn.send_message(flag, data, self.stream_id)
+                return
+            offset = 0
+            while offset < len(data):
+                chunk = data[offset : offset + CHUNK_SIZE]
+                await self.muxed_conn.send_message(flag, chunk, self.stream_id)
+                offset += len(chunk)
 
     async def close(self) -> None:
         """

--- a/newsfragments/1436.bugfix.rst
+++ b/newsfragments/1436.bugfix.rst
@@ -1,0 +1,1 @@
+Enforce go-mplex MaxMessageSize (1 MiB) on mplex frame reads, chunk large writes, and apply receive-timeout backpressure so oversized frames cannot exhaust memory.

--- a/tests/core/stream_muxer/test_mplex_stream.py
+++ b/tests/core/stream_muxer/test_mplex_stream.py
@@ -1,20 +1,27 @@
+import os
+
 import pytest
 import trio
 from trio.testing import (
     wait_all_tasks_blocked,
 )
 
+from libp2p.stream_muxer.mplex.constants import (
+    CHUNK_SIZE,
+    MAX_MESSAGE_SIZE,
+    RECEIVE_TIMEOUT_SECS,
+)
 from libp2p.stream_muxer.mplex.exceptions import (
     MplexStreamClosed,
     MplexStreamEOF,
     MplexStreamReset,
     MuxedConnUnavailable,
 )
-from libp2p.stream_muxer.mplex.mplex import (
-    MPLEX_MESSAGE_CHANNEL_SIZE,
-)
 from libp2p.tools.constants import (
     MAX_READ_LEN,
+)
+from libp2p.utils import (
+    encode_uvarint,
 )
 
 DATA = b"data_123"
@@ -30,23 +37,105 @@ async def test_mplex_stream_read_write(mplex_stream_pair):
 @pytest.mark.trio
 async def test_mplex_stream_full_buffer(mplex_stream_pair):
     stream_0, stream_1 = mplex_stream_pair
-    # Test: The message channel is of size `MPLEX_MESSAGE_CHANNEL_SIZE`.
-    #   It should be fine to read even there are already `MPLEX_MESSAGE_CHANNEL_SIZE`
-    #   messages arriving.
-    for _ in range(MPLEX_MESSAGE_CHANNEL_SIZE):
-        await stream_0.write(DATA)
+    # With go-mplex-style flow control (channel depth 1 + blocking delivery),
+    # a slow reader does not immediately reset. Writes that fit in the
+    # channel complete; the reader can still drain them.
+    await stream_0.write(DATA)
     await wait_all_tasks_blocked()
-    # Sanity check
-    assert MAX_READ_LEN >= MPLEX_MESSAGE_CHANNEL_SIZE * len(DATA)
-    assert (await stream_1.read(MAX_READ_LEN)) == MPLEX_MESSAGE_CHANNEL_SIZE * DATA
+    assert (await stream_1.read(MAX_READ_LEN)) == DATA
 
-    # Test: Read after `MPLEX_MESSAGE_CHANNEL_SIZE + 1` messages has arrived, which
-    #   exceeds the channel size. The stream should have been reset.
-    for _ in range(MPLEX_MESSAGE_CHANNEL_SIZE + 1):
-        await stream_0.write(DATA)
+    # A large write is chunked and must round-trip without resetting.
+    # Reader must run concurrently — channel depth 1 applies backpressure.
+    large = DATA * 500  # well above CHUNK_SIZE / channel depth
+    received = bytearray()
+
+    async def reader() -> None:
+        while len(received) < len(large):
+            received.extend(await stream_1.read(65536))
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(reader)
+        await stream_0.write(large)
+    assert bytes(received) == large
+
+
+@pytest.mark.trio
+async def test_mplex_write_chunks_large_payload(mplex_stream_pair):
+    stream_0, stream_1 = mplex_stream_pair
+    payload = b"x" * (CHUNK_SIZE * 3 + 100)
+    frame_sizes: list[int] = []
+    original = stream_0.muxed_conn.send_message
+
+    async def counting_send(flag, data, stream_id):
+        if data:
+            frame_sizes.append(len(data))
+        return await original(flag, data, stream_id)
+
+    stream_0.muxed_conn.send_message = counting_send  # type: ignore[method-assign]
+    received = bytearray()
+
+    async def reader() -> None:
+        while len(received) < len(payload):
+            received.extend(await stream_1.read(65536))
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(reader)
+        await stream_0.write(payload)
+    assert frame_sizes
+    assert all(size <= CHUNK_SIZE for size in frame_sizes)
+    assert sum(frame_sizes) == len(payload)
+    assert bytes(received) == payload
+
+
+@pytest.mark.trio
+async def test_mplex_large_write_read_roundtrip(mplex_stream_pair):
+    stream_0, stream_1 = mplex_stream_pair
+    payload = os.urandom(900 * 1024)
+    received = bytearray()
+
+    async def reader() -> None:
+        while len(received) < len(payload):
+            received.extend(await stream_1.read(65536))
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(reader)
+        await stream_0.write(payload)
+    assert bytes(received) == payload
+
+
+@pytest.mark.trio
+async def test_mplex_receive_timeout_resets_stream(mplex_stream_pair, autojump_clock):
+    stream_0, stream_1 = mplex_stream_pair
+    # Occupy the depth-1 channel so the next frame blocks in _handle_message.
+    await stream_0.write(DATA)
     await wait_all_tasks_blocked()
+
+    async def blocked_write() -> None:
+        await stream_0.write(DATA)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(blocked_write)
+        await wait_all_tasks_blocked()
+        # Advance past go-mplex ReceiveTimeout so the blocked delivery resets.
+        await trio.sleep(RECEIVE_TIMEOUT_SECS + 0.1)
+        nursery.cancel_scope.cancel()
+
     with pytest.raises(MplexStreamReset):
         await stream_1.read(MAX_READ_LEN)
+
+
+@pytest.mark.trio
+async def test_mplex_read_rejects_oversize_frame(mplex_conn_pair):
+    mplex_0, mplex_1 = mplex_conn_pair
+    # Craft a MessageInitiator frame whose length prefix exceeds MaxMessageSize.
+    # Header: (channel_id << 3) | flag; flag 2 = MessageInitiator.
+    header = encode_uvarint((0 << 3) | 2)
+    oversize_len = encode_uvarint(MAX_MESSAGE_SIZE + 1)
+    await mplex_0.secured_conn.write(header + oversize_len)
+    # Peer mux should tear down on MessageTooLarge → MplexUnavailable.
+    with trio.fail_after(5):
+        await mplex_1.event_closed.wait()
+    assert mplex_1.is_closed
 
 
 @pytest.mark.trio


### PR DESCRIPTION
## Summary
- Fixes #1436 (mplex half of GHSA-34vq-766q-gc73): reject frame bodies larger than go-mplex `MaxMessageSize` (1 MiB) via `read_varint_prefixed_bytes_limited`.
- Chunk large stream writes at go-mplex `ChunkSize` (4076) so py↔py transfers above 1 MiB still work.
- Replace count-based `send_nowait` / immediate reset (`MPLEX_MESSAGE_CHANNEL_SIZE=8`) with go-mplex-style depth-1 channel, blocking delivery, and 5s receive timeout → stream reset.

## Behavior change
Previously, the 9th unread message reset the stream immediately. Now backpressure blocks until the app reads or `RECEIVE_TIMEOUT_SECS` elapses. Aligns with current go-mplex.

## Out of scope
Pubsub’s unbounded `read_varint_prefixed_bytes` (same advisory) is not changed here.

## Test plan
- [x] `pytest tests/core/stream_muxer/` (135 passed)
- [x] `make lint` / `make typecheck`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)