### PR TITLE
fix: clear residual ResourceWarnings and enable CI guard

### DIFF
--- a/libp2p/network/swarm.py
+++ b/libp2p/network/swarm.py
@@ -457,6 +457,14 @@ class Swarm(Service, INetworkService):
                     except Exception as e:
                         logger.debug("Error closing listener during shutdown: %s", e)
 
+                # Close transports (QUIC/WebSocket/WebTransport) so UDP sockets
+                # and session state are released on the manager-stop path too.
+                # Swarm.close() already does this; keep parity here (#1498).
+                try:
+                    await self.transport_manager.close_all()
+                except Exception as e:
+                    logger.warning("Error closing transports during shutdown: %s", e)
+
                 # Cancel the background nursery (transport / auto-connector).
                 nursery.cancel_scope.cancel()
                 self.background_nursery = None

--- a/libp2p/transport/webrtc/_asyncio_bridge.py
+++ b/libp2p/transport/webrtc/_asyncio_bridge.py
@@ -169,6 +169,14 @@ class AsyncioBridge:
 
             await trio.to_thread.run_sync(_join_thread)
 
+            # Close the stopped loop so Python does not emit
+            # ResourceWarning: unclosed event loop on GC (#1498).
+            try:
+                if not loop.is_closed():
+                    loop.close()
+            except Exception:
+                logger.debug("Error closing asyncio loop", exc_info=True)
+
             with self._state_lock:
                 self._loop = None
                 self._thread = None

--- a/libp2p/transport/websocket/transport.py
+++ b/libp2p/transport/websocket/transport.py
@@ -920,7 +920,7 @@ class WebsocketTransport(ITransport):
         ):
             self._background_nursery.start_soon(self._initialize_autotls)
 
-        return WebsocketListener(
+        listener = WebsocketListener(
             handler,
             self._upgrader,
             WebsocketListenerConfig(
@@ -937,6 +937,8 @@ class WebsocketTransport(ITransport):
             ),
             peer_id=self._peer_id,
         )
+        self._active_listeners.add(listener)
+        return listener
 
     async def get_connections(self) -> dict[str, P2PWebSocketConnection]:
         """Get all active connections."""
@@ -957,6 +959,29 @@ class WebsocketTransport(ITransport):
             "proxy_connections": self._proxy_connections,
             "has_proxy_config": bool(self._config.proxy_url),
         }
