### PR TITLE
fix(mplex/tls): unblock teardown when SecureSession EOF is quiet-exited

### DIFF
--- a/libp2p/security/secure_session.py
+++ b/libp2p/security/secure_session.py
@@ -12,6 +12,9 @@ from libp2p.crypto.keys import (
 from libp2p.io.abc import (
     EncryptedMsgReadWriter,
 )
+from libp2p.io.exceptions import (
+    ConnectionClosedError,
+)
 from libp2p.peer.id import (
     ID,
 )
@@ -103,7 +106,7 @@ class SecureSession(BaseSession):
             # If underlying connection returned empty bytes, treat as closed
             # and raise to signal that reads after close are invalid.
             if msg == b"":
-                raise Exception("Connection closed")
+                raise ConnectionClosedError("Connection closed")
 
             return msg
 
@@ -126,7 +129,7 @@ class SecureSession(BaseSession):
             if msg == b"":
                 if result:
                     return bytes(result)
-                raise Exception("Connection closed")
+                raise ConnectionClosedError("Connection closed")
 
             if len(msg) <= needed:
                 result.extend(msg)

--- a/libp2p/stream_muxer/mplex/mplex.py
+++ b/libp2p/stream_muxer/mplex/mplex.py
@@ -148,6 +148,11 @@ class Mplex(IMuxedConn):
             # Set the `event_shutting_down`, to allow graceful shutdown.
             self.event_shutting_down.set()
         await self.secured_conn.close()
+        # If the read loop never observed EOF (or exited without cleanup),
+        # finish teardown ourselves. Mirrors Yamux: do not hang forever on
+        # event_closed after we already closed the secured connection.
+        if not self.event_closed.is_set():
+            await self._cleanup()
         # Blocked until `close` is finally set.
         await self.event_closed.wait()
 
@@ -244,15 +249,17 @@ class Mplex(IMuxedConn):
         """
         self._established = True
         self.event_started.set()
-        while True:
-            try:
-                await self._handle_incoming_message()
-            except MplexUnavailable as e:
-                logger.debug("mplex unavailable while waiting for incoming: %s", e)
-                break
-        # If we enter here, it means this connection is shutting down.
-        # We should clean things up.
-        await self._cleanup()
+        try:
+            while True:
+                try:
+                    await self._handle_incoming_message()
+                except MplexUnavailable as e:
+                    logger.debug("mplex unavailable while waiting for incoming: %s", e)
+                    break
+        finally:
+            # Always clean up so close() waiters are not left hanging, even if
+            # an unexpected exception escapes the read loop.
+            await self._cleanup()
 
     async def read_message(self) -> tuple[int, int, bytes]:
         """
@@ -406,18 +413,24 @@ class Mplex(IMuxedConn):
             self.streams_msg_channels.pop(stream_id, None)
 
     async def _cleanup(self) -> None:
-        if not self.event_shutting_down.is_set():
-            self.event_shutting_down.set()
+        # Idempotent: close() and handle_incoming may both invoke cleanup.
+        # Guard under streams_lock so concurrent callers cannot double-close.
         async with self.streams_lock:
-            for stream_id, stream in self.streams.items():
+            if self.event_closed.is_set():
+                return
+            if not self.event_shutting_down.is_set():
+                self.event_shutting_down.set()
+            for stream_id, stream in list(self.streams.items()):
                 async with stream.close_lock:
                     if not stream.event_remote_closed.is_set():
                         stream.event_remote_closed.set()
                         stream.event_reset.set()
                         stream.event_local_closed.set()
-                send_channel = self.streams_msg_channels[stream_id]
-                await send_channel.aclose()
-        self.event_closed.set()
+                send_channel = self.streams_msg_channels.pop(stream_id, None)
+                if send_channel is not None:
+                    await send_channel.aclose()
+            self.streams.clear()
+            self.event_closed.set()
         await self.new_stream_send_channel.aclose()
         # Call on_close callback if provided
         if self.on_close:

--- a/newsfragments/1526.bugfix.rst
+++ b/newsfragments/1526.bugfix.rst
@@ -1,0 +1,1 @@
+Fix tls+mplex teardown hang: SecureSession raises ConnectionClosedError on EOF, and Mplex cleans up idempotently if the read loop exits without setting event_closed.

--- a/tests/core/security/test_secure_session.py
+++ b/tests/core/security/test_secure_session.py
@@ -1,0 +1,59 @@
+from unittest.mock import (
+    Mock,
+)
+
+import pytest
+
+from libp2p.crypto.keys import (
+    PrivateKey,
+    PublicKey,
+)
+from libp2p.io.abc import (
+    EncryptedMsgReadWriter,
+)
+from libp2p.io.exceptions import (
+    ConnectionClosedError,
+)
+from libp2p.peer.id import (
+    ID,
+)
+from libp2p.security.secure_session import (
+    SecureSession,
+)
+
+
+class EmptyEOFConn(EncryptedMsgReadWriter):
+    async def read_msg(self) -> bytes:
+        return b""
+
+    async def write_msg(self, msg: bytes) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    def encrypt(self, data: bytes) -> bytes:
+        return data
+
+    def decrypt(self, data: bytes) -> bytes:
+        return data
+
+    def get_remote_address(self):
+        return None
+
+
+@pytest.mark.trio
+async def test_secure_session_eof_raises_connection_closed_error():
+    session = SecureSession(
+        local_peer=ID(b"local"),
+        local_private_key=Mock(spec=PrivateKey),
+        remote_peer=ID(b"remote"),
+        remote_permanent_pubkey=Mock(spec=PublicKey),
+        is_initiator=True,
+        conn=EmptyEOFConn(),
+    )
+    with pytest.raises(ConnectionClosedError, match="Connection closed"):
+        await session.read()
+
+    with pytest.raises(ConnectionClosedError, match="Connection closed"):
+        await session.read(16)

--- a/tests/core/stream_muxer/test_mplex_conn.py
+++ b/tests/core/stream_muxer/test_mplex_conn.py
@@ -202,3 +202,32 @@ async def test_mplex_on_close_callback_none():
 
     # Connection should be closed
     assert mplex_conn.is_closed, "Connection should be marked as closed"
+
+
+@pytest.mark.trio
+async def test_mplex_close_completes_when_read_loop_stalled():
+    """
+    close() must not hang if the read loop never reaches _cleanup.
+
+    Regression for tls+mplex teardown: SecureSession used to raise a bare
+    Exception on EOF that quiet-exit absorbed, so event_closed never set.
+    close() now calls _cleanup() itself when needed.
+    """
+
+    class StalledSecuredConn(DummySecuredConn):
+        async def read(self, n: int | None = -1) -> bytes:
+            await trio.sleep_forever()
+
+    secured_conn = StalledSecuredConn()
+    mplex_conn = Mplex(secured_conn, DUMMY_PEER_ID)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(mplex_conn.start)
+        await trio.sleep(0.05)
+
+        with trio.fail_after(1.0):
+            await mplex_conn.close()
+
+        nursery.cancel_scope.cancel()
+
+    assert mplex_conn.is_closed


### PR DESCRIPTION
## Summary
- Raise `ConnectionClosedError` from `SecureSession` on TLS EOF so mplex maps it to `MplexUnavailable` and cleans up (fixes hang after quiet-exit #1517).
- Make `Mplex.close()` call idempotent `_cleanup()` when `event_closed` is unset after closing the secured conn; wrap `handle_incoming` in `try/finally`.

Fixes #1526

## Test plan
- [x] Unit: `test_secure_session_eof_raises_connection_closed_error`
- [x] Unit: `test_mplex_close_completes_when_read_loop_stalled`
- [x] Rebuild python perf image from this branch; run `tcp, tls, mplex` (64 MiB × 3) — dialer must exit past `teardown_start`
- [x] Regression: noise+mplex, tls+yamux, ws+tls+mplex

### Local perf validation
- `tcp, tls, mplex` (64 MiB × 3): dialer logged `teardown_start` and exited 0 (~1.4 Gbps up/down).
- Regression (same image rebuild): `tcp noise+mplex`, `tcp tls+yamux`, `ws tls+mplex` all SUCCESS with clean teardown.