### PR TITLE
fix(rendezvous): strip /p2p suffix from REGISTER addrs

### DIFF
--- a/libp2p/discovery/rendezvous/messages.py
+++ b/libp2p/discovery/rendezvous/messages.py
@@ -3,6 +3,7 @@ Message construction helpers for rendezvous protocol.
 """
 
 from multiaddr import Multiaddr
+from multiaddr.exceptions import ProtocolLookupError
 
 from libp2p.peer.id import ID as PeerID
 
@@ -20,6 +21,15 @@ def create_register_message(
     peer_info = msg.register.peer
     peer_info.id = peer_id.to_bytes()
     for addr in addrs:
+        # Advertise bare transport addresses: strict servers reject (or fail
+        # to dial back) addresses carrying a `/p2p/<peer-id>` suffix, and the
+        # peer ID is already conveyed in `peer_info.id`.
+        try:
+            p2p_val = addr.value_for_protocol("p2p")
+        except ProtocolLookupError:
+            p2p_val = None
+        if p2p_val:
+            addr = addr.decapsulate(Multiaddr(f"/p2p/{p2p_val}"))
         peer_info.addrs.append(addr.to_bytes())
 
     msg.register.ns = namespace

--- a/newsfragments/1535.bugfix.rst
+++ b/newsfragments/1535.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the Rendezvous client advertising ``/p2p``-suffixed addresses in REGISTER messages. Strict servers dial back advertised addresses to verify reachability and rejected these registrations, so registering against non-Python servers failed. The client now advertises bare transport addresses.

--- a/tests/core/discovery/rendezvous/test_messages.py
+++ b/tests/core/discovery/rendezvous/test_messages.py
@@ -57,6 +57,19 @@ class TestMessageCreation:
         assert list(message.register.peer.addrs) == expected_addrs
         assert message.register.ttl == ttl
 
+    def test_create_register_message_strips_p2p_suffix(
+        self, sample_peer_id, sample_addrs
+    ):
+        """REGISTER must advertise bare transport addrs (strict servers dial back)."""
+        suffixed = [
+            addr.encapsulate(Multiaddr(f"/p2p/{sample_peer_id.to_base58()}"))
+            for addr in sample_addrs
+        ]
+        message = create_register_message("ns", sample_peer_id, suffixed, DEFAULT_TTL)
+
+        expected = [addr.to_bytes() for addr in sample_addrs]
+        assert list(message.register.peer.addrs) == expected
+
     def test_create_register_message_empty_addrs(self, sample_peer_id):
         """Test creating register message with empty addresses."""
         namespace = "test-namespace"


### PR DESCRIPTION
Fixes #1535.

## Problem

`RendezvousClient.register()` (and the auto-refresh loop) pass `host.get_addrs()` verbatim into the REGISTER message. Those addresses carry a `/p2p/<peer-id>` suffix. Strict servers dial back advertised addresses before storing the record, and the suffixed addresses fail dial-back ("no good addresses"), so registration against non-Python servers is rejected.

Found while building the unified-testing rendezvous interop suite (go server x py registrant) — a harness-side workaround was needed for 8/8 green.

## Fix

Strip the `/p2p` suffix in `create_register_message()` — the single choke point covering `register()` and refresh. `host.get_addrs()` is untouched, so no blast radius on identify/DHT/autonat. The peer ID is already conveyed in the message's peer record.

## Verification

- New unit test `test_create_register_message_strips_p2p_suffix`; full rendezvous suite 119/119 pass.
- Interop proof: with this fix, the unified-testing rendezvous suite (go x py, 8 combos) passes with the harness workaround removed.
- `ruff check` / `ruff format` clean; `mypy-local` and `pyrefly-local` report no errors in the touched file; newsfragment validated with `validate_files.py`.

## Newsfragment

`newsfragments/1535.bugfix.rst`