+
+    async def close(self) -> None:
+        """
+        Close all tracked WebSocket connections and listeners.
+
+        Invoked from ``Swarm.close()`` / ``Swarm.run()`` shutdown via
+        ``TransportManager.close_all()`` so dialed/accepted sockets are released
+        (#1498).
+        """
+        async with self._connection_lock:
+            connections = list(self._connections.values())
+            self._connections.clear()
+            self._current_connections = 0
+        listeners = list(self._active_listeners)
+        self._active_listeners.clear()
+
+        async with trio.open_nursery() as nursery:
+            for connection in connections:
+                nursery.start_soon(connection.close)
+            for listener in listeners:
+                nursery.start_soon(listener.close)
+
+        logger.debug("WebSocket transport closed")
 
     def resolve(self, maddr: Multiaddr) -> list[Multiaddr]:
         """

--- a/newsfragments/1485.bugfix.rst
+++ b/newsfragments/1485.bugfix.rst
@@ -1,5 +1,6 @@
 Close a swarm's live connections when it shuts down so their sockets are released
-instead of leaking. ``Swarm.run()``'s service-manager shutdown now closes tracked
-connections (not just listeners), and the test host/swarm factories tear their
-swarms down deterministically via ``close()``, eliminating the bulk of the
-``ResourceWarning: unclosed socket`` warnings the suite emitted (issues #92, #1485).
+instead of leaking, and treat ``ResourceWarning`` as an error in pytest so future
+socket leaks fail CI. ``Swarm.run()``'s service-manager shutdown closes tracked
+connections and transports (not just listeners); test fixtures tear hosts/swarms
+down while services are still running. Completes the work deferred from #1486
+(issues #92, #1485).

--- a/newsfragments/1498.bugfix.rst
+++ b/newsfragments/1498.bugfix.rst
@@ -1,0 +1,4 @@
+Clear residual unclosed-socket / event-loop ``ResourceWarning`` leaks across the
+core test suite and enable ``filterwarnings = ["error::ResourceWarning"]`` so
+new socket leaks fail CI. Completes the deferred guard from #1485 / #1486 and
+closes #1498.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ warn_unused_ignores = false
 addopts = "-v --showlocals --durations 50 --maxfail 10"
 log_date_format = "%m-%d %H:%M:%S"
 log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
+filterwarnings = ["error::ResourceWarning"]
 markers = [
     "slow: mark test as slow",
     "flaky: mark test as flaky (may fail intermittently)",

--- a/tests/core/bitswap/test_protocol_versions.py
+++ b/tests/core/bitswap/test_protocol_versions.py
@@ -126,6 +126,8 @@ class TestBitswapProtocolVersions:
                 Path(tmp_file_path).unlink()
                 await provider_bitswap.stop()
                 await client_bitswap.stop()
+                await provider_host.close()
+                await client_host.close()
 
     @pytest.mark.trio
     async def test_large_file_transfer_v100(self):
@@ -215,6 +217,8 @@ class TestBitswapProtocolVersions:
                 Path(tmp_file_path).unlink()
                 await provider_bitswap.stop()
                 await client_bitswap.stop()
+                await provider_host.close()
+                await client_host.close()
 
     @pytest.mark.trio
     async def test_bidirectional_exchange_v100(self):
@@ -300,6 +304,8 @@ class TestBitswapProtocolVersions:
                 # Cleanup
                 await node1_bitswap.stop()
                 await node2_bitswap.stop()
+                await node1_host.close()
+                await node2_host.close()
 
 
 class TestProtocolNegotiation:
@@ -406,6 +412,8 @@ class TestProtocolNegotiation:
                 # Cleanup
                 await provider_bitswap.stop()
                 await client_bitswap.stop()
+                await provider_host.close()
+                await client_host.close()
 
 
 class TestProtocolFeatures:
@@ -475,6 +483,8 @@ class TestProtocolFeatures:
                 # Cleanup
                 await provider_bitswap.stop()
                 await client_bitswap.stop()
+                await provider_host.close()
+                await client_host.close()
 
     @pytest.mark.trio
     async def test_v120_block_presence(self):
@@ -532,3 +542,5 @@ class TestProtocolFeatures:
                 # Cleanup
                 await provider_bitswap.stop()
                 await client_bitswap.stop()
+                await provider_host.close()
+                await client_host.close()

--- a/tests/core/discovery/rendezvous/test_integration.py
+++ b/tests/core/discovery/rendezvous/test_integration.py
@@ -105,47 +105,55 @@ async def test_full_rendezvous_workflow():
         async with server_host.run([server_listen_addr]):
             async with client1_host.run([client1_listen_addr]):
                 async with client2_host.run([client2_listen_addr]):
-                    # Give hosts time to start
-                    await trio.sleep(0.1)
-
-                    # Create client connections to server
-                    client1 = RendezvousClient(client1_host, server_peer_id)
-                    client2 = RendezvousClient(client2_host, server_peer_id)
-
-                    # Add server to client peerstores with address
-                    server_addrs = server_host.get_addrs()
-                    if server_addrs:
-                        client1_host.get_peerstore().add_addrs(
-                            server_peer_id, server_addrs, ttl=3600
-                        )
-                        client2_host.get_peerstore().add_addrs(
-                            server_peer_id, server_addrs, ttl=3600
-                        )
-
-                    namespace = "test-integration"
-
                     try:
-                        # Client1 registers under namespace
-                        ttl1 = await client1.register(namespace, DEFAULT_TTL)
-                        assert ttl1 > 0
-
-                        # Give registration time to process
+                        # Give hosts time to start
                         await trio.sleep(0.1)
 
-                        # Client2 discovers peers in namespace
-                        discoveredPeers, _ = await client2.discover(namespace)
+                        # Create client connections to server
+                        client1 = RendezvousClient(client1_host, server_peer_id)
+                        client2 = RendezvousClient(client2_host, server_peer_id)
 
-                        # Should find client1
-                        assert len(discoveredPeers) >= 1
-                        client1_peer_id = client1_host.get_id()
-                        discovered_peer_ids = [peer.peer_id for peer in discoveredPeers]
-                        assert client1_peer_id in discovered_peer_ids
+                        # Add server to client peerstores with address
+                        server_addrs = server_host.get_addrs()
+                        if server_addrs:
+                            client1_host.get_peerstore().add_addrs(
+                                server_peer_id, server_addrs, ttl=3600
+                            )
+                            client2_host.get_peerstore().add_addrs(
+                                server_peer_id, server_addrs, ttl=3600
+                            )
 
-                    except Exception as e:
-                        # Log the error for debugging
-                        logger.error("Integration test error: %s", e)
-                        # Don't fail the test for connection issues in unit tests
-                        raise
+                        namespace = "test-integration"
+
+                        try:
+                            # Client1 registers under namespace
+                            ttl1 = await client1.register(namespace, DEFAULT_TTL)
+                            assert ttl1 > 0
+
+                            # Give registration time to process
+                            await trio.sleep(0.1)
+
+                            # Client2 discovers peers in namespace
+                            discoveredPeers, _ = await client2.discover(namespace)
+
+                            # Should find client1
+                            assert len(discoveredPeers) >= 1
+                            client1_peer_id = client1_host.get_id()
+                            discovered_peer_ids = [
+                                peer.peer_id for peer in discoveredPeers
+                            ]
+                            assert client1_peer_id in discovered_peer_ids
+
+                        except Exception as e:
+                            # Log the error for debugging
+                            logger.error("Integration test error: %s", e)
+                            # Don't fail the test for connection issues in unit tests
+                            raise
+                    finally:
+                        # Close while run() contexts are still active.
+                        await client2_host.close()
+                        await client1_host.close()
+                        await server_host.close()
 
     except Exception as e:
         # Handle any startup/shutdown errors gracefully

--- a/tests/core/identity/identify/test_identify_integration.py
+++ b/tests/core/identity/identify/test_identify_integration.py
@@ -338,45 +338,50 @@ async def test_identify_multi_transport_host_addresses(security_protocol):
         background_trio_service(host_a.get_network()),
         background_trio_service(host_b.get_network()),
     ):
-        await host_a.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
-        await host_a.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0/ws"))
-        await host_b.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+        try:
+            await host_a.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
+            await host_a.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0/ws"))
+            await host_b.get_network().listen(Multiaddr("/ip4/127.0.0.1/tcp/0"))
 
-        await wait_for_host_addrs(host_a, min_count=2)
+            await wait_for_host_addrs(host_a, min_count=2)
 
-        # host_b dials host_a using one of its addresses
-        host_a.set_stream_handler(ID, identify_handler_for(host_a))
+            # host_b dials host_a using one of its addresses
+            host_a.set_stream_handler(ID, identify_handler_for(host_a))
 
-        host_a_addrs = host_a.get_addrs()
-        assert len(host_a_addrs) == 2, "host_a should have 2 listen addresses"
+            host_a_addrs = host_a.get_addrs()
+            assert len(host_a_addrs) == 2, "host_a should have 2 listen addresses"
 
-        # We dial using the first address
-        maddr = host_a_addrs[0].encapsulate(
-            Multiaddr(f"/p2p/{host_a.get_id().to_base58()}")
-        )
-        info = info_from_p2p_addr(maddr)
-
-        # Connect
-        await host_b.connect(info)
-
-        if hasattr(host_b, "_identify_inflight"):
-            from libp2p.host.basic_host import BasicHost
-
-            assert isinstance(host_b, BasicHost)
-            deadline = trio.current_time() + 10.0
-            while (
-                host_a.get_id() in host_b._identify_inflight
-                and trio.current_time() < deadline
-            ):
-                await trio.sleep(0.01)
-
-        # Make identify request
-        stream = await host_b.new_stream(host_a.get_id(), (ID,))
-        result = await read_and_parse_identify(stream, use_varint_format=True)
-        await stream.close()
-
-        # Verify response contains all addresses
-        for addr in host_a_addrs:
-            assert _multiaddr_to_bytes(addr) in result.listen_addrs, (
-                f"Address {addr} not advertised by host_a"
+            # We dial using the first address
+            maddr = host_a_addrs[0].encapsulate(
+                Multiaddr(f"/p2p/{host_a.get_id().to_base58()}")
             )
+            info = info_from_p2p_addr(maddr)
+
+            # Connect
+            await host_b.connect(info)
+
+            if hasattr(host_b, "_identify_inflight"):
+                from libp2p.host.basic_host import BasicHost
+
+                assert isinstance(host_b, BasicHost)
+                deadline = trio.current_time() + 10.0
+                while (
+                    host_a.get_id() in host_b._identify_inflight
+                    and trio.current_time() < deadline
+                ):
+                    await trio.sleep(0.01)
+
+            # Make identify request
+            stream = await host_b.new_stream(host_a.get_id(), (ID,))
+            result = await read_and_parse_identify(stream, use_varint_format=True)
+            await stream.close()
+
+            # Verify response contains all addresses
+            for addr in host_a_addrs:
+                assert _multiaddr_to_bytes(addr) in result.listen_addrs, (
+                    f"Address {addr} not advertised by host_a"
+                )
+        finally:
+            # Close while services are still running (matches HostFactory).
+            await host_a.close()
+            await host_b.close()

--- a/tests/core/identity/identify_push/test_identify_push.py
+++ b/tests/core/identity/identify_push/test_identify_push.py
@@ -82,7 +82,8 @@ async def test_identify_push_protocol(security_protocol):
         # Get the peerstore from host_b
         peerstore = host_b.get_peerstore()
 
-        # Check that host_b's peerstore has been updated with host_a's information
+        # Check that host_b's peerstore has been updated with host_a's
+        # information
         peer_id = host_a.get_id()
 
         # Check that the peer is in the peerstore
@@ -141,7 +142,8 @@ async def test_identify_push_handler(security_protocol):
         # Get the peerstore from host_b
         peerstore = host_b.get_peerstore()
 
-        # Check that host_b's peerstore has been updated with host_a's information
+        # Check that host_b's peerstore has been updated with host_a's
+        # information
         peer_id = host_a.get_id()
 
         # Check that the peer is in the peerstore
@@ -203,44 +205,49 @@ async def test_identify_push_to_peers(security_protocol):
         # Start listening on a random port using the run context manager
         listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
         async with host_c.run([listen_addr]):
-            # Connect host_c to host_a and host_b
-            await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
-            await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
+            try:
+                # Connect host_c to host_a and host_b
+                await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+                await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
 
-            # Push identify information from host_a to all connected peers
-            await push_identify_to_peers(host_a)
+                # Push identify information from host_a to all connected peers
+                await push_identify_to_peers(host_a)
 
-            # Wait a bit for the push to complete
-            await trio.sleep(0.1)
+                # Wait a bit for the push to complete
+                await trio.sleep(0.1)
 
-            # Check that host_b's peerstore has been updated with host_a's information
-            peerstore_b = host_b.get_peerstore()
-            peer_id_a = host_a.get_id()
+                # Check that host_b's peerstore has been updated with host_a's
+                # information
+                peerstore_b = host_b.get_peerstore()
+                peer_id_a = host_a.get_id()
 
-            # Check that the peer is in the peerstore
-            assert peer_id_a in peerstore_b.peer_ids()
+                # Check that the peer is in the peerstore
+                assert peer_id_a in peerstore_b.peer_ids()
 
-            # Check that host_c's peerstore has been updated with host_a's information
-            peerstore_c = host_c.get_peerstore()
+                # Check that host_c's peerstore has been updated with host_a's
+                # information
+                peerstore_c = host_c.get_peerstore()
 
-            # Check that the peer is in the peerstore
-            assert peer_id_a in peerstore_c.peer_ids()
+                # Check that the peer is in the peerstore
+                assert peer_id_a in peerstore_c.peer_ids()
 
-            # Test for push_identify to only connected peers and not all peers
-            # Disconnect a from c.
-            await host_c.disconnect(host_a.get_id())
+                # Test for push_identify to only connected peers and not all peers
+                # Disconnect a from c.
+                await host_c.disconnect(host_a.get_id())
 
-            await push_identify_to_peers(host_c)
+                await push_identify_to_peers(host_c)
 
-            # Wait a bit for the push to complete
-            await trio.sleep(0.1)
+                # Wait a bit for the push to complete
+                await trio.sleep(0.1)
 
-            # push_identify_to_peers only streams to connected peers; after c↔a
-            # disconnect, host_a must not be a push target. (host_a may still list
-            # host_c in peerstore from earlier Identify when c dialed in.)
-            assert host_a.get_id() not in host_c.get_connected_peers()
-            # Check that host_b's peerstore has been updated with host_c's info
-            assert host_c.get_id() in host_b.get_peerstore().peer_ids()
+                # push_identify_to_peers only streams to connected peers; after c↔a
+                # disconnect, host_a must not be a push target. (host_a may still list
+                # host_c in peerstore from earlier Identify when c dialed in.)
+                assert host_a.get_id() not in host_c.get_connected_peers()
+                # Check that host_b's peerstore has been updated with host_c's info
+                assert host_c.get_id() in host_b.get_peerstore().peer_ids()
+            finally:
+                await host_c.close()
 
 
 @pytest.mark.trio
@@ -279,38 +286,44 @@ async def test_push_identify_to_peers_with_explicit_params(security_protocol):
         listen_addr_d = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
 
         async with host_c.run([listen_addr_c]), host_d.run([listen_addr_d]):
-            # Connect all hosts to host_a
-            await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
-            await host_d.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+            try:
+                # Connect all hosts to host_a
+                await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+                await host_d.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
 
-            # Create a specific observed multiaddr for the test
-            observed_addr = multiaddr.Multiaddr("/ip4/192.0.2.1/tcp/1234")
+                # Create a specific observed multiaddr for the test
+                observed_addr = multiaddr.Multiaddr("/ip4/192.0.2.1/tcp/1234")
 
-            # Only push to hosts B and C (not D)
-            selected_peers = {host_b.get_id(), host_c.get_id()}
+                # Only push to hosts B and C (not D)
+                selected_peers = {host_b.get_id(), host_c.get_id()}
 
-            # Push identify information from host_a to selected peers with observed addr
-            await push_identify_to_peers(
-                host=host_a, peer_ids=selected_peers, observed_multiaddr=observed_addr
-            )
+                # Push identify from host_a to selected peers with observed addr
+                await push_identify_to_peers(
+                    host=host_a,
+                    peer_ids=selected_peers,
+                    observed_multiaddr=observed_addr,
+                )
 
-            # Wait a bit for the push to complete
-            await trio.sleep(0.1)
+                # Wait a bit for the push to complete
+                await trio.sleep(0.1)
 
-            # Check that host_b's and host_c's peerstores have been updated
-            peerstore_b = host_b.get_peerstore()
-            peerstore_c = host_c.get_peerstore()
-            peer_id_a = host_a.get_id()
+                # Check that host_b's and host_c's peerstores have been updated
+                peerstore_b = host_b.get_peerstore()
+                peerstore_c = host_c.get_peerstore()
+                peer_id_a = host_a.get_id()
 
-            # Hosts B and C should have peer_id_a in their peerstores
-            # (B only from the explicit push, C from both connect and push)
-            assert peer_id_a in peerstore_b.peer_ids()
-            assert peer_id_a in peerstore_c.peer_ids()
+                # Hosts B and C should have peer_id_a in their peerstores
+                # (B only from the explicit push, C from both connect and push)
+                assert peer_id_a in peerstore_b.peer_ids()
+                assert peer_id_a in peerstore_c.peer_ids()
 
-            # Verify that host_b received host_a's protocols from the push
-            peerstore_protocols_b = set(peerstore_b.get_protocols(peer_id_a))
-            host_a_protocols = set(host_a.get_mux().get_protocols())
-            assert all(p in peerstore_protocols_b for p in host_a_protocols)
+                # Verify that host_b received host_a's protocols from the push
+                peerstore_protocols_b = set(peerstore_b.get_protocols(peer_id_a))
+                host_a_protocols = set(host_a.get_mux().get_protocols())
+                assert all(p in peerstore_protocols_b for p in host_a_protocols)
+            finally:
+                await host_c.close()
+                await host_d.close()
 
 
 @pytest.mark.trio
@@ -554,6 +567,9 @@ async def test_all_peers_receive_identify_push_with_semaphore(security_protocol)
 
             nursery.cancel_scope.cancel()
 
+        for host, _ in dummy_peers:
+            await host.close()
+
 
 @pytest.mark.trio
 async def test_all_peers_receive_identify_push_with_semaphore_under_high_peer_load(
@@ -603,6 +619,9 @@ async def test_all_peers_receive_identify_push_with_semaphore_under_high_peer_lo
 
             # Give time for proper cleanup
             await trio.sleep(0.1)
+
+        for host, _ in dummy_peers:
+            await host.close()
 
 
 @pytest.mark.trio

--- a/tests/core/identity/identify_push/test_identify_push_integration.py
+++ b/tests/core/identity/identify_push/test_identify_push_integration.py
@@ -218,44 +218,49 @@ async def test_identify_push_multiple_peers_integration(security_protocol):
         # Start listening on a random port using the run context manager
         listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
         async with host_c.run([listen_addr]):
-            # Connect host_c to host_a and host_b using the correct pattern
-            await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
-            await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
+            try:
+                # Connect host_c to host_a and host_b using the correct pattern
+                await host_c.connect(info_from_p2p_addr(host_a.get_addrs()[0]))
+                await host_c.connect(info_from_p2p_addr(host_b.get_addrs()[0]))
 
-            # Push identify information from host_a to all connected peers
-            await push_identify_to_peers(host_a)
+                # Push identify information from host_a to all connected peers
+                await push_identify_to_peers(host_a)
 
-            # Wait a bit for the push to complete
-            await trio.sleep(0.1)
+                # Wait a bit for the push to complete
+                await trio.sleep(0.1)
 
-            # Check that host_b's peerstore has been updated with host_a's information
-            peerstore_b = host_b.get_peerstore()
-            peer_id_a = host_a.get_id()
+                # Check that host_b's peerstore has been updated with host_a's
+                # information
+                peerstore_b = host_b.get_peerstore()
+                peer_id_a = host_a.get_id()
 
-            # Check that the peer is in the peerstore
-            assert peer_id_a in peerstore_b.peer_ids()
+                # Check that the peer is in the peerstore
+                assert peer_id_a in peerstore_b.peer_ids()
 
-            # Check that host_c's peerstore has been updated with host_a's information
-            peerstore_c = host_c.get_peerstore()
+                # Check that host_c's peerstore has been updated with host_a's
+                # information
+                peerstore_c = host_c.get_peerstore()
 
-            # Check that the peer is in the peerstore
-            assert peer_id_a in peerstore_c.peer_ids()
+                # Check that the peer is in the peerstore
+                assert peer_id_a in peerstore_c.peer_ids()
 
-            # Test for push_identify to only connected peers and not all peers
-            # Disconnect a from c.
-            await host_c.disconnect(host_a.get_id())
+                # Test for push_identify to only connected peers and not all peers
+                # Disconnect a from c.
+                await host_c.disconnect(host_a.get_id())
 
-            await push_identify_to_peers(host_c)
+                await push_identify_to_peers(host_c)
 
-            # Wait a bit for the push to complete
-            await trio.sleep(0.1)
+                # Wait a bit for the push to complete
+                await trio.sleep(0.1)
 
-            # push_identify_to_peers only streams to connected peers; after c↔a
-            # disconnect, host_a must not be a push target. (host_a may still list
-            # host_c in peerstore from earlier Identify when c dialed in.)
-            assert host_a.get_id() not in host_c.get_connected_peers()
-            # Check that host_b's peerstore has been updated with host_c's info
-            assert host_c.get_id() in host_b.get_peerstore().peer_ids()
+                # push_identify_to_peers only streams to connected peers; after c↔a
+                # disconnect, host_a must not be a push target. (host_a may still list
+                # host_c in peerstore from earlier Identify when c dialed in.)
+                assert host_a.get_id() not in host_c.get_connected_peers()
+                # Check that host_b's peerstore has been updated with host_c's info
+                assert host_c.get_id() in host_b.get_peerstore().peer_ids()
+            finally:
+                await host_c.close()
 
 
 @pytest.mark.trio

--- a/tests/core/io/test_trio_real_connection.py
+++ b/tests/core/io/test_trio_real_connection.py
@@ -67,29 +67,34 @@ async def test_read_after_abrupt_reset_raises_error() -> None:
 
         transport = TCP()
         listener = transport.create_listener(on_accept)
-        await listener.listen(LISTEN_MADDR)
-        local_conn = await transport.dial(listener.get_addrs()[0])
-        await ready.wait()
+        try:
+            await listener.listen(LISTEN_MADDR)
+            local_conn = await transport.dial(listener.get_addrs()[0])
+            await ready.wait()
 
-        assert local_conn is not None and remote_conn is not None
+            assert local_conn is not None and remote_conn is not None
 
-        # Force the remote end to send RST on close (not graceful FIN)
-        _force_reset(remote_conn)
-        await remote_conn.close()
+            # Force the remote end to send RST on close (not graceful FIN)
+            _force_reset(remote_conn)
+            await remote_conn.close()
 
-        # Give the OS a moment to deliver the RST
-        await trio.sleep(0.05)
+            # Give the OS a moment to deliver the RST
+            await trio.sleep(0.05)
 
-        # Reading from the local side should raise, not return b""
-        with pytest.raises(ConnectionClosedError) as exc_info:
-            await local_conn.read(1024)
+            # Reading from the local side should raise, not return b""
+            with pytest.raises(ConnectionClosedError) as exc_info:
+                await local_conn.read(1024)
 
-        exc = exc_info.value
-        assert exc.transport == "tcp"
-        logger.info("read() raised ConnectionClosedError on RST: %s", exc)
-
-        await listener.close()
-        nursery.cancel_scope.cancel()
+            exc = exc_info.value
+            assert exc.transport == "tcp"
+            logger.info("read() raised ConnectionClosedError on RST: %s", exc)
+        finally:
+            if local_conn is not None:
+                await local_conn.close()
+            if remote_conn is not None:
+                await remote_conn.close()
+            await listener.close()
+            nursery.cancel_scope.cancel()
 
 
 @pytest.mark.trio
@@ -111,33 +116,38 @@ async def test_write_after_abrupt_reset_raises_error() -> None:
 
         transport = TCP()
         listener = transport.create_listener(on_accept)
-        await listener.listen(LISTEN_MADDR)
-        local_conn = await transport.dial(listener.get_addrs()[0])
-        await ready.wait()
+        try:
+            await listener.listen(LISTEN_MADDR)
+            local_conn = await transport.dial(listener.get_addrs()[0])
+            await ready.wait()
 
-        assert local_conn is not None and remote_conn is not None
+            assert local_conn is not None and remote_conn is not None
 
-        # Force the remote end to send RST on close
-        _force_reset(remote_conn)
-        await remote_conn.close()
+            # Force the remote end to send RST on close
+            _force_reset(remote_conn)
+            await remote_conn.close()
 
-        # Give the OS a moment to deliver the RST
-        await trio.sleep(0.05)
+            # Give the OS a moment to deliver the RST
+            await trio.sleep(0.05)
 
-        # Write until the broken-pipe / reset is detected.
-        # The first write may succeed (kernel buffers it), but subsequent
-        # writes will fail because the peer sent RST.
-        with pytest.raises(ConnectionClosedError) as exc_info:
-            for _ in range(100):
-                await local_conn.write(b"x" * 4096)
-                await trio.sleep(0.01)
+            # Write until the broken-pipe / reset is detected.
+            # The first write may succeed (kernel buffers it), but subsequent
+            # writes will fail because the peer sent RST.
+            with pytest.raises(ConnectionClosedError) as exc_info:
+                for _ in range(100):
+                    await local_conn.write(b"x" * 4096)
+                    await trio.sleep(0.01)
 
-        exc = exc_info.value
-        assert exc.transport == "tcp"
-        logger.info("write() raised ConnectionClosedError on RST: %s", exc)
-
-        await listener.close()
-        nursery.cancel_scope.cancel()
+            exc = exc_info.value
+            assert exc.transport == "tcp"
+            logger.info("write() raised ConnectionClosedError on RST: %s", exc)
+        finally:
+            if local_conn is not None:
+                await local_conn.close()
+            if remote_conn is not None:
+                await remote_conn.close()
+            await listener.close()
+            nursery.cancel_scope.cancel()
 
 
 @pytest.mark.trio
@@ -159,23 +169,28 @@ async def test_graceful_close_read_returns_eof() -> None:
 
         transport = TCP()
         listener = transport.create_listener(on_accept)
-        await listener.listen(LISTEN_MADDR)
-        local_conn = await transport.dial(listener.get_addrs()[0])
-        await ready.wait()
+        try:
+            await listener.listen(LISTEN_MADDR)
+            local_conn = await transport.dial(listener.get_addrs()[0])
+            await ready.wait()
 
-        assert local_conn is not None and remote_conn is not None
+            assert local_conn is not None and remote_conn is not None
 
-        # Graceful close (no SO_LINGER hack) — sends FIN
-        await remote_conn.close()
-        await trio.sleep(0.05)
+            # Graceful close (no SO_LINGER hack) — sends FIN
+            await remote_conn.close()
+            await trio.sleep(0.05)
 
-        # Should return empty bytes (EOF), NOT raise
-        data = await local_conn.read(1024)
-        assert data == b""
-        logger.info("Graceful close correctly returned EOF (b'')")
-
-        await listener.close()
-        nursery.cancel_scope.cancel()
+            # Should return empty bytes (EOF), NOT raise
+            data = await local_conn.read(1024)
+            assert data == b""
+            logger.info("Graceful close correctly returned EOF (b'')")
+        finally:
+            if local_conn is not None:
+                await local_conn.close()
+            if remote_conn is not None:
+                await remote_conn.close()
+            await listener.close()
+            nursery.cancel_scope.cancel()
 
 
 @pytest.mark.trio
@@ -197,22 +212,27 @@ async def test_normal_data_transfer_works() -> None:
 
         transport = TCP()
         listener = transport.create_listener(on_accept)
-        await listener.listen(LISTEN_MADDR)
-        local_conn = await transport.dial(listener.get_addrs()[0])
-        await ready.wait()
+        try:
+            await listener.listen(LISTEN_MADDR)
+            local_conn = await transport.dial(listener.get_addrs()[0])
+            await ready.wait()
 
-        assert local_conn is not None and remote_conn is not None
+            assert local_conn is not None and remote_conn is not None
 
-        # Normal round-trip
-        await local_conn.write(b"hello from dialer")
-        data = await remote_conn.read(1024)
-        assert data == b"hello from dialer"
+            # Normal round-trip
+            await local_conn.write(b"hello from dialer")
+            data = await remote_conn.read(1024)
+            assert data == b"hello from dialer"
 
-        await remote_conn.write(b"hello from listener")
-        data = await local_conn.read(1024)
-        assert data == b"hello from listener"
+            await remote_conn.write(b"hello from listener")
+            data = await local_conn.read(1024)
+            assert data == b"hello from listener"
 
-        logger.info("Normal data transfer works as expected")
-
-        await listener.close()
-        nursery.cancel_scope.cancel()
+            logger.info("Normal data transfer works as expected")
+        finally:
+            if local_conn is not None:
+                await local_conn.close()
+            if remote_conn is not None:
+                await remote_conn.close()
+            await listener.close()
+            nursery.cancel_scope.cancel()

--- a/tests/core/network/test_health_monitor_real_network.py
+++ b/tests/core/network/test_health_monitor_real_network.py
@@ -64,23 +64,32 @@ async def test_health_monitor_updates_rtt_on_real_network() -> None:
     host_a = BasicHost(swarm_a)
     host_b = BasicHost(swarm_b)
 
-    async with background_trio_service(swarm_a):
-        async with background_trio_service(swarm_b):
-            await swarm_a.listen(bind_a)
-            await swarm_b.listen(bind_b)
-            await connect(host_a, host_b)
+    try:
+        async with background_trio_service(swarm_a):
+            async with background_trio_service(swarm_b):
+                try:
+                    await swarm_a.listen(bind_a)
+                    await swarm_b.listen(bind_b)
+                    await connect(host_a, host_b)
 
-            peer_a = host_a.get_id()
-            conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
-            swarm_b.initialize_connection_health(peer_a, conn)
+                    peer_a = host_a.get_id()
+                    conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
+                    swarm_b.initialize_connection_health(peer_a, conn)
 
-            monitor = swarm_b._health_monitor
-            assert monitor is not None
-            await monitor._check_connection_health(peer_a, conn)
+                    monitor = swarm_b._health_monitor
+                    assert monitor is not None
+                    await monitor._check_connection_health(peer_a, conn)
 
-            summary = host_b.get_connection_health(peer_a)
-            assert summary["average_latency_ms"] >= 0
-            assert summary["average_health_score"] > 0
+                    summary = host_b.get_connection_health(peer_a)
+                    assert summary["average_latency_ms"] >= 0
+                    assert summary["average_health_score"] > 0
+                finally:
+                    await host_a.close()
+                    await host_b.close()
+    except Exception:
+        await host_a.close()
+        await host_b.close()
+        raise
 
 
 @pytest.mark.trio
@@ -105,27 +114,36 @@ async def test_health_monitor_detects_failed_ping_on_real_network() -> None:
     host_a = BasicHost(swarm_a)
     host_b = BasicHost(swarm_b)
 
-    async with background_trio_service(swarm_a):
-        async with background_trio_service(swarm_b):
-            await swarm_a.listen(bind_a)
-            await swarm_b.listen(bind_b)
-            await connect(host_a, host_b)
+    try:
+        async with background_trio_service(swarm_a):
+            async with background_trio_service(swarm_b):
+                try:
+                    await swarm_a.listen(bind_a)
+                    await swarm_b.listen(bind_b)
+                    await connect(host_a, host_b)
 
-            peer_a = host_a.get_id()
-            conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
-            swarm_b.initialize_connection_health(peer_a, conn)
+                    peer_a = host_a.get_id()
+                    conn = cast(SwarmConn, swarm_b.get_connections(peer_a)[0])
+                    swarm_b.initialize_connection_health(peer_a, conn)
 
-            monitor = swarm_b._health_monitor
-            assert monitor is not None
+                    monitor = swarm_b._health_monitor
+                    assert monitor is not None
 
-            await monitor._check_connection_health(peer_a, conn)
-            health = swarm_b.health_data[peer_a][conn]
-            assert health.ping_success_rate > 0.5
+                    await monitor._check_connection_health(peer_a, conn)
+                    health = swarm_b.health_data[peer_a][conn]
+                    assert health.ping_success_rate > 0.5
 
-            await conn.close()
-            await trio.sleep(0.05)
+                    await conn.close()
+                    await trio.sleep(0.05)
 
-            result = await monitor._ping_connection(conn)
-            assert result.success is False
-            health.update_ping_metrics(0.0, False)
-            assert health.ping_success_rate < 1.0
+                    result = await monitor._ping_connection(conn)
+                    assert result.success is False
+                    health.update_ping_metrics(0.0, False)
+                    assert health.ping_success_rate < 1.0
+                finally:
+                    await host_a.close()
+                    await host_b.close()
+    except Exception:
+        await host_a.close()
+        await host_b.close()
+        raise

--- a/tests/core/network/test_swarm.py
+++ b/tests/core/network/test_swarm.py
@@ -466,54 +466,76 @@ async def test_swarm_listen_multiple_addresses_connectivity(security_protocol):
     # Create a swarm and listen on multiple addresses
     swarm1 = SwarmFactory.build(security_protocol=security_protocol)
     async with background_trio_service(swarm1):
-        # Listen on all addresses
-        success = await swarm1.listen(*listen_addrs)
-        assert success, "Should successfully listen on at least one address"
+        try:
+            # Listen on all addresses
+            success = await swarm1.listen(*listen_addrs)
+            assert success, "Should successfully listen on at least one address"
 
-        # Verify all available interfaces are listening
-        assert len(swarm1.listeners) == len(listen_addrs), (
-            f"All {len(listen_addrs)} interfaces should be listening, "
-            f"but only {len(swarm1.listeners)} are"
-        )
+            # Verify all available interfaces are listening
+            assert len(swarm1.listeners) == len(listen_addrs), (
+                f"All {len(listen_addrs)} interfaces should be listening, "
+                f"but only {len(swarm1.listeners)} are"
+            )
 
-        # Create a second swarm to test connections
-        swarm2 = SwarmFactory.build(security_protocol=security_protocol)
-        async with background_trio_service(swarm2):
-            # Test connectivity to each listening address using real libp2p connections
-            for addr_str, listener in swarm1.listeners.items():
-                listener_addrs = listener.get_addrs()
-                for listener_addr in listener_addrs:
-                    # Create a full multiaddr with peer ID for libp2p connection
-                    peer_id = swarm1.get_peer_id()
-                    full_addr = listener_addr.encapsulate(f"/p2p/{peer_id}")
+            # Create a second swarm to test connections
+            swarm2 = SwarmFactory.build(security_protocol=security_protocol)
+            async with background_trio_service(swarm2):
+                try:
+                    # Test connectivity to each listening address using real
+                    # libp2p connections
+                    for addr_str, listener in swarm1.listeners.items():
+                        listener_addrs = listener.get_addrs()
+                        for listener_addr in listener_addrs:
+                            # Create a full multiaddr with peer ID for libp2p
+                            # connection
+                            peer_id = swarm1.get_peer_id()
+                            full_addr = listener_addr.encapsulate(f"/p2p/{peer_id}")
 
-                    # Test real libp2p connection
-                    try:
-                        peer_info = info_from_p2p_addr(full_addr)
+                            # Test real libp2p connection
+                            try:
+                                peer_info = info_from_p2p_addr(full_addr)
 
-                        # Add the peer info to swarm2's peerstore so it knows where to connect  # noqa: E501
-                        swarm2.peerstore.add_addrs(
-                            peer_info.peer_id, [listener_addr], 10000
-                        )
+                                # Add the peer info to swarm2's peerstore so it
+                                # knows where to connect
+                                swarm2.peerstore.add_addrs(
+                                    peer_info.peer_id, [listener_addr], 10000
+                                )
 
-                        await swarm2.dial_peer(peer_info.peer_id)
+                                await swarm2.dial_peer(peer_info.peer_id)
 
-                        # Verify connection was established
-                        assert peer_info.peer_id in swarm2.connections, (
-                            f"Connection to {full_addr} should be established"
-                        )
-                        assert swarm2.get_peer_id() in swarm1.connections, (
-                            f"Connection from {full_addr} should be established"
-                        )
+                                # Verify connection was established
+                                assert peer_info.peer_id in swarm2.connections, (
+                                    f"Connection to {full_addr} should be established"
+                                )
+                                assert swarm2.get_peer_id() in swarm1.connections, (
+                                    f"Connection from {full_addr} should be established"
+                                )
 
-                        # Clean up connection for next interface test
-                        await swarm2.close_peer(peer_info.peer_id)
-                        await trio.sleep(0.05)
+                                # Clean up both sides before the next interface dial
+                                # so accept/dial sockets are not left half-open (#1498).
+                                local_id = swarm2.get_peer_id()
+                                await swarm2.close_peer(peer_info.peer_id)
+                                if local_id in swarm1.connections:
+                                    await swarm1.close_peer(local_id)
+                                await wait_all_tasks_blocked()
+                                await trio.sleep(0.05)
 
-                    except Exception as e:
-                        pytest.fail(
-                            f"Failed to establish libp2p connection to {full_addr}: {e}"
-                        )
+                            except Exception as e:
+                                pytest.fail(
+                                    "Failed to establish libp2p connection to "
+                                    f"{full_addr}: {e}"
+                                )
+                finally:
+                    # Close while the service is still running (HostFactory pattern).
+                    for peer_id in list(swarm2.connections):
+                        await swarm2.close_peer(peer_id)
+                    await wait_all_tasks_blocked()
+                    await swarm2.close()
+        finally:
+            for peer_id in list(swarm1.connections):
+                await swarm1.close_peer(peer_id)
+            await wait_all_tasks_blocked()
+            await swarm1.close()
 
 
 @pytest.mark.trio

--- a/tests/core/pubsub/test_gossipsub.py
+++ b/tests/core/pubsub/test_gossipsub.py
@@ -293,6 +293,14 @@ async def test_dense():
                 msg = await wait_for_pubsub_payload(queue, msg_content)
                 assert msg.data == msg_content
 
+        # Drop peer connections before factory teardown so dense-mesh sockets
+        # are not left for GC (#1498).
+        for host in hosts:
+            network = host.get_network()
+            for peer_id in list(network.connections):
+                await network.close_peer(peer_id)
+        await trio.sleep(0.05)
+
 
 @pytest.mark.trio
 async def test_fanout():
@@ -360,6 +368,13 @@ async def test_fanout():
             for sub in subs:
                 msg = await wait_for_pubsub_payload(sub, msg_content)
                 assert msg.data == msg_content
+
+        # Drop peer connections before factory teardown (#1498).
+        for host in hosts:
+            network = host.get_network()
+            for peer_id in list(network.connections):
+                await network.close_peer(peer_id)
+        await trio.sleep(0.05)
 
 
 async def _wait_fanout_maintenance_ready(

--- a/tests/core/pubsub/test_pubsub_write_msg_exceptions.py
+++ b/tests/core/pubsub/test_pubsub_write_msg_exceptions.py
@@ -131,3 +131,7 @@ async def test_write_msg_stream_reset():
                         # Without StreamReset handling in Pubsub.write_msg, this will
                         # raise an exception
                         await pubsub_a.publish("test", b"crash test")
+
+                        # Close while host.run() is still active (#1498).
+                        await host_b.close()
+                        await host_a.close()

--- a/tests/core/transport/quic/test_integration.py
+++ b/tests/core/transport/quic/test_integration.py
@@ -592,6 +592,8 @@ async def test_yamux_stress_ping():
                 with trio.fail_after(120):  # Safety timeout
                     await completion_event.wait()
 
+            await client_host.close()
+
         # === Result Summary ===
         logger.info("Ping Stress Test Summary")
         logger.info(f"Total Streams Launched: {STREAM_COUNT}")
@@ -665,6 +667,8 @@ async def test_yamux_stress_ping():
         avg_latency = sum(latencies) / len(latencies)
         logger.info(f"Average Latency: {avg_latency:.2f} ms")
         assert avg_latency < 1000
+
+        await server_host.close()
 
 
 # ============================================================================

--- a/tests/core/transport/quic/test_quic_inbound_auth.py
+++ b/tests/core/transport/quic/test_quic_inbound_auth.py
@@ -101,6 +101,7 @@ async def test_listener_rejects_inbound_without_peer_certificate() -> None:
             nursery.cancel_scope.cancel()
     finally:
         await listener.close()
+        await server_transport.close()
 
     stats = listener.get_stats()
     assert handler_called is False
@@ -127,6 +128,7 @@ async def test_listener_accepts_authenticated_libp2p_peer() -> None:
     client_key = create_new_key_pair()
     client_config = QUICTransportConfig(idle_timeout=10.0, connection_timeout=5.0)
     client_transport = QUICTransport(client_key.private_key, client_config)
+    client_conn = None
 
     try:
         async with trio.open_nursery() as nursery:
@@ -139,12 +141,16 @@ async def test_listener_accepts_authenticated_libp2p_peer() -> None:
             )
 
             client_transport.set_background_nursery(nursery)
-            await client_transport.dial(server_addr)
+            client_conn = await client_transport.dial(server_addr)
             await trio.sleep(1.0)
 
             nursery.cancel_scope.cancel()
     finally:
+        if client_conn is not None:
+            await client_conn.close()
         await listener.close()
+        await client_transport.close()
+        await server_transport.close()
 
     assert handler_called is True
 

--- a/tests/core/transport/test_tcp.py
+++ b/tests/core/transport/test_tcp.py
@@ -9,7 +9,7 @@ import trio
 
 from examples.ping.ping import PING_LENGTH, PING_PROTOCOL_ID
 from libp2p import new_host
-from libp2p.abc import INetStream
+from libp2p.abc import INetStream, IRawConnection
 from libp2p.network.connection.raw_connection import (
     RawConnection,
 )
@@ -161,17 +161,26 @@ async def test_tcp_dial(nursery):
         await transport.dial(Multiaddr("/ip4/127.0.0.1/tcp/1"))
 
     listener = transport.create_listener(handler)
-    await listener.listen(LISTEN_MADDR)
-    addrs = listener.get_addrs()
-    assert len(addrs) == 1
-    listen_addr = addrs[0]
-    raw_conn = await transport.dial(listen_addr)
-    await event.wait()
+    raw_conn: IRawConnection | None = None
+    try:
+        await listener.listen(LISTEN_MADDR)
+        addrs = listener.get_addrs()
+        assert len(addrs) == 1
+        listen_addr = addrs[0]
+        raw_conn = await transport.dial(listen_addr)
+        await event.wait()
 
-    data = b"123"
-    assert raw_conn_other_side is not None
-    await raw_conn_other_side.write(data)
-    assert (await raw_conn.read(len(data))) == data
+        data = b"123"
+        assert raw_conn is not None
+        assert raw_conn_other_side is not None
+        await raw_conn_other_side.write(data)
+        assert (await raw_conn.read(len(data))) == data
+    finally:
+        if raw_conn is not None:
+            await raw_conn.close()
+        if raw_conn_other_side is not None:
+            await raw_conn_other_side.close()
+        await listener.close()
 
 
 @pytest.mark.trio
@@ -188,6 +197,7 @@ async def test_tcp_yamux_stress_ping():
 
     # === Server Setup ===
     server_host = new_host(listen_addrs=[listen_addr])
+    client_host = None
 
     async def handle_ping(stream: INetStream) -> None:
         try:
@@ -201,99 +211,109 @@ async def test_tcp_yamux_stress_ping():
 
     server_host.set_stream_handler(PING_PROTOCOL_ID, handle_ping)
 
-    async with server_host.run(listen_addrs=[listen_addr]):
-        # Wait for server to actually be listening
-        while not server_host.get_addrs():
-            await trio.sleep(0.01)
-
-        # === Client Setup ===
-        destination = str(server_host.get_addrs()[0])
-        maddr = multiaddr.Multiaddr(destination)
-        info = info_from_p2p_addr(maddr)
-
-        client_listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
-        client_host = new_host(listen_addrs=[client_listen_addr])
-
-        async with client_host.run(listen_addrs=[client_listen_addr]):
-            await client_host.connect(info)
-
-            # Wait for connection to be established and ready
-            network = client_host.get_network()
-            connections_map = network.get_connections_map()
-            while (
-                info.peer_id not in connections_map or not connections_map[info.peer_id]
-            ):
+    try:
+        async with server_host.run(listen_addrs=[listen_addr]):
+            # Wait for server to actually be listening
+            while not server_host.get_addrs():
                 await trio.sleep(0.01)
-                connections_map = network.get_connections_map()
 
-            # Wait for connection's event_started to ensure it's ready for streams
-            connections = connections_map[info.peer_id]
-            if connections:
-                swarm_conn = connections[0]
-                if hasattr(swarm_conn, "event_started"):
-                    await swarm_conn.event_started.wait()
-                await trio.sleep(0.05)
+            # === Client Setup ===
+            destination = str(server_host.get_addrs()[0])
+            maddr = multiaddr.Multiaddr(destination)
+            info = info_from_p2p_addr(maddr)
 
-            async def ping_stream(i: int):
-                stream = None
+            client_listen_addr = multiaddr.Multiaddr("/ip4/127.0.0.1/tcp/0")
+            client_host = new_host(listen_addrs=[client_listen_addr])
+
+            async with client_host.run(listen_addrs=[client_listen_addr]):
                 try:
-                    start = trio.current_time()
+                    await client_host.connect(info)
 
-                    stream = await client_host.new_stream(
-                        info.peer_id, [PING_PROTOCOL_ID]
-                    )
+                    # Wait for connection to be established and ready
+                    network = client_host.get_network()
+                    connections_map = network.get_connections_map()
+                    while (
+                        info.peer_id not in connections_map
+                        or not connections_map[info.peer_id]
+                    ):
+                        await trio.sleep(0.01)
+                        connections_map = network.get_connections_map()
 
-                    await stream.write(b"\x01" * PING_LENGTH)
+                    # Wait for event_started so the connection is ready for streams
+                    connections = connections_map[info.peer_id]
+                    if connections:
+                        swarm_conn = connections[0]
+                        if hasattr(swarm_conn, "event_started"):
+                            await swarm_conn.event_started.wait()
+                        await trio.sleep(0.05)
 
-                    with trio.fail_after(30):
-                        response = await stream.read(PING_LENGTH)
-
-                    if response == b"\x01" * PING_LENGTH:
-                        latency_ms = int((trio.current_time() - start) * 1000)
-                        latencies.append(latency_ms)
-                        logger.debug("[TCP Ping #%d] Latency: %d ms", i, latency_ms)
-                    await stream.close()
-                except Exception as e:
-                    logger.warning("[TCP Ping #%d] Failed: %s", i, e)
-                    failures.append(i)
-                    if stream:
+                    async def ping_stream(i: int):
+                        stream = None
                         try:
-                            await stream.reset()
-                        except Exception:
-                            pass
+                            start = trio.current_time()
+                            assert client_host is not None
+
+                            stream = await client_host.new_stream(
+                                info.peer_id, [PING_PROTOCOL_ID]
+                            )
+
+                            await stream.write(b"\x01" * PING_LENGTH)
+
+                            with trio.fail_after(30):
+                                response = await stream.read(PING_LENGTH)
+
+                            if response == b"\x01" * PING_LENGTH:
+                                latency_ms = int((trio.current_time() - start) * 1000)
+                                latencies.append(latency_ms)
+                                logger.debug(
+                                    "[TCP Ping #%d] Latency: %d ms", i, latency_ms
+                                )
+                            await stream.close()
+                        except Exception as e:
+                            logger.warning("[TCP Ping #%d] Failed: %s", i, e)
+                            failures.append(i)
+                            if stream:
+                                try:
+                                    await stream.reset()
+                                except Exception:
+                                    pass
+                        finally:
+                            async with completed_lock:
+                                completed_count[0] += 1
+                                if completed_count[0] == STREAM_COUNT:
+                                    completion_event.set()
+
+                    # No semaphore limit - run all streams concurrently
+                    async with trio.open_nursery() as nursery:
+                        for i in range(STREAM_COUNT):
+                            nursery.start_soon(ping_stream, i)
+
+                        with trio.fail_after(120):
+                            await completion_event.wait()
                 finally:
-                    async with completed_lock:
-                        completed_count[0] += 1
-                        if completed_count[0] == STREAM_COUNT:
-                            completion_event.set()
+                    await client_host.close()
 
-            # No semaphore limit - run all streams concurrently
-            async with trio.open_nursery() as nursery:
-                for i in range(STREAM_COUNT):
-                    nursery.start_soon(ping_stream, i)
+            # === Result Summary ===
+            logger.info("TCP Ping Stress Test Summary")
+            logger.info(f"Total Streams Launched: {STREAM_COUNT}")
+            logger.info(f"Successful Pings: {len(latencies)}")
+            logger.info(f"Failed Pings: {len(failures)}")
+            if failures:
+                logger.warning(f"Failed stream indices: {failures}")
 
-                with trio.fail_after(120):
-                    await completion_event.wait()
+            # === Assertions ===
+            assert len(latencies) == STREAM_COUNT, (
+                f"Expected {STREAM_COUNT} successful streams, got {len(latencies)}"
+            )
+            assert all(isinstance(x, int) and x >= 0 for x in latencies), (
+                "Invalid latencies"
+            )
 
-        # === Result Summary ===
-        logger.info("TCP Ping Stress Test Summary")
-        logger.info(f"Total Streams Launched: {STREAM_COUNT}")
-        logger.info(f"Successful Pings: {len(latencies)}")
-        logger.info(f"Failed Pings: {len(failures)}")
-        if failures:
-            logger.warning(f"Failed stream indices: {failures}")
-
-        # === Assertions ===
-        assert len(latencies) == STREAM_COUNT, (
-            f"Expected {STREAM_COUNT} successful streams, got {len(latencies)}"
-        )
-        assert all(isinstance(x, int) and x >= 0 for x in latencies), (
-            "Invalid latencies"
-        )
-
-        avg_latency = sum(latencies) / len(latencies)
-        logger.info(f"Average Latency: {avg_latency:.2f} ms")
-        assert avg_latency < 1000
+            avg_latency = sum(latencies) / len(latencies)
+            logger.info(f"Average Latency: {avg_latency:.2f} ms")
+            assert avg_latency < 1000
+    finally:
+        await server_host.close()
 
 
 @pytest.mark.trio
@@ -335,24 +355,33 @@ async def test_ipv6_tcp_listen_and_dial(nursery):
     # Listen on IPv6 loopback
     listen_addr = Multiaddr("/ip6/::1/tcp/0")
     listener = transport.create_listener(handler)
-    await listener.listen(listen_addr)
-    addrs = listener.get_addrs()
-    assert len(addrs) == 1
+    raw_conn: IRawConnection | None = None
+    try:
+        await listener.listen(listen_addr)
+        addrs = listener.get_addrs()
+        assert len(addrs) == 1
 
-    # Verify that the address is IPv6
-    listen_addr = addrs[0]
-    protocol = get_ip_protocol_from_multiaddr(listen_addr)
-    assert protocol == "ip6", f"Expected ip6 protocol, got {protocol}"
+        # Verify that the address is IPv6
+        listen_addr = addrs[0]
+        protocol = get_ip_protocol_from_multiaddr(listen_addr)
+        assert protocol == "ip6", f"Expected ip6 protocol, got {protocol}"
 
-    # Dial to IPv6 address
-    raw_conn = await transport.dial(listen_addr)
-    await event.wait()
+        # Dial to IPv6 address
+        raw_conn = await transport.dial(listen_addr)
+        await event.wait()
 
-    # Test data transfer
-    data = b"test_ipv6_data"
-    assert raw_conn_other_side is not None
-    await raw_conn_other_side.write(data)
-    assert (await raw_conn.read(len(data))) == data
+        # Test data transfer
+        data = b"test_ipv6_data"
+        assert raw_conn is not None
+        assert raw_conn_other_side is not None
+        await raw_conn_other_side.write(data)
+        assert (await raw_conn.read(len(data))) == data
+    finally:
+        if raw_conn is not None:
+            await raw_conn.close()
+        if raw_conn_other_side is not None:
+            await raw_conn_other_side.close()
+        await listener.close()
 
 
 @pytest.mark.trio
@@ -371,24 +400,33 @@ async def test_ipv6_tcp_dial_with_ipv4_fallback(nursery):
     # Listen on IPv4 loopback
     listen_addr = Multiaddr("/ip4/127.0.0.1/tcp/0")
     listener = transport.create_listener(handler)
-    await listener.listen(listen_addr)
-    addrs = listener.get_addrs()
-    assert len(addrs) == 1
+    raw_conn: IRawConnection | None = None
+    try:
+        await listener.listen(listen_addr)
+        addrs = listener.get_addrs()
+        assert len(addrs) == 1
 
-    # Verify that the address is IPv4
-    listen_addr = addrs[0]
-    protocol = get_ip_protocol_from_multiaddr(listen_addr)
-    assert protocol == "ip4", f"Expected ip4 protocol, got {protocol}"
+        # Verify that the address is IPv4
+        listen_addr = addrs[0]
+        protocol = get_ip_protocol_from_multiaddr(listen_addr)
+        assert protocol == "ip4", f"Expected ip4 protocol, got {protocol}"
 
-    # Dial to IPv4 address (should still work)
-    raw_conn = await transport.dial(listen_addr)
-    await event.wait()
+        # Dial to IPv4 address (should still work)
+        raw_conn = await transport.dial(listen_addr)
+        await event.wait()
 
-    # Test data transfer
-    data = b"test_ipv4_data"
-    assert raw_conn_other_side is not None
-    await raw_conn_other_side.write(data)
-    assert (await raw_conn.read(len(data))) == data
+        # Test data transfer
+        data = b"test_ipv4_data"
+        assert raw_conn is not None
+        assert raw_conn_other_side is not None
+        await raw_conn_other_side.write(data)
+        assert (await raw_conn.read(len(data))) == data
+    finally:
+        if raw_conn is not None:
+            await raw_conn.close()
+        if raw_conn_other_side is not None:
+            await raw_conn_other_side.close()
+        await listener.close()
 
 
 def test_extract_ip_from_multiaddr():

--- a/tests/core/transport/websocket/test_websocket.py
+++ b/tests/core/transport/websocket/test_websocket.py
@@ -1301,11 +1301,15 @@ async def test_websocket_listener_addr_format():
         await trio.sleep(0)
 
     listener_wss = transport_wss.create_listener(dummy_handler_wss)
-    # Type assertion to access private attributes for testing
-    assert hasattr(listener_wss, "_tls_config")
-    assert getattr(listener_wss, "_tls_config") is not None
-    assert hasattr(listener_wss, "_handshake_timeout")
-    assert getattr(listener_wss, "_handshake_timeout") == 15.0
+    try:
+        # Type assertion to access private attributes for testing
+        assert hasattr(listener_wss, "_tls_config")
+        assert getattr(listener_wss, "_tls_config") is not None
+        assert hasattr(listener_wss, "_handshake_timeout")
+        assert getattr(listener_wss, "_handshake_timeout") == 15.0
+    finally:
+        await listener_ws.close()
+        await listener_wss.close()
 
 
 @pytest.mark.trio

--- a/tests/core/transport/websocket/test_websocket_integration.py
+++ b/tests/core/transport/websocket/test_websocket_integration.py
@@ -104,7 +104,11 @@ async def create_websocket_host(
                 await swarm.listen(addr)
                 # Small delay to ensure listener is ready
                 await trio.sleep(0.05)
-        yield host
+        try:
+            yield host
+        finally:
+            # Close while the service is still running (matches HostFactory).
+            await host.close()
 
 
 @pytest.mark.trio


### PR DESCRIPTION
## Summary

- Finish residual `ResourceWarning` teardown across `tests/core` and enable `filterwarnings = ["error::ResourceWarning"]` in pytest.
- Library: `Swarm.run()` now calls `transport_manager.close_all()` (parity with `Swarm.close()`); `WebsocketTransport` tracks/closes listeners; `AsyncioBridge.stop()` closes the asyncio loop.
- Tests/fixtures: close hosts/swarms/conns **while** `run()` / `background_trio_service` is still active (HostFactory pattern), covering transport, bitswap, identity, io, discovery, network, pubsub, websocket, quic.

Fixes #1498, #1485

### Note on #1485

The Swarm connection-close fix already landed in #1486. This PR finishes residual teardown + the deferred CI guard that kept #1485 open.

### ResourceWarning before / after (`tests/core`)

| Directory | Before (#1498) | After |
|-----------|----------------|-------|
| transport | 24 | 0 |
| bitswap | 15 | 0 |
| identity | 5 | 0 |
| io | 4 | 0 |
| pubsub | 3 | 0 |
| discovery | 2 | 0 |
| network | 1 | 0 |
| **total** | **~54** | **0** |

Measurement: `pytest tests/core/<dir> -W all::ResourceWarning -p no:cacheprovider -o addopts="" -q`

Full `tests/core` under xdist with the guard: **3281 passed**.

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `pytest tests/core -n auto` green with `error::ResourceWarning`
- [x] `make linux-docs`
- [x] CI tox / core suites on this PR


Made with [Cursor](https://cursor.com)